### PR TITLE
feat: emotional regulation playlists — 7 moods

### DIFF
--- a/src/app/music/moods/page.tsx
+++ b/src/app/music/moods/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useState } from "react";
+import type { MoodKey } from "../../../lib/emotional-playlists";
+import MoodSelector from "../../../components/MoodSelector";
+import PlaylistView from "../../../components/PlaylistView";
+
+export default function MoodsPage() {
+  const [selectedMood, setSelectedMood] = useState<MoodKey | null>(null);
+
+  if (selectedMood) {
+    return <PlaylistView mood={selectedMood} onBack={() => setSelectedMood(null)} />;
+  }
+
+  return <MoodSelector onSelectMood={setSelectedMood} />;
+}

--- a/src/components/MoodSelector.tsx
+++ b/src/components/MoodSelector.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { type MoodKey, getAllPlaylists } from "../lib/emotional-playlists";
+
+interface MoodSelectorProps {
+  onSelectMood: (mood: MoodKey) => void;
+}
+
+export default function MoodSelector({ onSelectMood }: MoodSelectorProps) {
+  const playlists = getAllPlaylists();
+
+  return (
+    <div>
+      <h1 style={{ textAlign: "center", fontSize: 28, margin: "16px 0 8px" }}>
+        How are you feeling?
+      </h1>
+      <p style={{ textAlign: "center", fontSize: 16, color: "#666", margin: "0 0 20px" }}>
+        Pick a mood for your music
+      </p>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 12,
+          padding: "0 16px 24px",
+        }}
+      >
+        {playlists.map(({ key, name, emoji, color }) => (
+          <button
+            key={key}
+            onClick={() => onSelectMood(key)}
+            style={{
+              minHeight: 60,
+              background: color,
+              border: "none",
+              borderRadius: 16,
+              cursor: "pointer",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: 16,
+              gap: 4,
+              boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
+              transition: "transform 0.15s ease",
+            }}
+            onPointerDown={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.transform = "scale(0.95)";
+            }}
+            onPointerUp={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.transform = "scale(1)";
+            }}
+            onPointerLeave={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.transform = "scale(1)";
+            }}
+            aria-label={`Select ${name} mood`}
+          >
+            <span style={{ fontSize: 36 }}>{emoji}</span>
+            <span style={{ fontSize: 16, fontWeight: 600, color: "#1a1a2e" }}>{name}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PlaylistView.tsx
+++ b/src/components/PlaylistView.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { type MoodKey, getPlaylist } from "../lib/emotional-playlists";
+
+interface PlaylistViewProps {
+  mood: MoodKey;
+  onBack: () => void;
+}
+
+export default function PlaylistView({ mood, onBack }: PlaylistViewProps) {
+  const playlist = getPlaylist(mood);
+  const [playingIndex, setPlayingIndex] = useState<number | null>(null);
+
+  function togglePlay(index: number) {
+    setPlayingIndex(playingIndex === index ? null : index);
+  }
+
+  return (
+    <div style={{ padding: "0 16px 24px" }}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "16px 0" }}>
+        <button
+          onClick={onBack}
+          style={{
+            background: "none",
+            border: "2px solid #ccc",
+            borderRadius: 12,
+            padding: "8px 14px",
+            fontSize: 16,
+            cursor: "pointer",
+            color: "#1a1a2e",
+            fontWeight: 600,
+          }}
+          aria-label="Back to mood selector"
+        >
+          &larr; Back
+        </button>
+        <div style={{ flex: 1, textAlign: "center" }}>
+          <span style={{ fontSize: 32 }}>{playlist.emoji}</span>
+          <h2 style={{ margin: "4px 0 0", fontSize: 22 }}>{playlist.name}</h2>
+          <p style={{ margin: 0, fontSize: 14, color: "#666" }}>{playlist.description}</p>
+        </div>
+        {/* Spacer to center the title */}
+        <div style={{ width: 70 }} />
+      </div>
+
+      {/* Track list */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {playlist.tracks.map((track, i) => {
+          const isPlaying = playingIndex === i;
+          return (
+            <div
+              key={i}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                background: isPlaying ? playlist.color + "33" : "#fff",
+                border: `2px solid ${isPlaying ? playlist.color : "#e0e0e0"}`,
+                borderRadius: 14,
+                padding: "12px 16px",
+                transition: "all 0.15s ease",
+              }}
+            >
+              {/* Play/Pause button */}
+              <button
+                onClick={() => togglePlay(i)}
+                style={{
+                  width: 44,
+                  height: 44,
+                  minWidth: 44,
+                  borderRadius: "50%",
+                  border: "none",
+                  background: playlist.color,
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 18,
+                  boxShadow: "0 1px 4px rgba(0,0,0,0.1)",
+                }}
+                aria-label={isPlaying ? `Pause ${track.title}` : `Play ${track.title}`}
+              >
+                {isPlaying ? "\u23F8\uFE0F" : "\u25B6\uFE0F"}
+              </button>
+
+              {/* Track info */}
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    fontSize: 15,
+                    fontWeight: 600,
+                    color: "#1a1a2e",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {track.title}
+                </div>
+                <div style={{ fontSize: 13, color: "#888", marginTop: 2 }}>{track.artist}</div>
+              </div>
+
+              {/* Duration */}
+              <span style={{ fontSize: 13, color: "#999", fontVariantNumeric: "tabular-nums" }}>
+                {track.duration}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Placeholder note */}
+      <p style={{ textAlign: "center", fontSize: 12, color: "#aaa", marginTop: 16 }}>
+        Audio playback coming in a future update
+      </p>
+    </div>
+  );
+}

