### PR TITLE
feat: SchoolTube speech games batch (#21)

### DIFF
--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import GameCard from "@/components/games/GameCard";
+import AnimalSounds from "@/components/games/speech/AnimalSounds";
+import WordRepeat from "@/components/games/speech/WordRepeat";
+import RhymeTime from "@/components/games/speech/RhymeTime";
+import FeelingsExplorer from "@/components/games/speech/FeelingsExplorer";
+
+type Category = "speech" | "maths" | "music";
+type GameId = "animal-sounds" | "word-repeat" | "rhyme-time" | "feelings";
+
+const categories: { id: Category; label: string; emoji: string }[] = [
+  { id: "speech", label: "Speech", emoji: "\u{1F5E3}\uFE0F" },
+  { id: "maths", label: "Maths", emoji: "\u{1F522}" },
+  { id: "music", label: "Music", emoji: "\u{1F3B5}" },
+];
+
+const games: { id: GameId; category: Category; emoji: string; title: string; description: string; color: string }[] = [
+  { id: "animal-sounds", category: "speech", emoji: "\u{1F43E}", title: "Animal Sounds", description: "Match animals to their sounds!", color: "#E8A87C" },
+  { id: "word-repeat", category: "speech", emoji: "\u{1F3A4}", title: "Word Repeat", description: "Hear a word and say it 3 times!", color: "#9B59B6" },
+  { id: "rhyme-time", category: "speech", emoji: "\u{1F3B5}", title: "Rhyme Time", description: "Find the words that rhyme!", color: "#6C5CE7" },
+  { id: "feelings", category: "speech", emoji: "\u{1F60A}", title: "Feelings Explorer", description: "Learn about emotions and feelings!", color: "#FFD93D" },
+];
+
+const gameComponents: Record<GameId, React.ComponentType> = {
+  "animal-sounds": AnimalSounds,
+  "word-repeat": WordRepeat,
+  "rhyme-time": RhymeTime,
+  "feelings": FeelingsExplorer,
+};
+
+export default function GamesPage() {
+  const [tab, setTab] = useState<Category>("speech");
+  const [activeGame, setActiveGame] = useState<GameId | null>(null);
+
+  if (activeGame) {
+    const GameComponent = gameComponents[activeGame];
+    return (
+      <div style={{ minHeight: "100vh", background: "#FFF8F0" }}>
+        <div style={{ display: "flex", alignItems: "center", padding: "12px 16px", borderBottom: "1px solid #F0DECA" }}>
+          <button onClick={() => setActiveGame(null)}
+            style={{ border: "none", background: "none", fontSize: 20, cursor: "pointer", padding: "4px 8px", color: "#E8610A", fontWeight: 700 }}>
+            &larr; Back
+          </button>
+          <span style={{ fontWeight: 700, fontSize: 16, color: "#333", marginLeft: 8 }}>
+            {games.find((g) => g.id === activeGame)?.title}
+          </span>
+        </div>
+        <GameComponent />
+      </div>
+    );
+  }
+
+  const filtered = games.filter((g) => g.category === tab);
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#FFF8F0", padding: "24px 16px 100px" }}>
+      <h1 style={{ fontSize: 32, fontWeight: 800, color: "#E8610A", textAlign: "center", margin: "0 0 4px" }}>
+        SchoolTube Games
+      </h1>
+      <p style={{ textAlign: "center", color: "#888", fontSize: 14, margin: "0 0 20px" }}>Learn through play!</p>
+
+      {/* Category tabs */}
+      <div style={{ display: "flex", justifyContent: "center", gap: 8, marginBottom: 24 }}>
+        {categories.map((c) => (
+          <button key={c.id} onClick={() => setTab(c.id)}
+            style={{
+              padding: "8px 20px", borderRadius: 20, border: "none", fontWeight: 700, fontSize: 14, cursor: "pointer",
+              background: tab === c.id ? "#E8610A" : "#F0DECA",
+              color: tab === c.id ? "#fff" : "#888",
+              transition: "all 0.15s",
+            }}>
+            {c.emoji} {c.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Game grid */}
+      {filtered.length > 0 ? (
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14, maxWidth: 400, margin: "0 auto" }}>
+          {filtered.map((g) => (
+            <GameCard key={g.id} emoji={g.emoji} title={g.title} description={g.description} color={g.color}
+              onClick={() => setActiveGame(g.id)} />
+          ))}
+        </div>
+      ) : (
+        <div style={{ textAlign: "center", padding: "48px 16px", color: "#bbb" }}>
+          <div style={{ fontSize: 48, marginBottom: 8 }}>&#x1F6A7;</div>
+          <p style={{ fontWeight: 600 }}>Coming soon!</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/games/GameCard.tsx
+++ b/src/components/games/GameCard.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+interface GameCardProps {
+  emoji: string;
+  title: string;
+  description: string;
+  color: string;
+  onClick?: () => void;
+}
+
+export default function GameCard({ emoji, title, description, color, onClick }: GameCardProps) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 8,
+        padding: "24px 16px",
+        borderRadius: 20,
+        border: `2px solid ${color}30`,
+        background: `${color}12`,
+        cursor: "pointer",
+        width: "100%",
+        minHeight: 160,
+        transition: "transform 0.15s ease, box-shadow 0.15s ease",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.06)",
+        WebkitTapHighlightColor: "transparent",
+      }}
+      onPointerDown={(e) => {
+        (e.currentTarget as HTMLElement).style.transform = "scale(0.95)";
+      }}
+      onPointerUp={(e) => {
+        (e.currentTarget as HTMLElement).style.transform = "scale(1)";
+      }}
+      onPointerCancel={(e) => {
+        (e.currentTarget as HTMLElement).style.transform = "scale(1)";
+      }}
+    >
+      <span style={{ fontSize: 48 }}>{emoji}</span>
+      <span style={{ fontSize: 18, fontWeight: 800, color }}>{title}</span>
+      <span style={{ fontSize: 13, color: "#777", lineHeight: 1.3, textAlign: "center" }}>
+        {description}
+      </span>
+    </button>
+  );
+}

