### PR TITLE
feat: port Groq autocomplete + sentence improvement API (#53)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Groq API — free tier, used for autocomplete + sentence improvement
+# Get a key at https://console.groq.com/keys
+GROQ_API_KEY=

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "@8gi-foundation/8gentjr",
       "dependencies": {
         "@clerk/nextjs": "^6.37.4",
+        "groq-sdk": "^1.1.2",
         "next": "^15.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -185,6 +186,8 @@
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
+    "groq-sdk": ["groq-sdk@1.1.2", "", { "bin": { "groq-sdk": "bin/cli" } }, "sha512-CZO0XUQQDhn43ri1+lZHxZKpb+bGutgTvFmCJtooexiitGmPqhm1hntOT3nCoaq07e+OpeokVnfUs0i/oQuUaQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.37.4",
+    "groq-sdk": "^1.1.2",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/app/api/autocomplete/route.ts
+++ b/src/app/api/autocomplete/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Groq from 'groq-sdk';
+
+/**
+ * 8gent Jr — Autocomplete API
+ *
+ * Uses Groq (fast, free) for AI-powered word suggestions.
+ * Ported from NickOS autocomplete endpoint, adapted for 8gent Jr AAC.
+ *
+ * Issue: #53
+ */
+
+export const runtime = 'edge';
+
+interface AutocompleteRequest {
+  input: string;
+  existingWords: string[];
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const groqKey = process.env.GROQ_API_KEY;
+    if (!groqKey) {
+      return NextResponse.json(
+        { error: 'GROQ_API_KEY not configured', suggestions: [] },
+        { status: 500 }
+      );
+    }
+
+    const body: AutocompleteRequest = await request.json();
+    const { input, existingWords = [] } = body;
+
+    if (!input || input.trim().length === 0) {
+      return NextResponse.json({ suggestions: [] });
+    }
+
+    const groq = new Groq({ apiKey: groqKey });
+
+    const prompt = `You are an AAC (Augmentative and Alternative Communication) word suggestion assistant for a 7-year-old child.
+
+The child has started typing: "${input}"
+
+Existing vocabulary cards available: ${existingWords.slice(0, 50).join(', ')}
+
+Suggest 5 words that:
+1. Complete or relate to what they started typing
+2. Are age-appropriate for a 7-year-old
+3. Are commonly used in daily communication
+4. Mix between words they already have (from the list) and new useful words
+
+Return ONLY a JSON array of 5 words, no explanation. Example: ["hello", "help", "happy", "home", "hungry"]`;
+
+    const completion = await groq.chat.completions.create({
+      model: 'llama-3.1-8b-instant',
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 128,
+    });
+
+    const text = completion.choices?.[0]?.message?.content ?? '';
+
+    // Parse the response — expecting a JSON array
+    let suggestions: string[] = [];
+    try {
+      const cleanedText = text
+        .replace(/```json\n?/g, '')
+        .replace(/```\n?/g, '')
+        .trim();
+
+      suggestions = JSON.parse(cleanedText);
+
+      if (!Array.isArray(suggestions)) {
+        suggestions = [];
+      }
+      suggestions = suggestions
+        .filter((s): s is string => typeof s === 'string')
+        .slice(0, 6);
+    } catch {
+      // If parsing fails, try to extract words from the text
+      const wordMatch = text.match(/["']([^"']+)["']/g);
+      if (wordMatch) {
+        suggestions = wordMatch
+          .map((w) => w.replace(/["']/g, ''))
+          .slice(0, 6);
+      }
+    }
+
+    return NextResponse.json({ suggestions });
+  } catch (error) {
+    console.error('[8gent Jr Autocomplete] Error:', error);
+    return NextResponse.json(
+      { error: 'Failed to generate suggestions', suggestions: [] },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/improve-sentence/route.ts
+++ b/src/app/api/improve-sentence/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest } from 'next/server';
+import Groq from 'groq-sdk';
+
+/**
+ * 8gent Jr — Sentence Improvement API (Magic Button)
+ *
+ * Takes raw AAC card words and returns a grammatically improved sentence.
+ * Uses Groq (free, fast) for LLM-powered grammar correction.
+ * Ported from NickOS improve-sentence endpoint.
+ *
+ * Issue: #53
+ */
+
+export const runtime = 'edge';
+
+const SYSTEM_PROMPT = `You are an AAC sentence improver for children. Your job is to take words from communication cards and form natural sentences.
+
+Rules:
+1. Keep the meaning EXACTLY the same
+2. Add only necessary grammar (articles, prepositions, conjugations)
+3. Keep sentences simple and age-appropriate
+4. Output should sound natural when spoken aloud
+5. Do NOT add new concepts or change the intent
+
+Also detect if the sentence is missing important vocabulary. Return suggestions for cards that would help.
+
+Example:
+Input: "I want apple juice"
+Output: "I would like some apple juice, please"
+Missing: None
+
+Example:
+Input: "go park"
+Output: "I want to go to the park"
+Missing: ["I", "want"] - core vocabulary for expressing desires
+
+Respond with JSON:
+{
+  "improved": "the improved sentence",
+  "explanation": "brief explanation of changes",
+  "missing": [
+    {
+      "word": "missing word",
+      "category": "core|actions|feelings|etc",
+      "reason": "why this would help"
+    }
+  ]
+}`;
+
+interface ImproveRequest {
+  cards: string[];
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body: ImproveRequest = await request.json();
+
+    if (!body.cards || !Array.isArray(body.cards) || body.cards.length === 0) {
+      return new Response(JSON.stringify({ error: 'Cards array required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const groqKey = process.env.GROQ_API_KEY;
+
+    if (!groqKey) {
+      return new Response(JSON.stringify({ error: 'GROQ_API_KEY not configured' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const rawSentence = body.cards.join(' ');
+
+    const groq = new Groq({ apiKey: groqKey });
+
+    const completion = await groq.chat.completions.create({
+      model: 'llama-3.1-8b-instant',
+      max_tokens: 512,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: `Improve this AAC sentence: "${rawSentence}"` },
+      ],
+    });
+
+    const content = completion.choices?.[0]?.message?.content;
+
+    if (content) {
+      return parseAndRespond(content, rawSentence);
+    }
+
+    return new Response(JSON.stringify({ error: 'No response from AI' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('[8gent Jr Improve] Error:', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+function parseAndRespond(content: string, rawSentence: string): Response {
+  try {
+    let jsonStr = content;
+    const jsonMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (jsonMatch) {
+      jsonStr = jsonMatch[1].trim();
+    }
+    const result = JSON.parse(jsonStr);
+    return new Response(
+      JSON.stringify({
+        original: rawSentence,
+        improved: result.improved,
+        explanation: result.explanation,
+        missing: result.missing || [],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch {
+    return new Response(
+      JSON.stringify({
+        original: rawSentence,
+        improved: content.trim(),
+        explanation: 'Grammar improved',
+        missing: [],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/src/components/SentenceBuilder.tsx
+++ b/src/components/SentenceBuilder.tsx
@@ -10,11 +10,12 @@
  * Issue: #22
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import {
   suggestNextWord,
   improveSentence,
   getWordColor,
+  getAllWords,
 } from '@/lib/sentence-engine';
 import { useApp } from '@/context/AppContext';
 
@@ -40,8 +41,49 @@ export default function SentenceBuilder() {
   const [encouragement, setEncouragement] = useState<string | null>(null);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [improvedPreview, setImprovedPreview] = useState<string | null>(null);
+  const [aiSuggestions, setAiSuggestions] = useState<string[] | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const suggestions = suggestNextWord(selectedWords);
+  // Local suggestions as baseline (always available)
+  const localSuggestions = suggestNextWord(selectedWords);
+  // Use AI suggestions if available, otherwise local
+  const suggestions = aiSuggestions ?? localSuggestions;
+
+  // Fetch AI autocomplete suggestions (with debounce + local fallback)
+  useEffect(() => {
+    // Reset AI suggestions when words change — local kicks in immediately
+    setAiSuggestions(null);
+
+    if (selectedWords.length === 0) return;
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const lastWord = selectedWords[selectedWords.length - 1];
+        const res = await fetch('/api/autocomplete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            input: lastWord,
+            existingWords: getAllWords(),
+          }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.suggestions?.length > 0) {
+            setAiSuggestions(data.suggestions);
+          }
+        }
+      } catch {
+        // Silently fall back to local suggestions
+      }
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [selectedWords]);
 
   // Show encouragement on milestones
   useEffect(() => {
@@ -53,7 +95,7 @@ export default function SentenceBuilder() {
     }
   }, [selectedWords.length]);
 
-  // Update improved preview when words change
+  // Update improved preview when words change (local, instant)
   useEffect(() => {
     if (selectedWords.length >= 2) {
       setImprovedPreview(improveSentence(selectedWords));


### PR DESCRIPTION
## Summary
- Ports Groq-powered autocomplete and sentence improvement API routes from NickOS to 8gent Jr
- Adds `/api/autocomplete` for AI word suggestions using Groq llama-3.1-8b-instant
- Adds `/api/improve-sentence` for LLM-powered AAC grammar correction
- Updates SentenceBuilder.tsx to call autocomplete API with 300ms debounce and local engine fallback
- Adds groq-sdk dependency and .env.example with GROQ_API_KEY placeholder

## Test plan
- [ ] Set GROQ_API_KEY in .env.local and verify autocomplete returns AI suggestions
- [ ] Verify local fallback works when API is unavailable (remove key)
- [ ] Test improve-sentence endpoint with sample card arrays
- [ ] Confirm build passes cleanly

Generated with [Claude Code](https://claude.com/claude-code)