### PR TITLE
feat: voice input for parents

### DIFF
--- a/src/components/VoiceButton.tsx
+++ b/src/components/VoiceButton.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import React from "react";
+import { useVoiceInput } from "@/hooks/useVoiceInput";
+
+// ---------------------------------------------------------------------------
+// Mic SVG Icon (no external deps)
+// ---------------------------------------------------------------------------
+
+function MicIcon({ active }: { active: boolean }) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={active ? "#fff" : "currentColor"}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {/* Mic body */}
+      <rect x="9" y="1" width="6" height="12" rx="3" />
+      {/* Mic arc */}
+      <path d="M19 10a7 7 0 0 1-14 0" />
+      {/* Stand */}
+      <line x1="12" y1="17" x2="12" y2="21" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const buttonBase: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minWidth: 48,
+  minHeight: 48,
+  borderRadius: "50%",
+  border: "none",
+  cursor: "pointer",
+  transition: "background-color 0.2s, box-shadow 0.2s, transform 0.15s",
+  position: "relative",
+};
+
+const buttonIdle: React.CSSProperties = {
+  ...buttonBase,
+  backgroundColor: "#e5e7eb",
+  color: "#374151",
+};
+
+const buttonActive: React.CSSProperties = {
+  ...buttonBase,
+  backgroundColor: "#ef4444",
+  color: "#fff",
+  boxShadow: "0 0 0 0 rgba(239,68,68,0.5)",
+  animation: "voice-pulse 1.4s ease-in-out infinite",
+};
+
+const transcriptStyle: React.CSSProperties = {
+  marginTop: 8,
+  fontSize: 14,
+  color: "#374151",
+  maxWidth: 280,
+  wordBreak: "break-word",
+  minHeight: 20,
+};
+
+const errorStyle: React.CSSProperties = {
+  marginTop: 4,
+  fontSize: 12,
+  color: "#dc2626",
+};
+
+// Keyframes injected once via <style> tag
+const pulseKeyframes = `
+@keyframes voice-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(239,68,68,0.5); }
+  70%  { box-shadow: 0 0 0 12px rgba(239,68,68,0); }
+  100% { box-shadow: 0 0 0 0 rgba(239,68,68,0); }
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface VoiceButtonProps {
+  /** Language for recognition (default: "en-US") */
+  lang?: string;
+  /** Called whenever transcript changes */
+  onTranscript?: (text: string) => void;
+  /** Additional className on the wrapper */
+  className?: string;
+}
+
+export function VoiceButton({
+  lang = "en-US",
+  onTranscript,
+  className,
+}: VoiceButtonProps) {
+  const { isSupported, isListening, transcript, error, start, stop, reset } =
+    useVoiceInput(lang);
+
+  // Notify parent of transcript changes
+  React.useEffect(() => {
+    if (transcript && onTranscript) {
+      onTranscript(transcript);
+    }
+  }, [transcript, onTranscript]);
+
+  if (!isSupported) {
+    return null; // Graceful degradation — hide if unsupported
+  }
+
+  const toggle = () => {
+    if (isListening) {
+      stop();
+    } else {
+      reset();
+      start();
+    }
+  };
+
+  return (
+    <div
+      className={className}
+      style={{ display: "inline-flex", flexDirection: "column", alignItems: "center" }}
+    >
+      {/* Inject pulse keyframes */}
+      <style>{pulseKeyframes}</style>
+
+      <button
+        type="button"
+        onClick={toggle}
+        aria-label={isListening ? "Stop listening" : "Start voice input"}
+        aria-pressed={isListening}
+        style={isListening ? buttonActive : buttonIdle}
+      >
+        <MicIcon active={isListening} />
+      </button>
+
+      {transcript && <div style={transcriptStyle}>{transcript}</div>}
+      {error && <div role="alert" style={errorStyle}>{error}</div>}
+    </div>
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,5 @@
 export { useTapFeedback } from "./useTapFeedback";
 export type { TapFeedbackOptions, TapFeedbackResult } from "./useTapFeedback";
+
+export { useVoiceInput } from "./useVoiceInput";
+export type { VoiceInputResult } from "./useVoiceInput";

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -1,0 +1,146 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VoiceInputResult {
+  /** Whether the browser supports SpeechRecognition */
+  isSupported: boolean;
+  /** Whether recognition is currently active */
+  isListening: boolean;
+  /** The current / most recent transcript */
+  transcript: string;
+  /** Last error message, if any */
+  error: string | null;
+  /** Start listening */
+  start: () => void;
+  /** Stop listening */
+  stop: () => void;
+  /** Clear the transcript and error */
+  reset: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// SpeechRecognition compat (standard + webkit prefix for Safari)
+// ---------------------------------------------------------------------------
+
+// Web Speech API types — not in all TS DOM libs, so we define a minimal shape.
+interface SpeechRecognitionResult {
+  readonly transcript: string;
+}
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  [index: number]: { readonly [index: number]: SpeechRecognitionResult };
+}
+interface SpeechRecognitionEventCompat extends Event {
+  readonly results: SpeechRecognitionResultList;
+}
+interface SpeechRecognitionErrorEventCompat extends Event {
+  readonly error: string;
+}
+interface SpeechRecognitionCompat extends EventTarget {
+  lang: string;
+  interimResults: boolean;
+  continuous: boolean;
+  onresult: ((event: SpeechRecognitionEventCompat) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventCompat) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+function getSpeechRecognitionCtor():
+  | (new () => SpeechRecognitionCompat)
+  | null {
+  if (typeof window === "undefined") return null;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any;
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useVoiceInput(lang = "en-US"): VoiceInputResult {
+  const [isListening, setIsListening] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const recognitionRef = useRef<SpeechRecognitionCompat | null>(null);
+  const isSupported = typeof window !== "undefined" && !!getSpeechRecognitionCtor();
+
+  // Tear down on unmount
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.abort();
+      recognitionRef.current = null;
+    };
+  }, []);
+
+  const start = useCallback(() => {
+    const Ctor = getSpeechRecognitionCtor();
+    if (!Ctor) {
+      setError("Speech recognition is not supported in this browser.");
+      return;
+    }
+
+    // If already running, bail
+    if (recognitionRef.current) return;
+
+    setError(null);
+
+    const recognition = new Ctor();
+    recognition.lang = lang;
+    recognition.interimResults = true;
+    recognition.continuous = true;
+
+    recognition.onresult = (event: SpeechRecognitionEventCompat) => {
+      let text = "";
+      for (let i = 0; i < event.results.length; i++) {
+        text += event.results[i][0].transcript;
+      }
+      setTranscript(text);
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEventCompat) => {
+      if (event.error === "not-allowed") {
+        setError("Microphone permission was denied.");
+      } else if (event.error === "no-speech") {
+        // Ignore — just means silence, not a real error
+      } else {
+        setError(`Speech recognition error: ${event.error}`);
+      }
+      setIsListening(false);
+      recognitionRef.current = null;
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+      recognitionRef.current = null;
+    };
+
+    recognition.start();
+    recognitionRef.current = recognition;
+    setIsListening(true);
+  }, [lang]);
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.stop();
+    recognitionRef.current = null;
+    setIsListening(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    stop();
+    setTranscript("");
+    setError(null);
+  }, [stop]);
+
+  return { isSupported, isListening, transcript, error, start, stop, reset };
+}


### PR DESCRIPTION
## Summary
- Add `useVoiceInput` hook wrapping Web Speech API with webkit prefix compatibility for Safari, permission denial handling, and `isListening`/`isSupported` state
- Add `VoiceButton` component with inline SVG mic icon, pulsing red animation when listening, 48px minimum touch target, live transcript display, and `onTranscript` callback
- Export hook from `src/hooks/index.ts` barrel

Closes #14

## Test plan
- [ ] Verify mic button renders on Chrome/Safari
- [ ] Test toggle on/off — pulse animation appears while listening
- [ ] Speak and confirm live transcript appears below button
- [ ] Deny mic permission and confirm error message displays
- [ ] Verify button is hidden on unsupported browsers (graceful degradation)

Generated with [Claude Code](https://claude.com/claude-code)