--- a/src/lib/emotional-playlists.ts
+++ b/src/lib/emotional-playlists.ts
@@ -1,0 +1,142 @@
+/**
+ * Emotional Regulation Playlists for 8gent Jr
+ *
+ * 7 mood-based playlists with curated tracks to support
+ * emotional regulation in neurodivergent children.
+ *
+ * Inspired by GLP (Gestalt Language Processing) research:
+ * music preserves prosody and rhythm, which are primary language pathways.
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface Track {
+  title: string;
+  artist: string;
+  /** Duration in "M:SS" format */
+  duration: string;
+}
+
+export interface MoodPlaylist {
+  name: string;
+  emoji: string;
+  color: string;
+  description: string;
+  tracks: Track[];
+}
+
+export type MoodKey = "calm" | "happy" | "focus" | "energize" | "sleepy" | "brave" | "silly";
+
+// =============================================================================
+// Playlists
+// =============================================================================
+
+export const MOOD_PLAYLISTS: Record<MoodKey, MoodPlaylist> = {
+  calm: {
+    name: "Calm",
+    emoji: "\u2601\uFE0F",
+    color: "#81D4FA",
+    description: "Breathe and relax",
+    tracks: [
+      { title: "Weightless", artist: "Marconi Union", duration: "8:09" },
+      { title: "Clair de Lune", artist: "Claude Debussy", duration: "5:00" },
+      { title: "Spiegel im Spiegel", artist: "Arvo Part", duration: "7:40" },
+      { title: "Aqueous Transmission", artist: "Incubus", duration: "7:50" },
+      { title: "Pure Shores", artist: "All Saints", duration: "4:24" },
+    ],
+  },
+  happy: {
+    name: "Happy",
+    emoji: "\u2600\uFE0F",
+    color: "#FFD54F",
+    description: "Smile and celebrate",
+    tracks: [
+      { title: "Happy", artist: "Pharrell Williams", duration: "3:53" },
+      { title: "Walking on Sunshine", artist: "Katrina and the Waves", duration: "3:58" },
+      { title: "Can't Stop the Feeling!", artist: "Justin Timberlake", duration: "3:56" },
+      { title: "Best Day of My Life", artist: "American Authors", duration: "3:14" },
+      { title: "Three Little Birds", artist: "Bob Marley", duration: "3:00" },
+    ],
+  },
+  focus: {
+    name: "Focus",
+    emoji: "\uD83C\uDF3F",
+    color: "#81C784",
+    description: "Concentrate and learn",
+    tracks: [
+      { title: "Experience", artist: "Ludovico Einaudi", duration: "5:15" },
+      { title: "Gymnopedies No.1", artist: "Erik Satie", duration: "3:24" },
+      { title: "Nuvole Bianche", artist: "Ludovico Einaudi", duration: "5:57" },
+      { title: "Divenire", artist: "Ludovico Einaudi", duration: "6:42" },
+      { title: "River Flows in You", artist: "Yiruma", duration: "3:10" },
+    ],
+  },
+  energize: {
+    name: "Energize",
+    emoji: "\u26A1",
+    color: "#FF7043",
+    description: "Move and dance",
+    tracks: [
+      { title: "Shake It Off", artist: "Taylor Swift", duration: "3:39" },
+      { title: "Uptown Funk", artist: "Bruno Mars", duration: "4:30" },
+      { title: "Dance Monkey", artist: "Tones and I", duration: "3:29" },
+      { title: "Dynamite", artist: "BTS", duration: "3:19" },
+      { title: "Roar", artist: "Katy Perry", duration: "3:43" },
+    ],
+  },
+  sleepy: {
+    name: "Sleepy",
+    emoji: "\uD83C\uDF19",
+    color: "#CE93D8",
+    description: "Wind down and rest",
+    tracks: [
+      { title: "Twinkle Twinkle Little Star", artist: "Traditional", duration: "2:30" },
+      { title: "Brahms' Lullaby", artist: "Johannes Brahms", duration: "3:45" },
+      { title: "Golden Slumbers", artist: "The Beatles", duration: "1:31" },
+      { title: "Dream a Little Dream of Me", artist: "The Mamas & the Papas", duration: "2:57" },
+      { title: "Somewhere Over the Rainbow", artist: "Israel Kamakawiwo'ole", duration: "3:48" },
+    ],
+  },
+  brave: {
+    name: "Brave",
+    emoji: "\uD83D\uDEE1\uFE0F",
+    color: "#42A5F5",
+    description: "Be strong and courageous",
+    tracks: [
+      { title: "Brave", artist: "Sara Bareilles", duration: "3:40" },
+      { title: "Fight Song", artist: "Rachel Platten", duration: "3:22" },
+      { title: "Stronger", artist: "Kelly Clarkson", duration: "3:42" },
+      { title: "Eye of the Tiger", artist: "Survivor", duration: "4:05" },
+      { title: "Hall of Fame", artist: "The Script ft. will.i.am", duration: "3:22" },
+    ],
+  },
+  silly: {
+    name: "Silly",
+    emoji: "\uD83E\uDD2A",
+    color: "#F48FB1",
+    description: "Laugh and be goofy",
+    tracks: [
+      { title: "Baby Shark", artist: "Pinkfong", duration: "1:36" },
+      { title: "The Chicken Dance", artist: "Werner Thomas", duration: "2:45" },
+      { title: "Banana Phone", artist: "Raffi", duration: "3:02" },
+      { title: "I Am a Gummy Bear", artist: "Gummibar", duration: "2:30" },
+      { title: "Crazy Frog", artist: "Axel F", duration: "2:52" },
+    ],
+  },
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+export const MOOD_KEYS: MoodKey[] = ["calm", "happy", "focus", "energize", "sleepy", "brave", "silly"];
+
+export function getPlaylist(mood: MoodKey): MoodPlaylist {
+  return MOOD_PLAYLISTS[mood];
+}
+
+export function getAllPlaylists(): Array<MoodPlaylist & { key: MoodKey }> {
+  return MOOD_KEYS.map((key) => ({ key, ...MOOD_PLAYLISTS[key] }));
+}


### PR DESCRIPTION
## Summary
- Adds 7 mood-based playlists (calm, happy, focus, energize, sleepy, brave, silly) with 5 curated tracks each
- MoodSelector component: 2-column grid of large, touch-friendly mood cards with emoji + color
- PlaylistView component: track list with play/pause toggle (placeholder UI, no audio in v1)
- New route at `/music/moods`

Closes #5

## Test plan
- [ ] Navigate to `/music/moods` and verify 7 mood cards render in 2-column grid
- [ ] Tap each mood card and verify playlist view shows 5 tracks
- [ ] Tap play/pause buttons and verify toggle state
- [ ] Tap back button to return to mood selector
- [ ] Verify touch targets are at least 60px height
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)