### PR TITLE
feat: child-first design tokens + warm app shell

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body style={{ margin: 0, fontFamily: "Inter, system-ui, sans-serif", background: "#fefefe", color: "#1a1a2e" }}>
+      <body style={{ margin: 0, fontFamily: "Inter, system-ui, -apple-system, sans-serif", background: "#FFF8F0", color: "#1a1a2e" }}>
         {children}
       </body>
     </html>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * AppShell — Root layout wrapper that applies the child-first warm theme.
+ *
+ * Responsibilities:
+ * - Warm background (never pure white)
+ * - Consistent padding
+ * - Safe area insets for mobile (notch, home indicator)
+ * - Provides theme context to children
+ *
+ * @see https://github.com/8gi-foundation/8gentjr/issues/11
+ */
+
+import React, { createContext, useContext } from "react";
+import theme from "@/styles/theme";
+
+// ---------------------------------------------------------------------------
+// Theme Context
+// ---------------------------------------------------------------------------
+
+const ThemeContext = createContext(theme);
+
+/** Hook to access design tokens from any child component */
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface AppShellProps {
+  children: React.ReactNode;
+  /** Override padding (default: theme.spacing.md) */
+  padding?: number;
+  /** Disable the warm background (e.g. for full-bleed pages like Draw) */
+  transparentBg?: boolean;
+}
+
+export default function AppShell({
+  children,
+  padding = theme.spacing.md,
+  transparentBg = false,
+}: AppShellProps) {
+  return (
+    <ThemeContext.Provider value={theme}>
+      <div
+        style={{
+          minHeight: "100dvh",
+          background: transparentBg ? "transparent" : theme.colors.background,
+          color: theme.colors.text,
+          fontFamily: theme.fonts.family,
+          fontSize: theme.fonts.sizeBody,
+          lineHeight: 1.5,
+          padding,
+          paddingTop: `calc(${padding}px + env(safe-area-inset-top))`,
+          paddingRight: `calc(${padding}px + env(safe-area-inset-right))`,
+          paddingBottom: `calc(${padding}px + env(safe-area-inset-bottom))`,
+          paddingLeft: `calc(${padding}px + env(safe-area-inset-left))`,
+          boxSizing: "border-box",
+          // Prevent horizontal overflow on mobile
+          overflowX: "hidden",
+        }}
+      >
+        {children}
+      </div>
+    </ThemeContext.Provider>
+  );
+}