--- a/src/components/games/speech/AnimalSounds.tsx
+++ b/src/components/games/speech/AnimalSounds.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+
+const animals = [
+  { name: "Dog", sound: "Woof woof!", emoji: "\u{1F415}", color: "#E8A87C" },
+  { name: "Cat", sound: "Meow!", emoji: "\u{1F431}", color: "#FFB347" },
+  { name: "Cow", sound: "Moo!", emoji: "\u{1F404}", color: "#C8A87A" },
+  { name: "Duck", sound: "Quack quack!", emoji: "\u{1F986}", color: "#FFD700" },
+  { name: "Pig", sound: "Oink oink!", emoji: "\u{1F437}", color: "#FFB6C1" },
+  { name: "Sheep", sound: "Baa baa!", emoji: "\u{1F411}", color: "#D4C5A0" },
+  { name: "Frog", sound: "Ribbit!", emoji: "\u{1F438}", color: "#5DBB63" },
+  { name: "Lion", sound: "Roar!", emoji: "\u{1F981}", color: "#DAA520" },
+];
+
+function shuffle<T>(arr: T[]): T[] {
+  return [...arr].sort(() => Math.random() - 0.5);
+}
+
+export default function AnimalSounds() {
+  const [index, setIndex] = useState(0);
+  const [phase, setPhase] = useState<"learn" | "quiz">("learn");
+  const [options, setOptions] = useState<typeof animals>([]);
+  const [picked, setPicked] = useState<string | null>(null);
+  const [score, setScore] = useState(0);
+
+  const animal = animals[index];
+  const done = index >= animals.length;
+
+  const startQuiz = () => {
+    const others = shuffle(animals.filter((a) => a.name !== animal.name)).slice(0, 3);
+    setOptions(shuffle([animal, ...others]));
+    setPhase("quiz");
+    setPicked(null);
+  };
+
+  const answer = (name: string) => {
+    if (picked) return;
+    setPicked(name);
+    if (name === animal.name) {
+      setScore((s) => s + 1);
+      setTimeout(() => { setIndex((i) => i + 1); setPhase("learn"); setPicked(null); }, 1200);
+    } else {
+      setTimeout(() => setPicked(null), 800);
+    }
+  };
+
+  if (done) {
+    return (
+      <div style={{ textAlign: "center", padding: 32 }}>
+        <div style={{ fontSize: 64 }}>&#x1F3C6;</div>
+        <h2 style={{ fontSize: 28, fontWeight: 800, color: "#E8610A", margin: "16px 0 8px" }}>
+          All Done! {score}/{animals.length}
+        </h2>
+        <p style={{ color: "#777" }}>You learned all the animal sounds!</p>
+        <button onClick={() => { setIndex(0); setScore(0); setPhase("learn"); }}
+          style={{ marginTop: 16, padding: "12px 32px", borderRadius: 16, border: "none", background: "#E8610A", color: "#fff", fontWeight: 700, fontSize: 18, cursor: "pointer" }}>
+          Play Again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ textAlign: "center", padding: 24 }}>
+      <div style={{ fontSize: 12, color: "#999", marginBottom: 8 }}>{index + 1} / {animals.length}</div>
+      <div style={{ height: 6, background: "#eee", borderRadius: 3, marginBottom: 20 }}>
+        <div style={{ height: 6, borderRadius: 3, background: `linear-gradient(90deg, #E8610A, #FFB347)`, width: `${(index / animals.length) * 100}%`, transition: "width 0.3s" }} />
+      </div>
+
+      {phase === "learn" ? (
+        <>
+          <div style={{ fontSize: 80, marginBottom: 8 }}>{animal.emoji}</div>
+          <h3 style={{ fontSize: 32, fontWeight: 800, color: animal.color, margin: "0 0 4px" }}>{animal.name}</h3>
+          <div style={{ display: "inline-block", padding: "8px 20px", borderRadius: 16, border: `2px solid ${animal.color}`, background: `${animal.color}15`, fontSize: 20, fontWeight: 700, color: "#444", marginBottom: 16 }}>
+            &ldquo;{animal.sound}&rdquo;
+          </div>
+          <br />
+          <button onClick={() => { try { speechSynthesis.speak(new SpeechSynthesisUtterance(`The ${animal.name} says ${animal.sound}`)); } catch {} }}
+            style={{ padding: "10px 24px", borderRadius: 14, border: "none", background: animal.color, color: "#fff", fontWeight: 700, fontSize: 16, cursor: "pointer", marginRight: 8 }}>
+            Hear It
+          </button>
+          <button onClick={startQuiz}
+            style={{ padding: "10px 24px", borderRadius: 14, border: "none", background: "#4ECDC4", color: "#fff", fontWeight: 700, fontSize: 16, cursor: "pointer" }}>
+            Quiz Me!
+          </button>
+        </>
+      ) : (
+        <>
+          <div style={{ padding: "12px 20px", borderRadius: 16, background: "#FFF8E1", border: "2px solid #FFD54F", display: "inline-block", marginBottom: 16 }}>
+            <span style={{ fontWeight: 800, color: "#F57F17", fontSize: 18 }}>Which animal says &ldquo;{animal.sound}&rdquo;?</span>
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, maxWidth: 280, margin: "0 auto" }}>
+            {options.map((o) => {
+              const isThis = picked === o.name;
+              const right = isThis && o.name === animal.name;
+              const wrong = isThis && o.name !== animal.name;
+              return (
+                <button key={o.name} onClick={() => answer(o.name)}
+                  style={{ padding: 16, borderRadius: 16, border: right ? "3px solid #4CAF50" : wrong ? "3px solid #EF5350" : "2px solid #ddd", background: right ? "#C8E6C9" : wrong ? "#FFCDD2" : "#fff", cursor: "pointer", textAlign: "center", transition: "all 0.15s" }}>
+                  <div style={{ fontSize: 40 }}>{o.emoji}</div>
+                  <div style={{ fontWeight: 700, fontSize: 14, marginTop: 4 }}>{o.name}</div>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/games/speech/FeelingsExplorer.tsx
+++ b/src/components/games/speech/FeelingsExplorer.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+
+const feelings = [
+  { name: "Happy", emoji: "\u{1F60A}", color: "#FFD93D", desc: "Warm and sunny inside!",
+    body: "You smile and feel light!", options: ["Opening a birthday present", "Eating broccoli", "Stuck in traffic"], answer: 0 },
+  { name: "Sad", emoji: "\u{1F622}", color: "#74B9FF", desc: "Heavy like rain clouds",
+    body: "Your eyes feel watery", options: ["Winning a game", "Losing your favourite toy", "Eating cake"], answer: 1 },
+  { name: "Angry", emoji: "\u{1F620}", color: "#FF6B6B", desc: "Hot and fiery inside!",
+    body: "Your face gets red and hot", options: ["Watching a sunset", "Someone breaks your toy", "Getting a hug"], answer: 1 },
+  { name: "Scared", emoji: "\u{1F628}", color: "#A29BFE", desc: "Wobbly and shaky",
+    body: "Your heart beats fast!", options: ["Hearing a big thunder crash", "Playing with a puppy", "Eating ice cream"], answer: 0 },
+  { name: "Excited", emoji: "\u{1F929}", color: "#FF9F43", desc: "Bouncy and zingy inside!",
+    body: "You can't stop moving!", options: ["Going to sleep early", "Your birthday party starts NOW", "Washing dishes"], answer: 1 },
+  { name: "Calm", emoji: "\u{1F60C}", color: "#95E1D3", desc: "Peaceful like a quiet lake",
+    body: "Your breathing is slow and soft", options: ["Taking deep breaths outside", "Spinning really fast", "Shouting loud"], answer: 0 },
+];
+
+export default function FeelingsExplorer() {
+  const [index, setIndex] = useState(0);
+  const [phase, setPhase] = useState<"learn" | "quiz" | "result">("learn");
+  const [picked, setPicked] = useState<number | null>(null);
+  const [score, setScore] = useState(0);
+
+  const f = feelings[index];
+  const done = index >= feelings.length;
+
+  const tryAnswer = (i: number) => {
+    if (picked !== null) return;
+    setPicked(i);
+    if (i === f.answer) {
+      setScore((s) => s + 1);
+      setTimeout(() => setPhase("result"), 1000);
+    } else {
+      setTimeout(() => setPicked(null), 700);
+    }
+  };
+
+  const next = () => {
+    setIndex((i) => i + 1);
+    setPhase("learn");
+    setPicked(null);
+  };
+
+  if (done) {
+    return (
+      <div style={{ textAlign: "center", padding: 32 }}>
+        <div style={{ fontSize: 64 }}>&#x1F308;</div>
+        <h2 style={{ fontSize: 28, fontWeight: 800, color: "#9B59B6", margin: "16px 0 8px" }}>Feelings Expert!</h2>
+        <p style={{ color: "#777" }}>You scored {score}/{feelings.length}!</p>
+        <div style={{ display: "flex", justifyContent: "center", gap: 8, margin: "12px 0" }}>
+          {feelings.map((fl) => <span key={fl.name} style={{ fontSize: 32 }}>{fl.emoji}</span>)}
+        </div>
+        <button onClick={() => { setIndex(0); setScore(0); setPhase("learn"); setPicked(null); }}
+          style={{ marginTop: 12, padding: "12px 32px", borderRadius: 16, border: "none", background: "#9B59B6", color: "#fff", fontWeight: 700, fontSize: 18, cursor: "pointer" }}>
+          Play Again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ textAlign: "center", padding: 24 }}>
+      <div style={{ fontSize: 12, color: "#999", marginBottom: 8 }}>{index + 1} / {feelings.length}</div>
+      <div style={{ height: 6, background: "#eee", borderRadius: 3, marginBottom: 20 }}>
+        <div style={{ height: 6, borderRadius: 3, background: `linear-gradient(90deg, #FFD93D, #FF6B6B)`, width: `${(index / feelings.length) * 100}%`, transition: "width 0.3s" }} />
+      </div>
+
+      <div style={{ fontSize: 72, marginBottom: 4 }}>{f.emoji}</div>
+      <h3 style={{ fontSize: 32, fontWeight: 800, color: f.color, margin: "0 0 4px" }}>{f.name}</h3>
+
+      {phase === "learn" && (
+        <>
+          <div style={{ display: "inline-block", padding: "10px 20px", borderRadius: 16, border: `2px solid ${f.color}`, background: `${f.color}15`, marginBottom: 8 }}>
+            <p style={{ margin: 0, fontWeight: 700, color: "#444", fontSize: 16 }}>{f.desc}</p>
+            <p style={{ margin: "4px 0 0", color: "#999", fontSize: 13 }}>{f.body}</p>
+          </div>
+          <br />
+          <button onClick={() => setPhase("quiz")}
+            style={{ marginTop: 12, padding: "12px 28px", borderRadius: 14, border: "none", background: "#4ECDC4", color: "#fff", fontWeight: 700, fontSize: 16, cursor: "pointer" }}>
+            Quiz Me!
+          </button>
+        </>
+      )}
+
+      {phase === "quiz" && (
+        <>
+          <p style={{ fontWeight: 700, color: f.color, fontSize: 16, margin: "8px 0 12px" }}>When do you feel {f.name}?</p>
+          <div style={{ display: "flex", flexDirection: "column", gap: 10, maxWidth: 320, margin: "0 auto" }}>
+            {f.options.map((opt, i) => {
+              const sel = picked === i;
+              const right = sel && i === f.answer;
+              const wrong = sel && i !== f.answer;
+              return (
+                <button key={opt} onClick={() => tryAnswer(i)}
+                  style={{ padding: "14px 18px", borderRadius: 14, border: right ? "3px solid #4CAF50" : wrong ? "3px solid #EF5350" : "2px solid #ddd",
+                    background: right ? "#C8E6C9" : wrong ? "#FFCDD2" : "#fff", fontWeight: 700, fontSize: 15, cursor: "pointer", textAlign: "left", transition: "all 0.15s" }}>
+                  {opt}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {phase === "result" && (
+        <>
+          <div style={{ fontSize: 48, margin: "8px 0" }}>&#x1F31F;</div>
+          <p style={{ color: "#555", fontSize: 16 }}>We feel <strong>{f.name}</strong> when &ldquo;{f.options[f.answer]}&rdquo;</p>
+          <button onClick={next}
+            style={{ marginTop: 12, padding: "12px 28px", borderRadius: 14, border: "none", background: "#4ECDC4", color: "#fff", fontWeight: 700, fontSize: 16, cursor: "pointer" }}>
+            Next Feeling
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/games/speech/RhymeTime.tsx
+++ b/src/components/games/speech/RhymeTime.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+
+const challenges = [
+  { target: "Cat", emoji: "\u{1F431}", ending: "-at", color: "#FF6B6B",
+    rhymes: [{ w: "Hat", e: "\u{1F3A9}" }, { w: "Bat", e: "\u{1F987}" }],
+    fakes:  [{ w: "Dog", e: "\u{1F415}" }, { w: "Car", e: "\u{1F697}" }] },
+  { target: "Bee", emoji: "\u{1F41D}", ending: "-ee", color: "#4ECDC4",
+    rhymes: [{ w: "Tree", e: "\u{1F333}" }, { w: "Key", e: "\u{1F511}" }],
+    fakes:  [{ w: "Bug", e: "\u{1F41B}" }, { w: "Rock", e: "\u{1FAA8}" }] },
+  { target: "Star", emoji: "\u2B50", ending: "-ar", color: "#FFD700",
+    rhymes: [{ w: "Car", e: "\u{1F697}" }, { w: "Jar", e: "\u{1FAD9}" }],
+    fakes:  [{ w: "Sun", e: "\u2600\uFE0F" }, { w: "Moon", e: "\u{1F319}" }] },
+  { target: "Moon", emoji: "\u{1F319}", ending: "-oon", color: "#686DE0",
+    rhymes: [{ w: "Spoon", e: "\u{1F944}" }, { w: "Balloon", e: "\u{1F388}" }],
+    fakes:  [{ w: "Night", e: "\u{1F303}" }, { w: "Dark", e: "\u{1F311}" }] },
+  { target: "Fish", emoji: "\u{1F41F}", ending: "-ish", color: "#74B9FF",
+    rhymes: [{ w: "Dish", e: "\u{1F37D}\uFE0F" }, { w: "Wish", e: "\u2728" }],
+    fakes:  [{ w: "Boat", e: "\u26F5" }, { w: "Wave", e: "\u{1F30A}" }] },
+  { target: "Dog", emoji: "\u{1F415}", ending: "-og", color: "#E8A87C",
+    rhymes: [{ w: "Log", e: "\u{1FAB5}" }, { w: "Frog", e: "\u{1F438}" }],
+    fakes:  [{ w: "Cat", e: "\u{1F431}" }, { w: "Bone", e: "\u{1F9B4}" }] },
+];
+
+function shuffle<T>(arr: T[]): T[] { return [...arr].sort(() => Math.random() - 0.5); }
+
+export default function RhymeTime() {
+  const [ci, setCi] = useState(0);
+  const [found, setFound] = useState<string[]>([]);
+  const [wrong, setWrong] = useState<string | null>(null);
+  const [allFound, setAllFound] = useState(false);
+
+  const ch = challenges[ci];
+  const done = ci >= challenges.length;
+
+  const options = useState(() => shuffle([
+    ...challenges[0].rhymes.map((r) => ({ ...r, rhyme: true })),
+    ...challenges[0].fakes.map((f) => ({ ...f, rhyme: false })),
+  ]))[0];
+
+  const [opts, setOpts] = useState(() => shuffle([
+    ...ch.rhymes.map((r) => ({ ...r, rhyme: true })),
+    ...ch.fakes.map((f) => ({ ...f, rhyme: false })),
+  ]));
+
+  const tap = (word: string, isRhyme: boolean) => {
+    if (found.includes(word) || allFound) return;
+    if (isRhyme) {
+      const next = [...found, word];
+      setFound(next);
+      if (next.length >= ch.rhymes.length) setAllFound(true);
+    } else {
+      setWrong(word);
+      setTimeout(() => setWrong(null), 700);
+    }
+  };
+
+  const next = () => {
+    const ni = ci + 1;
+    setCi(ni);
+    setFound([]);
+    setAllFound(false);
+    if (ni < challenges.length) {
+      const c = challenges[ni];
+      setOpts(shuffle([...c.rhymes.map((r) => ({ ...r, rhyme: true })), ...c.fakes.map((f) => ({ ...f, rhyme: false }))]));
+    }
+  };
+
+  if (done) {
+    return (
+      <div style={{ textAlign: "center", padding: 32 }}>
+        <div style={{ fontSize: 64 }}>&#x1F3B5;</div>
+        <h2 style={{ fontSize: 28, fontWeight: 800, color: "#6C5CE7", margin: "16px 0 8px" }}>Rhyme Champion!</h2>
+        <p style={{ color: "#777" }}>You found all the rhymes!</p>
+        <button onClick={() => { setCi(0); setFound([]); setAllFound(false); const c = challenges[0]; setOpts(shuffle([...c.rhymes.map((r) => ({ ...r, rhyme: true })), ...c.fakes.map((f) => ({ ...f, rhyme: false }))])); }}
+          style={{ marginTop: 16, padding: "12px 32px", borderRadius: 16, border: "none", background: "#6C5CE7", color: "#fff", fontWeight: 700, fontSize: 18, cursor: "pointer" }}>
+          Play Again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ textAlign: "center", padding: 24 }}>
+      <div style={{ fontSize: 12, color: "#999", marginBottom: 8 }}>Round {ci + 1} / {challenges.length}</div>
+      <div style={{ height: 6, background: "#eee", borderRadius: 3, marginBottom: 16 }}>
+        <div style={{ height: 6, borderRadius: 3, background: `linear-gradient(90deg, #6C5CE7, #A29BFE)`, width: `${(ci / challenges.length) * 100}%`, transition: "width 0.3s" }} />
+      </div>
+
+      <p style={{ color: "#888", fontSize: 13, margin: "0 0 6px" }}>Find words that rhyme with:</p>
+      <div style={{ display: "inline-flex", flexDirection: "column", alignItems: "center", padding: 16, borderRadius: 20, background: `${ch.color}18`, marginBottom: 8 }}>
+        <span style={{ fontSize: 48 }}>{ch.emoji}</span>
+        <span style={{ fontSize: 24, fontWeight: 800, color: ch.color }}>{ch.target}</span>
+      </div>
+      <div style={{ display: "inline-block", padding: "4px 14px", borderRadius: 12, background: ch.color, color: "#fff", fontWeight: 800, fontSize: 13, marginBottom: 16 }}>
+        ends in {ch.ending}
+      </div>
+
+      {!allFound ? (
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10, maxWidth: 260, margin: "0 auto" }}>
+          {opts.map((o) => {
+            const isFound = found.includes(o.w);
+            const isWrong = wrong === o.w;
+            return (
+              <button key={o.w} onClick={() => tap(o.w, o.rhyme)}
+                style={{ padding: 14, borderRadius: 16, border: isFound ? "3px solid #4CAF50" : isWrong ? "3px solid #EF5350" : "2px solid #ddd",
+                  background: isFound ? "#C8E6C9" : isWrong ? "#FFCDD2" : "#fff", cursor: "pointer", textAlign: "center", transition: "all 0.15s", opacity: isFound ? 0.7 : 1 }}>
+                <div style={{ fontSize: 32 }}>{o.e}</div>
+                <div style={{ fontWeight: 700, fontSize: 13, marginTop: 2 }}>{o.w}</div>
+                {isFound && <div style={{ fontSize: 10, color: "#4CAF50", fontWeight: 700 }}>rhymes!</div>}
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <div>
+          <div style={{ fontSize: 48, marginBottom: 8 }}>&#x2728;</div>
+          <p style={{ fontWeight: 800, color: "#4CAF50", fontSize: 20 }}>All Found!</p>
+          <button onClick={next}
+            style={{ marginTop: 12, padding: "12px 32px", borderRadius: 16, border: "none", background: "#6C5CE7", color: "#fff", fontWeight: 700, fontSize: 18, cursor: "pointer" }}>
+            {ci + 1 >= challenges.length ? "Finish!" : "Next Rhymes"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/games/speech/WordRepeat.tsx
+++ b/src/components/games/speech/WordRepeat.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+
+const words = [
+  { word: "Ball", emoji: "\u{1F3C0}", syllables: "ball" },
+  { word: "Cat", emoji: "\u{1F431}", syllables: "cat" },
+  { word: "Apple", emoji: "\u{1F34E}", syllables: "ap-ple" },
+  { word: "Banana", emoji: "\u{1F34C}", syllables: "ba-na-na" },
+  { word: "Elephant", emoji: "\u{1F418}", syllables: "el-e-phant" },
+  { word: "Rainbow", emoji: "\u{1F308}", syllables: "rain-bow" },
+  { word: "Butterfly", emoji: "\u{1F98B}", syllables: "but-ter-fly" },
+  { word: "Dinosaur", emoji: "\u{1F995}", syllables: "di-no-saur" },
+  { word: "Octopus", emoji: "\u{1F419}", syllables: "oc-to-pus" },
+  { word: "Strawberry", emoji: "\u{1F353}", syllables: "straw-ber-ry" },
+];
+
+const REPEATS = 3;
+const TOTAL = 8;
+
+export default function WordRepeat() {
+  const [pool] = useState(() => [...words].sort(() => Math.random() - 0.5).slice(0, TOTAL));
+  const [index, setIndex] = useState(0);
+  const [reps, setReps] = useState(0);
+  const [speaking, setSpeaking] = useState(false);
+
+  const current = pool[index];
+  const done = index >= TOTAL;
+
+  const speak = (text: string) => {
+    try {
+      const u = new SpeechSynthesisUtterance(text);
+      u.rate = 0.7;
+      u.pitch = 1.1;
+      setSpeaking(true);
+      u.onend = () => setSpeaking(false);
+      u.onerror = () => setSpeaking(false);
+      speechSynthesis.cancel();
+      speechSynthesis.speak(u);
+    } catch { setSpeaking(false); }
+  };
+
+  const saidIt = () => {
+    const next = reps + 1;
+    setReps(next);
+    if (next >= REPEATS) {
+      setTimeout(() => { setIndex((i) => i + 1); setReps(0); }, 1000);
+    }
+  };
+
+  if (done) {
+    return (
+      <div style={{ textAlign: "center", padding: 32 }}>
+        <div style={{ fontSize: 64 }}>&#x1F3A4;</div>
+        <h2 style={{ fontSize: 28, fontWeight: 800, color: "#9B59B6", margin: "16px 0 8px" }}>Word Master!</h2>
+        <p style={{ color: "#777" }}>You practised {TOTAL} words!</p>
+        <div style={{ display: "flex", justifyContent: "center", gap: 8, flexWrap: "wrap", margin: "12px 0" }}>
+          {pool.map((w) => <span key={w.word} style={{ fontSize: 32 }}>{w.emoji}</span>)}
+        </div>
+        <button onClick={() => { setIndex(0); setReps(0); }}
+          style={{ marginTop: 12, padding: "12px 32px", borderRadius: 16, border: "none", background: "#9B59B6", color: "#fff", fontWeight: 700, fontSize: 18, cursor: "pointer" }}>
+          Play Again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ textAlign: "center", padding: 24 }}>
+      <div style={{ fontSize: 12, color: "#999", marginBottom: 8 }}>{index + 1} / {TOTAL}</div>
+      <div style={{ height: 6, background: "#eee", borderRadius: 3, marginBottom: 20 }}>
+        <div style={{ height: 6, borderRadius: 3, background: "linear-gradient(90deg, #9B59B6, #E91E9B)", width: `${(index / TOTAL) * 100}%`, transition: "width 0.3s" }} />
+      </div>
+
+      <div style={{ fontSize: 80, marginBottom: 8, animation: speaking ? "pulse 0.5s infinite" : "none" }}>{current.emoji}</div>
+      <h3 style={{ fontSize: 36, fontWeight: 800, color: "#9B59B6", margin: "0 0 4px" }}>{current.word}</h3>
+      <p style={{ color: "#aaa", fontSize: 14, letterSpacing: 2, margin: "0 0 16px" }}>{current.syllables}</p>
+
+      <div style={{ display: "flex", justifyContent: "center", gap: 10, marginBottom: 16 }}>
+        {Array.from({ length: REPEATS }).map((_, i) => (
+          <div key={i} style={{
+            width: 36, height: 36, borderRadius: 18, display: "flex", alignItems: "center", justifyContent: "center",
+            background: i < reps ? "#4ECDC4" : "#eee", color: i < reps ? "#fff" : "#bbb", fontWeight: 800, fontSize: 14, transition: "all 0.2s",
+          }}>{i < reps ? "\u2713" : i + 1}</div>
+        ))}
+      </div>
+      <p style={{ color: "#888", fontSize: 14, marginBottom: 16 }}>Say it <strong>{REPEATS - reps}</strong> more {REPEATS - reps === 1 ? "time" : "times"}!</p>
+
+      <button onClick={() => speak(current.word)} disabled={speaking}
+        style={{ padding: "10px 24px", borderRadius: 14, border: "none", background: "#FFD54F", color: "#333", fontWeight: 700, fontSize: 16, cursor: "pointer", marginRight: 8, opacity: speaking ? 0.5 : 1 }}>
+        Hear It
+      </button>
+      <button onClick={saidIt}
+        style={{ padding: "10px 24px", borderRadius: 14, border: "none", background: "#9B59B6", color: "#fff", fontWeight: 700, fontSize: 16, cursor: "pointer" }}>
+        I Said It!
+      </button>
+
+      <style>{`@keyframes pulse { 0%,100% { transform: scale(1) } 50% { transform: scale(1.08) } }`}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Game Hub** (`/games`) with category tabs (Speech, Maths, Music) and GameCard grid
- **4 Speech/Phonics games** — self-contained, inline styles, zero external deps:
  - **Animal Sounds** — learn animal sounds, then quiz (match sound to animal)
  - **Word Repeat** — hear a word via TTS, tap "I Said It" 3 times with syllable breakdown
  - **Rhyme Time** — find all rhyming words from a mixed grid (6 rounds)
  - **Feelings Explorer** — learn emotions, body clues, match feelings to situations
- Each game has progress bars, score tracking, replay, and playful visual design
- Simplified from Nick OS prototypes (~80-120 lines each vs 300-400 in originals)

Closes #21 (partial — speech batch only, maths/music batches to follow)

## Test plan
- [ ] Visit `/games` — tabs render, Speech tab shows 4 game cards
- [ ] Click each game — loads correctly, back button returns to hub
- [ ] Animal Sounds: learn phase shows emoji + sound, quiz gives 4 options, progress tracks
- [ ] Word Repeat: TTS speaks word, 3 repeat dots fill, cycles through 8 words
- [ ] Rhyme Time: tap rhyming words (green), wrong ones flash red, 6 rounds
- [ ] Feelings Explorer: learn phase shows emoji + description, quiz has 3 situation options
- [ ] Maths and Music tabs show "Coming soon" placeholder
- [ ] Build passes (`next build`) with no errors

Generated with [Claude Code](https://claude.com/claude-code)