### PR TITLE
feat: visual schedule — daily activity cards (#9)

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import VisualSchedule from "@/components/VisualSchedule";
+
+export default function SchedulePage() {
+  return (
+    <main
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        minHeight: "100dvh",
+        padding: "16px",
+        paddingBottom: "6rem",
+        boxSizing: "border-box",
+        fontFamily: "Inter, system-ui, sans-serif",
+        background: "#FFF8F0",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 16,
+        }}
+      >
+        <h1
+          style={{
+            fontSize: "1.3rem",
+            fontWeight: 800,
+            color: "#E8610A",
+            margin: 0,
+          }}
+        >
+          My Day
+        </h1>
+        <a
+          href="/"
+          style={{
+            color: "#666",
+            textDecoration: "none",
+            fontSize: "0.9rem",
+          }}
+        >
+          Back
+        </a>
+      </header>
+
+      <p
+        style={{
+          fontSize: "0.95rem",
+          color: "#6B7280",
+          margin: "0 0 16px",
+          textAlign: "center",
+        }}
+      >
+        Here is your schedule for today
+      </p>
+
+      <VisualSchedule />
+    </main>
+  );
+}

--- a/src/components/VisualSchedule.tsx
+++ b/src/components/VisualSchedule.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+/**
+ * VisualSchedule — Vertical list of daily activity cards.
+ *
+ * - Current activity: glowing border, slightly larger
+ * - Past activities: dimmed
+ * - Future activities: normal
+ * - Auto-scrolls to current activity on mount
+ *
+ * @see https://github.com/8gi-foundation/8gentjr/issues/9
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import { DEFAULT_SCHEDULE, getCurrentActivity, type ScheduleItem } from "@/lib/schedule";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ActivityState = "past" | "current" | "future";
+
+function getActivityState(item: ScheduleItem, currentItem: ScheduleItem | null): ActivityState {
+  if (!currentItem) {
+    // If no current activity, compare against now
+    const now = new Date();
+    const hour = now.getHours() + now.getMinutes() / 60;
+    return hour >= item.endHour ? "past" : "future";
+  }
+  if (item.startHour === currentItem.startHour) return "current";
+  return item.endHour <= currentItem.startHour ? "past" : "future";
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+function cardStyle(state: ActivityState): React.CSSProperties {
+  const base: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 16,
+    padding: "16px 20px",
+    borderRadius: 16,
+    border: "2px solid transparent",
+    transition: "all 200ms cubic-bezier(0.4, 0, 0.2, 1)",
+    cursor: "default",
+  };
+
+  if (state === "current") {
+    return {
+      ...base,
+      border: "2px solid #E8610A",
+      boxShadow: "0 0 16px rgba(232, 97, 10, 0.3)",
+      transform: "scale(1.03)",
+    };
+  }
+
+  if (state === "past") {
+    return {
+      ...base,
+      opacity: 0.45,
+      filter: "grayscale(0.3)",
+    };
+  }
+
+  return base; // future — normal
+}
+
+const emojiStyle = (state: ActivityState): React.CSSProperties => ({
+  fontSize: state === "current" ? 40 : 32,
+  lineHeight: 1,
+  flexShrink: 0,
+  transition: "font-size 200ms cubic-bezier(0.4, 0, 0.2, 1)",
+});
+
+const nameStyle: React.CSSProperties = {
+  fontSize: 18,
+  fontWeight: 700,
+  color: "#1a1a2e",
+  margin: 0,
+};
+
+const timeStyle: React.CSSProperties = {
+  fontSize: 14,
+  color: "#6B7280",
+  margin: 0,
+  fontWeight: 500,
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface VisualScheduleProps {
+  schedule?: ScheduleItem[];
+}
+
+export default function VisualSchedule({ schedule = DEFAULT_SCHEDULE }: VisualScheduleProps) {
+  const currentRef = useRef<HTMLDivElement>(null);
+  const [currentItem, setCurrentItem] = useState<ScheduleItem | null>(null);
+
+  // Determine current activity on mount
+  useEffect(() => {
+    setCurrentItem(getCurrentActivity(schedule));
+  }, [schedule]);
+
+  // Auto-scroll to current activity once it's identified
+  useEffect(() => {
+    if (currentRef.current) {
+      currentRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [currentItem]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        width: "100%",
+        maxWidth: 480,
+        margin: "0 auto",
+      }}
+    >
+      {schedule.map((item) => {
+        const state = getActivityState(item, currentItem);
+        return (
+          <div
+            key={item.name}
+            ref={state === "current" ? currentRef : undefined}
+            style={{
+              ...cardStyle(state),
+              background: item.color,
+            }}
+            aria-current={state === "current" ? "true" : undefined}
+            role="listitem"
+          >
+            <span style={emojiStyle(state)} aria-hidden="true">
+              {item.emoji}
+            </span>
+            <div>
+              <p style={nameStyle}>{item.name}</p>
+              <p style={timeStyle}>{item.timeRange}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -1,0 +1,44 @@
+/**
+ * schedule.ts — Daily visual schedule data and helpers for 8gent Jr.
+ *
+ * Provides a default day schedule with time ranges, emojis, and colors.
+ * getCurrentActivity() returns the activity matching the current hour.
+ *
+ * @see https://github.com/8gi-foundation/8gentjr/issues/9
+ */
+
+export interface ScheduleItem {
+  name: string;
+  emoji: string;
+  timeRange: string;
+  startHour: number;
+  endHour: number;
+  color: string;
+}
+
+/**
+ * Default schedule — covers 7 AM through 8 PM.
+ * Colors use warm, child-friendly tints from the design system.
+ */
+export const DEFAULT_SCHEDULE: ScheduleItem[] = [
+  { name: "Morning Routine", emoji: "\u{1F31E}", timeRange: "7:00 - 8:00",  startHour: 7,  endHour: 8,  color: "#FFF3E0" },
+  { name: "School",          emoji: "\u{1F4DA}", timeRange: "8:00 - 12:00", startHour: 8,  endHour: 12, color: "#E3F2FD" },
+  { name: "Lunch",           emoji: "\u{1F96A}", timeRange: "12:00 - 13:00",startHour: 12, endHour: 13, color: "#E8F5E9" },
+  { name: "Play Time",       emoji: "\u{1F3C0}", timeRange: "13:00 - 15:00",startHour: 13, endHour: 15, color: "#F3E5F5" },
+  { name: "Snack",           emoji: "\u{1F34E}", timeRange: "15:00 - 15:30",startHour: 15, endHour: 15.5, color: "#FFF3E0" },
+  { name: "Dinner",          emoji: "\u{1F35D}", timeRange: "17:00 - 18:00",startHour: 17, endHour: 18, color: "#E8F5E9" },
+  { name: "Bath",            emoji: "\u{1F6C1}", timeRange: "18:00 - 18:30",startHour: 18, endHour: 18.5, color: "#E3F2FD" },
+  { name: "Bedtime",         emoji: "\u{1F319}", timeRange: "19:00 - 20:00",startHour: 19, endHour: 20, color: "#FCE4EC" },
+];
+
+/**
+ * Returns the schedule item that matches the current time, or null if
+ * the current time falls outside any scheduled activity.
+ */
+export function getCurrentActivity(
+  schedule: ScheduleItem[] = DEFAULT_SCHEDULE,
+  now: Date = new Date(),
+): ScheduleItem | null {
+  const currentHour = now.getHours() + now.getMinutes() / 60;
+  return schedule.find((item) => currentHour >= item.startHour && currentHour < item.endHour) ?? null;
+}


### PR DESCRIPTION
## Summary

- Add `src/lib/schedule.ts` with default daily schedule (8 activities), `ScheduleItem` type, and `getCurrentActivity()` helper
- Add `src/components/VisualSchedule.tsx` — vertical card list with current activity highlighted (glowing border, scaled up), past activities dimmed, future activities normal, auto-scrolls to current on mount
- Add `/schedule` route (`src/app/schedule/page.tsx`) titled "My Day"

Closes #9

## Test plan

- [ ] Visit `/schedule` and verify all 8 activity cards render with emoji, name, and time range
- [ ] Check current time activity has orange glowing border and is slightly larger
- [ ] Confirm past activities are dimmed, future activities normal
- [ ] Verify page auto-scrolls to current activity on load
- [ ] Test on mobile viewport — cards should be responsive within 480px max-width

Generated with [Claude Code](https://claude.com/claude-code)