--- a/src/components/Dock.tsx
+++ b/src/components/Dock.tsx
@@ -16,7 +16,7 @@ const CORE_ITEMS: DockItem[] = [
   { id: "aac",      label: "Talk",     icon: "💬" },
   { id: "music",    label: "Music",    icon: "🎵" },
   { id: "games",    label: "Games",    icon: "🎮" },
-  { id: "settings", label: "Settings", icon: "⚙️" },
+  { id: "settings", label: "My Stuff", icon: "⚙️" },
 ];
 
 const MORE_ITEMS: DockItem[] = [
@@ -40,8 +40,8 @@ const styles = {
     display: "flex",
     alignItems: "center",
     justifyContent: "space-around",
-    background: "rgba(255,255,255,0.95)",
-    borderTop: "1px solid #e0e0e0",
+    background: "rgba(255,248,240,0.95)",
+    borderTop: "1px solid #F0DECA",
     backdropFilter: "blur(12px)",
     WebkitBackdropFilter: "blur(12px)",
     zIndex: 100,
@@ -92,9 +92,9 @@ const styles = {
     position: "fixed" as const,
     bottom: DOCK_HEIGHT + 8,
     right: 12,
-    background: "#fff",
+    background: "#FFF8F0",
     borderRadius: 16,
-    boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+    boxShadow: "0 8px 32px rgba(232, 97, 10, 0.12)",
     padding: 8,
     display: "flex",
     flexDirection: "column" as const,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,134 @@
+/**
+ * 8gent Jr — Shared Design Tokens
+ *
+ * Child-first visual design: warm colors, rounded shapes, large touch targets.
+ * All components should reference these tokens instead of hardcoding values.
+ *
+ * @see https://github.com/8gi-foundation/8gentjr/issues/11
+ */
+
+export const colors = {
+  /** Warm cream background — never pure white */
+  background: '#FFF8F0',
+  /** Slightly warmer surface for cards, panels */
+  surface: '#FFF1E6',
+  /** Primary brand orange */
+  primary: '#E8610A',
+  /** Lighter primary for hover/active states */
+  primaryLight: 'rgba(232, 97, 10, 0.12)',
+  /** Dark text on light backgrounds */
+  text: '#1a1a2e',
+  /** Secondary/muted text */
+  textMuted: '#6B7280',
+  /** Subtle text (timestamps, hints) */
+  textSubtle: '#9CA3AF',
+  /** Card border */
+  border: '#F0DECA',
+  /** Divider lines */
+  divider: '#F0DECA',
+  /** Success green */
+  success: '#059669',
+  /** Error/danger red */
+  danger: '#DC2626',
+
+  /** AAC card category tints — warm, child-friendly */
+  cardGreen: '#E8F5E9',
+  cardBlue: '#E3F2FD',
+  cardOrange: '#FFF3E0',
+  cardPink: '#FCE4EC',
+  cardRed: '#FFEBEE',
+  cardPurple: '#F3E5F5',
+} as const;
+
+export const borderRadius = {
+  /** Default rounded corners — friendly, not clinical */
+  default: 16,
+  /** Slightly smaller for inline elements */
+  small: 12,
+  /** Pill shape for chips/badges */
+  pill: 9999,
+  /** Circle for icon buttons */
+  circle: '50%',
+} as const;
+
+export const shadows = {
+  /** Soft card shadow — warm, not sharp */
+  card: '0 2px 12px rgba(232, 97, 10, 0.08)',
+  /** Elevated panel (modals, popovers) */
+  panel: '0 8px 32px rgba(232, 97, 10, 0.12)',
+  /** Subtle inner glow for active states */
+  glow: '0 0 0 3px rgba(232, 97, 10, 0.2)',
+} as const;
+
+export const fonts = {
+  /** System font stack — fast, accessible, familiar */
+  family: 'Inter, system-ui, -apple-system, sans-serif',
+  /** Body text — larger than typical for arm's-length readability */
+  sizeBody: 16,
+  /** Headings */
+  sizeHeading: 20,
+  /** Small labels (dock labels, badges) */
+  sizeSmall: 13,
+  /** Card labels — meets AAC readability guidelines */
+  sizeCard: 16,
+  /** Weight: normal */
+  weightNormal: 400,
+  /** Weight: medium */
+  weightMedium: 500,
+  /** Weight: semibold */
+  weightSemibold: 600,
+  /** Weight: bold */
+  weightBold: 700,
+  /** Weight: extra-bold (page titles) */
+  weightExtrabold: 800,
+} as const;
+
+export const spacing = {
+  /** Base unit — 8px grid system */
+  unit: 8,
+  /** Shorthand helpers */
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+  xxl: 48,
+} as const;
+
+export const touchTarget = {
+  /** Minimum interactive element size (WCAG 2.5.5 / 2.5.8) */
+  min: 48,
+  /** Comfortable size for primary actions */
+  comfortable: 56,
+  /** Minimum gap between interactive elements */
+  gap: 8,
+} as const;
+
+export const animation = {
+  /** Default transition duration */
+  duration: '200ms',
+  /** Smooth deceleration curve */
+  easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
+  /** Quick press feedback */
+  pressDuration: '100ms',
+} as const;
+
+/** Convenience: CSS transition shorthand using default duration + easing */
+export function transition(...properties: string[]): string {
+  return properties
+    .map((prop) => `${prop} ${animation.duration} ${animation.easing}`)
+    .join(', ');
+}
+
+const theme = {
+  colors,
+  borderRadius,
+  shadows,
+  fonts,
+  spacing,
+  touchTarget,
+  animation,
+  transition,
+} as const;
+
+export default theme;


### PR DESCRIPTION
## Summary

- **New `src/styles/theme.ts`** — shared design token file with warm color palette (soft oranges, creams), 16px default border radius, soft warm shadows, 48px minimum touch targets, 8px spacing grid, and animation tokens
- **New `src/components/AppShell.tsx`** — layout wrapper applying warm background (`#FFF8F0`), consistent padding, safe area insets for mobile, and `ThemeContext` provider so any child component can access tokens via `useTheme()`
- **Updated `Dock.tsx`** — renamed "Settings" to "My Stuff" (child-friendly language), warmed up background/border/shadow colors
- **Updated root `layout.tsx`** — background changed from clinical `#fefefe` to warm `#FFF8F0`

Closes #11

## Test plan

- [ ] Run `npx tsc --noEmit` — passes clean
- [ ] Verify warm background renders on home page (`/`)
- [ ] Verify Dock shows "My Stuff" instead of "Settings"
- [ ] Import `useTheme()` in a component and confirm tokens are accessible
- [ ] Check safe area insets render correctly on mobile Safari (notch/home indicator)

Generated with [Claude Code](https://claude.com/claude-code)