### PR TITLE
feat: ARASAAC symbol search — browse 46K symbols

### DIFF
--- a/src/app/symbols/page.tsx
+++ b/src/app/symbols/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import SymbolSearch from "@/components/SymbolSearch";
+
+export const metadata: Metadata = {
+  title: "Symbol Search - 8gent Jr",
+  description:
+    "Browse and search 46,000+ ARASAAC pictographic symbols for AAC communication boards.",
+};
+
+export default function SymbolsPage() {
+  return (
+    <main style={{ minHeight: "100vh" }}>
+      <header
+        style={{
+          padding: "24px 16px 0",
+          maxWidth: 960,
+          margin: "0 auto",
+        }}
+      >
+        <h1 style={{ fontSize: 28, fontWeight: 700, margin: "0 0 4px" }}>
+          Symbol Search
+        </h1>
+        <p style={{ color: "#666", fontSize: 15, margin: "0 0 8px" }}>
+          Browse 46,000+ ARASAAC pictographic symbols for communication boards.
+        </p>
+      </header>
+      <SymbolSearch />
+    </main>
+  );
+}

--- a/src/components/SymbolSearch.tsx
+++ b/src/components/SymbolSearch.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { search, getImageUrl, type ArasaacSymbol } from "@/lib/arasaac";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const DEBOUNCE_MS = 300;
+const RECENT_KEY = "arasaac-recent-searches";
+const MAX_RECENT = 8;
+
+// ---------------------------------------------------------------------------
+// Recent searches helpers (localStorage)
+// ---------------------------------------------------------------------------
+function getRecent(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    return JSON.parse(localStorage.getItem(RECENT_KEY) || "[]");
+  } catch {
+    return [];
+  }
+}
+
+function addRecent(term: string) {
+  const list = getRecent().filter((t) => t !== term);
+  list.unshift(term);
+  localStorage.setItem(RECENT_KEY, JSON.stringify(list.slice(0, MAX_RECENT)));
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+export default function SymbolSearch() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<ArasaacSymbol[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const [recent, setRecent] = useState<string[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Load recent searches on mount
+  useEffect(() => {
+    setRecent(getRecent());
+  }, []);
+
+  const doSearch = useCallback(async (term: string) => {
+    const trimmed = term.trim();
+    if (!trimmed) {
+      setResults([]);
+      setSearched(false);
+      return;
+    }
+    setLoading(true);
+    setSearched(true);
+    try {
+      const data = await search(trimmed);
+      setResults(data);
+      addRecent(trimmed);
+      setRecent(getRecent());
+    } catch (err) {
+      console.error("ARASAAC search failed:", err);
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Debounced input handler
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setQuery(value);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => doSearch(value), DEBOUNCE_MS);
+  };
+
+  const handleRecentClick = (term: string) => {
+    setQuery(term);
+    doSearch(term);
+  };
+
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: "24px 16px" }}>
+      {/* Search input */}
+      <div style={{ position: "relative", marginBottom: 16 }}>
+        <input
+          type="text"
+          value={query}
+          onChange={handleChange}
+          placeholder="Search 46,000+ symbols... e.g. happy, food, school"
+          autoFocus
+          style={{
+            width: "100%",
+            padding: "14px 16px",
+            fontSize: 18,
+            border: "2px solid #ddd",
+            borderRadius: 12,
+            outline: "none",
+            boxSizing: "border-box",
+            fontFamily: "inherit",
+          }}
+        />
+      </div>
+
+      {/* Recent searches */}
+      {!searched && recent.length > 0 && (
+        <div style={{ marginBottom: 24 }}>
+          <p style={{ fontSize: 13, color: "#888", margin: "0 0 8px" }}>
+            Recent searches
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {recent.map((term) => (
+              <button
+                key={term}
+                onClick={() => handleRecentClick(term)}
+                style={{
+                  padding: "6px 14px",
+                  fontSize: 14,
+                  border: "1px solid #ddd",
+                  borderRadius: 20,
+                  background: "#f5f5f5",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                }}
+              >
+                {term}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Loading spinner */}
+      {loading && (
+        <div style={{ textAlign: "center", padding: 48 }}>
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              border: "4px solid #eee",
+              borderTop: "4px solid #6c63ff",
+              borderRadius: "50%",
+              animation: "spin 0.8s linear infinite",
+              margin: "0 auto 12px",
+            }}
+          />
+          <p style={{ color: "#888", fontSize: 14 }}>Searching ARASAAC...</p>
+          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+        </div>
+      )}
+
+      {/* No results */}
+      {searched && !loading && results.length === 0 && (
+        <div style={{ textAlign: "center", padding: 48 }}>
+          <p style={{ fontSize: 48, margin: "0 0 8px" }}>:/</p>
+          <p style={{ color: "#888", fontSize: 16 }}>
+            No symbols found for &ldquo;{query.trim()}&rdquo;
+          </p>
+          <p style={{ color: "#aaa", fontSize: 13 }}>
+            Try a simpler word like &ldquo;eat&rdquo;, &ldquo;happy&rdquo;, or
+            &ldquo;school&rdquo;
+          </p>
+        </div>
+      )}
+
+      {/* Results grid */}
+      {!loading && results.length > 0 && (
+        <>
+          <p style={{ fontSize: 13, color: "#888", margin: "0 0 12px" }}>
+            {results.length} symbol{results.length !== 1 ? "s" : ""} found
+          </p>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+              gap: 12,
+            }}
+          >
+            {results.map((sym) => (
+              <div
+                key={sym._id}
+                style={{
+                  border: "1px solid #eee",
+                  borderRadius: 12,
+                  padding: 12,
+                  textAlign: "center",
+                  background: "#fff",
+                  transition: "box-shadow 0.15s",
+                  cursor: "pointer",
+                }}
+                onMouseEnter={(e) =>
+                  (e.currentTarget.style.boxShadow =
+                    "0 2px 12px rgba(0,0,0,0.1)")
+                }
+                onMouseLeave={(e) =>
+                  (e.currentTarget.style.boxShadow = "none")
+                }
+              >
+                <img
+                  src={getImageUrl(sym._id)}
+                  alt={sym.keywords[0]?.keyword || `Symbol ${sym._id}`}
+                  loading="lazy"
+                  style={{
+                    width: "100%",
+                    height: "auto",
+                    maxHeight: 120,
+                    objectFit: "contain",
+                  }}
+                />
+                <p
+                  style={{
+                    margin: "8px 0 0",
+                    fontSize: 13,
+                    fontWeight: 500,
+                    color: "#333",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {sym.keywords[0]?.keyword || `#${sym._id}`}
+                </p>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/arasaac.ts
+++ b/src/lib/arasaac.ts
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------
+// ARASAAC API client — search 46K+ pictographic symbols
+// https://arasaac.org/developers/api
+// ---------------------------------------------------------------------------
+
+export interface ArasaacSymbol {
+  /** Pictogram numeric ID */
+  _id: number;
+  /** Keyword entries with meaning and type info */
+  keywords: Array<{
+    keyword: string;
+    type: number;
+    meaning?: string;
+    plural?: string;
+  }>;
+  /** Whether the symbol depicts violence */
+  violence: boolean;
+  /** Whether the symbol has sexual content */
+  sex: boolean;
+  /** Schema version */
+  schpiVersion?: number;
+  /** Categories the symbol belongs to */
+  categories?: string[];
+  /** Tags for additional classification */
+  tags?: string[];
+}
+
+const BASE_URL = "https://api.arasaac.org/v1";
+const STATIC_URL = "https://static.arasaac.org/pictograms";
+
+// ---------------------------------------------------------------------------
+// In-memory cache to avoid redundant API calls within a session
+// ---------------------------------------------------------------------------
+const cache = new Map<string, { data: ArasaacSymbol[]; ts: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Search ARASAAC pictograms by keyword (English).
+ * Results are cached in memory for 5 minutes.
+ */
+export async function search(keyword: string): Promise<ArasaacSymbol[]> {
+  const key = keyword.trim().toLowerCase();
+  if (!key) return [];
+
+  const cached = cache.get(key);
+  if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+    return cached.data;
+  }
+
+  const url = `${BASE_URL}/pictograms/en/search/${encodeURIComponent(key)}`;
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    // ARASAAC returns 404 when no results match
+    if (res.status === 404) {
+      cache.set(key, { data: [], ts: Date.now() });
+      return [];
+    }
+    throw new Error(`ARASAAC API error: ${res.status} ${res.statusText}`);
+  }
+
+  const data: ArasaacSymbol[] = await res.json();
+  cache.set(key, { data, ts: Date.now() });
+  return data;
+}
+
+/**
+ * Build the static image URL for a pictogram by ID.
+ * Returns the 2500px PNG variant.
+ */
+export function getImageUrl(id: number): string {
+  return `${STATIC_URL}/${id}/${id}_2500.png`;
+}


### PR DESCRIPTION
## Summary
- **ARASAAC API client** (`src/lib/arasaac.ts`) — search and image URL helpers with in-memory cache and TypeScript interfaces
- **SymbolSearch component** (`src/components/SymbolSearch.tsx`) — debounced search input, responsive image grid, loading spinner, no-results state, recent searches via localStorage
- **`/symbols` route** (`src/app/symbols/page.tsx`) — new page exposing the search UI

Closes #16

## Test plan
- [ ] Navigate to `/symbols` and confirm the page renders
- [ ] Type a keyword (e.g. "happy") and verify results appear after 300ms debounce
- [ ] Verify images load from ARASAAC static CDN
- [ ] Search a nonsense term and confirm no-results state shows
- [ ] Refresh and confirm recent searches appear as chips
- [ ] Check responsive grid on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)