### PR TITLE
feat: port ElevenLabs TTS + GLP stage system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # Groq API — free tier, used for autocomplete + sentence improvement
 # Get a key at https://console.groq.com/keys
 GROQ_API_KEY=
+
+# ElevenLabs TTS (optional — falls back to browser speech synthesis)
+ELEVENLABS_API_KEY=
+ELEVENLABS_JR_VOICE_ID=          # Default: EXAVITQu4vr4xnSDxMaL (Sarah)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1135 @@
+{
+  "name": "@8gi-foundation/8gentjr",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@8gi-foundation/8gentjr",
+      "version": "0.1.0",
+      "dependencies": {
+        "@clerk/nextjs": "^6.37.4",
+        "next": "^15.1.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@clerk/backend": {
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.1.tgz",
+      "integrity": "sha512-DRwmFu6gEmzHRUeXXB5y02QxMihHDEgetSQrb0ME6KaYe29+LnenBUQAmlASXmsovIi9cBqk4hE4WHWNRXX+Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.3",
+        "@clerk/types": "^4.101.21",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@clerk/clerk-react": {
+      "version": "5.61.4",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.4.tgz",
+      "integrity": "sha512-xGvQvzfc5pQEuqCW8CNUgnlR+9nt6gSSMGMYx3l972utIJrFKByQJFCRZpwYBvAHiveuK11Wgy3J39p904jb+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.3",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/nextjs": {
+      "version": "6.39.1",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.1.tgz",
+      "integrity": "sha512-crc6nJOK+1V7kf7tMxeoOaJK9/HHGbjqWm1rW11RrRKA7lnaIeCUtO6kSy8dZ/4ZyVfUACVOwUdQM7EqwHmzWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^2.33.1",
+        "@clerk/clerk-react": "^5.61.4",
+        "@clerk/shared": "^3.47.3",
+        "@clerk/types": "^4.101.21",
+        "server-only": "0.0.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "next": "^13.5.7 || ^14.2.25 || ^15.2.3 || ^16",
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "3.47.3",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.3.tgz",
+      "integrity": "sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0",
+        "swr": "2.3.4"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/types": {
+      "version": "4.101.21",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.21.tgz",
+      "integrity": "sha512-/70W603A6bRv1n24dDNAs3kWHLSIgXebEyzXZ46IuROWcq0+guSqqLa+nKekxxIdk6I/vnI9SWjBvBRuZVMnhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.3"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
+      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
+      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
+      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
+      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
+      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
+      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
+      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
+      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
+      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react/node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001782",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+      "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
+      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.5.14",
+        "@swc/helpers": "0.5.15",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.5.14",
+        "@next/swc-darwin-x64": "15.5.14",
+        "@next/swc-linux-arm64-gnu": "15.5.14",
+        "@next/swc-linux-arm64-musl": "15.5.14",
+        "@next/swc-linux-x64-gnu": "15.5.14",
+        "@next/swc-linux-x64-musl": "15.5.14",
+        "@next/swc-win32-arm64-msvc": "15.5.14",
+        "@next/swc-win32-x64-msvc": "15.5.14",
+        "sharp": "^0.34.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    }
+  }
+}

--- a/src/app/api/tts/route.ts
+++ b/src/app/api/tts/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * POST /api/tts
+ *
+ * ElevenLabs TTS proxy endpoint for 8gent Jr.
+ * Keeps the API key server-side. Returns audio/mpeg stream.
+ *
+ * Body: { text: string, voiceId?: string, stability?: number, similarityBoost?: number }
+ * Returns: audio/mpeg (or 204 if ElevenLabs not configured)
+ *
+ * Issue: #53
+ */
+
+const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const DEFAULT_VOICE_ID = process.env.ELEVENLABS_JR_VOICE_ID ?? 'EXAVITQu4vr4xnSDxMaL'; // Sarah (child-friendly)
+
+interface TTSRequest {
+  text: string;
+  voiceId?: string;
+  stability?: number;
+  similarityBoost?: number;
+}
+
+export async function POST(request: NextRequest) {
+  // No API key configured — client should fall back to browser TTS
+  if (!ELEVENLABS_API_KEY) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  try {
+    const body: TTSRequest = await request.json();
+    const { text, voiceId, stability = 0.5, similarityBoost = 0.75 } = body;
+
+    // Validate
+    if (!text || typeof text !== 'string') {
+      return NextResponse.json({ error: 'Text is required' }, { status: 400 });
+    }
+    if (text.length > 1000) {
+      return NextResponse.json({ error: 'Text too long (max 1000 chars)' }, { status: 400 });
+    }
+
+    const voice = voiceId || DEFAULT_VOICE_ID;
+
+    const res = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voice}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'xi-api-key': ELEVENLABS_API_KEY,
+      },
+      body: JSON.stringify({
+        text,
+        model_id: 'eleven_turbo_v2_5',
+        voice_settings: {
+          stability: Math.max(0, Math.min(1, stability)),
+          similarity_boost: Math.max(0, Math.min(1, similarityBoost)),
+          style: 0.0,
+          use_speaker_boost: true,
+        },
+      }),
+    });
+
+    if (!res.ok) {
+      const errText = await res.text().catch(() => 'Unknown error');
+      console.error(`[TTS API] ElevenLabs ${res.status}: ${errText}`);
+      // Return 204 so client falls back gracefully
+      return new NextResponse(null, { status: 204 });
+    }
+
+    const audioBuffer = await res.arrayBuffer();
+
+    return new NextResponse(audioBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'audio/mpeg',
+        'Content-Length': String(audioBuffer.byteLength),
+        'Cache-Control': 'private, max-age=3600',
+      },
+    });
+  } catch (error) {
+    console.error('[TTS API] Error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,21 +3,15 @@
 import PhraseBoard from "../components/PhraseBoard";
 import Dock from "../components/Dock";
 import AACBoard from "@/components/AACBoard";
+import { GENERAL_PHRASES } from "@/lib/vocabulary";
+import { FITZGERALD_COLORS } from "@/lib/fitzgerald-key";
 
-const DEMO_CARDS = [
-  { label: "I want", bgColor: "#E8F5E9" },
-  { label: "More", bgColor: "#E3F2FD" },
-  { label: "Help", bgColor: "#FFF3E0" },
-  { label: "Yes", bgColor: "#E8F5E9" },
-  { label: "No", bgColor: "#FFEBEE" },
-  { label: "Drink", bgColor: "#E3F2FD" },
-  { label: "Food", bgColor: "#FFF3E0" },
-  { label: "Play", bgColor: "#F3E5F5" },
-  { label: "Stop", bgColor: "#FFEBEE" },
-  { label: "Bathroom", bgColor: "#E3F2FD" },
-  { label: "Happy", bgColor: "#E8F5E9" },
-  { label: "Sad", bgColor: "#FFEBEE" },
-];
+/** PhraseBoard cards built from the vocabulary system's General phrases */
+const PHRASE_CARDS = GENERAL_PHRASES.map((phrase) => ({
+  label: phrase.text,
+  symbolUrl: phrase.imageUrl,
+  bgColor: FITZGERALD_COLORS.verb.bg,
+}));
 
 export default function Home() {
   return (
@@ -40,7 +34,7 @@ export default function Home() {
         </p>
 
         <PhraseBoard
-          cards={DEMO_CARDS}
+          cards={PHRASE_CARDS}
           onCardTap={(label) => {
             console.log("tapped:", label);
           }}

--- a/src/components/AACBoard.tsx
+++ b/src/components/AACBoard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { GENERAL_PHRASES, FEELINGS_PHRASES, ACTIONS_PHRASES } from "@/lib/vocabulary";
 
 // ---------------------------------------------------------------------------
 // Grid density presets — progressive from accessible to advanced
@@ -11,22 +12,17 @@ export type GridDensity = (typeof GRID_DENSITY_OPTIONS)[number];
 const DEFAULT_COLUMNS: GridDensity = 4;
 
 // ---------------------------------------------------------------------------
-// Sample AAC symbols (placeholder set — will be replaced by real symbol bank)
+// AAC symbols from vocabulary system (replaces hardcoded SAMPLE_SYMBOLS)
 // ---------------------------------------------------------------------------
-const SAMPLE_SYMBOLS = [
-  { id: "want", label: "I want", emoji: "\u{1F44B}" },
-  { id: "eat", label: "Eat", emoji: "\u{1F37D}\uFE0F" },
-  { id: "drink", label: "Drink", emoji: "\u{1F964}" },
-  { id: "play", label: "Play", emoji: "\u{1F3AE}" },
-  { id: "help", label: "Help", emoji: "\u{1F198}" },
-  { id: "more", label: "More", emoji: "\u2795" },
-  { id: "stop", label: "Stop", emoji: "\u{1F6D1}" },
-  { id: "yes", label: "Yes", emoji: "\u2705" },
-  { id: "no", label: "No", emoji: "\u274C" },
-  { id: "happy", label: "Happy", emoji: "\u{1F60A}" },
-  { id: "sad", label: "Sad", emoji: "\u{1F622}" },
-  { id: "tired", label: "Tired", emoji: "\u{1F634}" },
-];
+const AAC_SYMBOLS = [
+  ...GENERAL_PHRASES,
+  ...FEELINGS_PHRASES,
+  ...ACTIONS_PHRASES,
+].map((phrase) => ({
+  id: phrase.id,
+  label: phrase.text,
+  imageUrl: phrase.imageUrl,
+}));
 
 // ---------------------------------------------------------------------------
 // Props

--- a/src/lib/fitzgerald-key.ts
+++ b/src/lib/fitzgerald-key.ts
@@ -1,0 +1,133 @@
+/**
+ * Modified Fitzgerald Key Color Coding System
+ *
+ * Industry-standard AAC color coding for grammatical categories.
+ * Used by Supercore, Grid 3, and recommended by SLTs globally.
+ *
+ * Colors encode word class so the user can visually scan:
+ *   "I need a verb"  -> scan for green
+ *   "I need a noun"  -> scan for orange
+ *
+ * WCAG AA contrast ratios maintained for all combinations.
+ *
+ * @see https://en.wikipedia.org/wiki/Fitzgerald_Key
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** All word categories recognized by the Fitzgerald Key */
+export type WordCategory =
+  | 'pronoun'
+  | 'verb'
+  | 'noun'
+  | 'adjective'
+  | 'adverb'
+  | 'preposition'
+  | 'conjunction'
+  | 'determiner'
+  | 'question'
+  | 'negation'
+  | 'interjection'
+  | 'social';
+
+/** Color definition for a single Fitzgerald Key category */
+export interface FitzgeraldColor {
+  /** Card background color (hex) */
+  bg: string;
+  /** Text color for readability (hex) */
+  text: string;
+  /** Human-readable label for this category */
+  label: string;
+  /** Border color — slightly darker variant for card edges */
+  border: string;
+}
+
+// =============================================================================
+// Color Definitions
+// =============================================================================
+
+export const FITZGERALD_COLORS: Record<WordCategory, FitzgeraldColor> = {
+  /** Yellow — people words */
+  pronoun:      { bg: '#FFEB3B', text: '#000000', label: 'Pronouns',     border: '#F9A825' },
+  /** Green — actions */
+  verb:         { bg: '#4CAF50', text: '#FFFFFF', label: 'Verbs',        border: '#388E3C' },
+  /** Orange — things */
+  noun:         { bg: '#FF9800', text: '#FFFFFF', label: 'Nouns',        border: '#E65100' },
+  /** Pink — describing words */
+  adjective:    { bg: '#E91E63', text: '#FFFFFF', label: 'Adjectives',   border: '#AD1457' },
+  /** Pink — describing words (same as adjective) */
+  adverb:       { bg: '#E91E63', text: '#FFFFFF', label: 'Adverbs',      border: '#AD1457' },
+  /** Purple — question words */
+  question:     { bg: '#9C27B0', text: '#FFFFFF', label: 'Questions',    border: '#6A1B9A' },
+  /** Blue — location/direction words */
+  preposition:  { bg: '#2196F3', text: '#FFFFFF', label: 'Prepositions', border: '#1565C0' },
+  /** White — grammatical glue */
+  conjunction:  { bg: '#FFFFFF', text: '#000000', label: 'Small Words',  border: '#BDBDBD' },
+  /** White — grammatical glue */
+  determiner:   { bg: '#FFFFFF', text: '#000000', label: 'Small Words',  border: '#BDBDBD' },
+  /** Red — stop/alert words */
+  negation:     { bg: '#F44336', text: '#FFFFFF', label: 'Negatives',    border: '#C62828' },
+  /** Red — exclamations */
+  interjection: { bg: '#F44336', text: '#FFFFFF', label: 'Interjections', border: '#C62828' },
+  /** Teal — greetings & manners */
+  social:       { bg: '#00BCD4', text: '#FFFFFF', label: 'Social',       border: '#00838F' },
+} as const;
+
+// =============================================================================
+// Lookup Helpers
+// =============================================================================
+
+/**
+ * Get the Fitzgerald Key color for a given word category.
+ * Returns the full color object (bg, text, label, border).
+ */
+export function getFitzgeraldColor(category: WordCategory): FitzgeraldColor {
+  return FITZGERALD_COLORS[category];
+}
+
+/**
+ * Get inline style object suitable for a card element.
+ * Returns { backgroundColor, color, borderColor, borderWidth, borderStyle }.
+ */
+export function getFitzgeraldStyle(category: WordCategory): Record<string, string> {
+  const color = FITZGERALD_COLORS[category];
+  return {
+    backgroundColor: color.bg,
+    color: color.text,
+    borderColor: color.border,
+    borderWidth: '2px',
+    borderStyle: 'solid',
+  };
+}
+
+/**
+ * Get CSS custom properties for a word category.
+ * Useful for components that need Fitzgerald colors via CSS variables.
+ */
+export function getFitzgeraldCSSVars(category: WordCategory): Record<string, string> {
+  const color = FITZGERALD_COLORS[category];
+  return {
+    '--fitzgerald-bg': color.bg,
+    '--fitzgerald-text': color.text,
+    '--fitzgerald-border': color.border,
+  };
+}
+
+// =============================================================================
+// Category Grouping (for legend/key display)
+// =============================================================================
+
+/** Unique display categories for the Fitzgerald Key legend */
+export const FITZGERALD_LEGEND: { wordTypes: WordCategory[]; color: FitzgeraldColor }[] = [
+  { wordTypes: ['verb'],                      color: FITZGERALD_COLORS.verb },
+  { wordTypes: ['pronoun'],                   color: FITZGERALD_COLORS.pronoun },
+  { wordTypes: ['noun'],                      color: FITZGERALD_COLORS.noun },
+  { wordTypes: ['adjective', 'adverb'],       color: FITZGERALD_COLORS.adjective },
+  { wordTypes: ['question'],                  color: FITZGERALD_COLORS.question },
+  { wordTypes: ['preposition'],               color: FITZGERALD_COLORS.preposition },
+  { wordTypes: ['conjunction', 'determiner'], color: FITZGERALD_COLORS.conjunction },
+  { wordTypes: ['negation', 'interjection'],  color: FITZGERALD_COLORS.negation },
+  { wordTypes: ['social'],                    color: FITZGERALD_COLORS.social },
+];

--- a/src/lib/glp/index.ts
+++ b/src/lib/glp/index.ts
@@ -1,0 +1,14 @@
+/**
+ * 8gent Jr — GLP (Graded Language Proficiency) module
+ *
+ * Re-exports stages and vocabulary for clean imports:
+ *   import { getStage, getWordsForStage } from '@/lib/glp';
+ *
+ * Issue: #53
+ */
+
+export { GLP_STAGES, getStage, isCategoryAvailable, getMaxWords } from './stages';
+export type { GLPStage } from './stages';
+
+export { VOCABULARY, getWordsForStage, getWordsByCategory, getWordStringsForStage, getStageWordCounts } from './vocabulary';
+export type { VocabWord } from './vocabulary';

--- a/src/lib/glp/stages.ts
+++ b/src/lib/glp/stages.ts
@@ -1,0 +1,133 @@
+/**
+ * 8gent Jr — Graded Language Proficiency (GLP) Stages
+ *
+ * Six stages modelled on typical AAC/SLP progression:
+ *   1. Single words (requesting, labelling)
+ *   2. Two-word combinations (agent + action, action + object)
+ *   3. Three-word sentences (subject + verb + object)
+ *   4. Simple sentences (4-5 words with grammar)
+ *   5. Complex sentences (conjunctions, questions, temporal)
+ *   6. Conversation (multi-turn, narrative, social)
+ *
+ * Each stage defines the max utterance length, grammar features,
+ * and the vocabulary tier the child can access.
+ *
+ * Issue: #53
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GLPStage {
+  /** Stage number 1-6 */
+  id: number;
+  /** Short label */
+  name: string;
+  /** Description for parents/therapists */
+  description: string;
+  /** Max words per utterance at this stage */
+  maxWords: number;
+  /** Grammar features unlocked */
+  grammarFeatures: string[];
+  /** Word categories available */
+  wordCategories: string[];
+  /** Example utterances */
+  examples: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Stage definitions
+// ---------------------------------------------------------------------------
+
+export const GLP_STAGES: GLPStage[] = [
+  {
+    id: 1,
+    name: 'Single Words',
+    description: 'Requesting and labelling with single words. Focus on high-frequency core vocabulary.',
+    maxWords: 1,
+    grammarFeatures: [],
+    wordCategories: ['noun', 'verb', 'social'],
+    examples: ['more', 'stop', 'help', 'water', 'play', 'yes', 'no'],
+  },
+  {
+    id: 2,
+    name: 'Two-Word Combinations',
+    description: 'Combining two words: agent+action, action+object, attribute+object.',
+    maxWords: 2,
+    grammarFeatures: ['agent-action', 'action-object'],
+    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective'],
+    examples: ['want more', 'go home', 'big toy', 'I want', 'help me', 'play music'],
+  },
+  {
+    id: 3,
+    name: 'Three-Word Sentences',
+    description: 'Subject + verb + object structures. Basic sentence formation.',
+    maxWords: 3,
+    grammarFeatures: ['agent-action', 'action-object', 'subject-verb-object'],
+    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective', 'determiner'],
+    examples: ['I want water', 'she is happy', 'play the game', 'I feel sad'],
+  },
+  {
+    id: 4,
+    name: 'Simple Sentences',
+    description: 'Full simple sentences with articles, prepositions, and basic grammar.',
+    maxWords: 5,
+    grammarFeatures: ['agent-action', 'action-object', 'subject-verb-object', 'prepositions', 'articles'],
+    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective', 'determiner', 'preposition'],
+    examples: ['I want to go home', 'can I have more water', 'I am happy today'],
+  },
+  {
+    id: 5,
+    name: 'Complex Sentences',
+    description: 'Questions, conjunctions, temporal words, and longer expressions.',
+    maxWords: 8,
+    grammarFeatures: [
+      'agent-action', 'action-object', 'subject-verb-object',
+      'prepositions', 'articles', 'questions', 'conjunctions', 'temporal',
+    ],
+    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective', 'determiner', 'preposition', 'question', 'adverb'],
+    examples: [
+      'what do you want to play',
+      'I want to go outside and play',
+      'can we have food now please',
+    ],
+  },
+  {
+    id: 6,
+    name: 'Conversation',
+    description: 'Multi-turn conversation, narrative, social language, and open expression.',
+    maxWords: 12,
+    grammarFeatures: [
+      'agent-action', 'action-object', 'subject-verb-object',
+      'prepositions', 'articles', 'questions', 'conjunctions', 'temporal',
+      'narrative', 'social-pragmatic',
+    ],
+    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective', 'determiner', 'preposition', 'question', 'adverb'],
+    examples: [
+      'hello, I am happy today because we played outside',
+      'can you help me with the big book please',
+      'I liked the game but I feel tired now',
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Get a stage by ID (1-6). Returns stage 3 as safe default. */
+export function getStage(id: number): GLPStage {
+  return GLP_STAGES.find((s) => s.id === id) ?? GLP_STAGES[2];
+}
+
+/** Check if a word category is available at a given stage */
+export function isCategoryAvailable(stageId: number, category: string): boolean {
+  const stage = getStage(stageId);
+  return stage.wordCategories.includes(category);
+}
+
+/** Get max words allowed for a stage */
+export function getMaxWords(stageId: number): number {
+  return getStage(stageId).maxWords;
+}

--- a/src/lib/glp/vocabulary.ts
+++ b/src/lib/glp/vocabulary.ts
@@ -1,0 +1,159 @@
+/**
+ * 8gent Jr — GLP Vocabulary by Stage
+ *
+ * Word sets appropriate for each GLP stage.
+ * Stage 1 uses a minimal high-frequency set.
+ * Each subsequent stage adds words from new categories.
+ *
+ * Words are drawn from AAC core vocabulary research
+ * (Banajee, Dicarlo & Stricklin, 2003; Cross et al., 2006).
+ *
+ * Issue: #53
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VocabWord {
+  word: string;
+  category: 'noun' | 'verb' | 'pronoun' | 'adjective' | 'social' | 'preposition' | 'question' | 'determiner' | 'adverb' | 'conjunction';
+  /** Minimum GLP stage where this word appears */
+  minStage: number;
+  /** Optional symbol ID for ARASAAC/symbol display */
+  symbolId?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Core vocabulary
+// ---------------------------------------------------------------------------
+
+export const VOCABULARY: VocabWord[] = [
+  // --- Stage 1: Single words (high-frequency requests and labels) ---
+  { word: 'more', category: 'adverb', minStage: 1 },
+  { word: 'stop', category: 'verb', minStage: 1 },
+  { word: 'help', category: 'verb', minStage: 1 },
+  { word: 'yes', category: 'social', minStage: 1 },
+  { word: 'no', category: 'social', minStage: 1 },
+  { word: 'want', category: 'verb', minStage: 1 },
+  { word: 'go', category: 'verb', minStage: 1 },
+  { word: 'eat', category: 'verb', minStage: 1 },
+  { word: 'drink', category: 'verb', minStage: 1 },
+  { word: 'play', category: 'verb', minStage: 1 },
+  { word: 'food', category: 'noun', minStage: 1 },
+  { word: 'water', category: 'noun', minStage: 1 },
+  { word: 'home', category: 'noun', minStage: 1 },
+  { word: 'toilet', category: 'noun', minStage: 1 },
+  { word: 'please', category: 'social', minStage: 1 },
+  { word: 'hello', category: 'social', minStage: 1 },
+  { word: 'bye', category: 'social', minStage: 1 },
+
+  // --- Stage 2: Two-word combos (add pronouns, basic adjectives) ---
+  { word: 'I', category: 'pronoun', minStage: 2 },
+  { word: 'you', category: 'pronoun', minStage: 2 },
+  { word: 'my', category: 'pronoun', minStage: 2 },
+  { word: 'me', category: 'pronoun', minStage: 2 },
+  { word: 'it', category: 'pronoun', minStage: 2 },
+  { word: 'like', category: 'verb', minStage: 2 },
+  { word: 'need', category: 'verb', minStage: 2 },
+  { word: 'look', category: 'verb', minStage: 2 },
+  { word: 'big', category: 'adjective', minStage: 2 },
+  { word: 'small', category: 'adjective', minStage: 2 },
+  { word: 'happy', category: 'adjective', minStage: 2 },
+  { word: 'sad', category: 'adjective', minStage: 2 },
+  { word: 'good', category: 'adjective', minStage: 2 },
+  { word: 'toy', category: 'noun', minStage: 2 },
+  { word: 'book', category: 'noun', minStage: 2 },
+  { word: 'music', category: 'noun', minStage: 2 },
+  { word: 'juice', category: 'noun', minStage: 2 },
+
+  // --- Stage 3: Three-word sentences (add he/she/we, more verbs) ---
+  { word: 'he', category: 'pronoun', minStage: 3 },
+  { word: 'she', category: 'pronoun', minStage: 3 },
+  { word: 'we', category: 'pronoun', minStage: 3 },
+  { word: 'am', category: 'verb', minStage: 3 },
+  { word: 'is', category: 'verb', minStage: 3 },
+  { word: 'are', category: 'verb', minStage: 3 },
+  { word: 'have', category: 'verb', minStage: 3 },
+  { word: 'see', category: 'verb', minStage: 3 },
+  { word: 'feel', category: 'verb', minStage: 3 },
+  { word: 'the', category: 'determiner', minStage: 3 },
+  { word: 'a', category: 'determiner', minStage: 3 },
+  { word: 'tired', category: 'adjective', minStage: 3 },
+  { word: 'hungry', category: 'adjective', minStage: 3 },
+  { word: 'done', category: 'adjective', minStage: 3 },
+  { word: 'game', category: 'noun', minStage: 3 },
+  { word: 'friend', category: 'noun', minStage: 3 },
+  { word: 'turn', category: 'noun', minStage: 3 },
+
+  // --- Stage 4: Simple sentences (add prepositions, more structure) ---
+  { word: 'to', category: 'preposition', minStage: 4 },
+  { word: 'with', category: 'preposition', minStage: 4 },
+  { word: 'at', category: 'preposition', minStage: 4 },
+  { word: 'on', category: 'preposition', minStage: 4 },
+  { word: 'in', category: 'preposition', minStage: 4 },
+  { word: 'can', category: 'verb', minStage: 4 },
+  { word: 'do', category: 'verb', minStage: 4 },
+  { word: 'this', category: 'determiner', minStage: 4 },
+  { word: 'that', category: 'determiner', minStage: 4 },
+  { word: 'fun', category: 'adjective', minStage: 4 },
+  { word: 'ready', category: 'adjective', minStage: 4 },
+  { word: 'now', category: 'adverb', minStage: 4 },
+  { word: 'here', category: 'adverb', minStage: 4 },
+  { word: 'there', category: 'adverb', minStage: 4 },
+
+  // --- Stage 5: Complex sentences (add questions, adverbs) ---
+  { word: 'what', category: 'question', minStage: 5 },
+  { word: 'where', category: 'question', minStage: 5 },
+  { word: 'who', category: 'question', minStage: 5 },
+  { word: 'when', category: 'question', minStage: 5 },
+  { word: 'how', category: 'question', minStage: 5 },
+  { word: 'why', category: 'question', minStage: 5 },
+  { word: 'again', category: 'adverb', minStage: 5 },
+  { word: 'outside', category: 'adverb', minStage: 5 },
+  { word: 'today', category: 'adverb', minStage: 5 },
+  { word: 'and', category: 'conjunction', minStage: 5 },
+  { word: 'but', category: 'conjunction', minStage: 5 },
+  { word: 'because', category: 'conjunction', minStage: 5 },
+
+  // --- Stage 6: Conversation (add social-pragmatic, narrative) ---
+  { word: 'thank you', category: 'social', minStage: 6 },
+  { word: 'sorry', category: 'social', minStage: 6 },
+  { word: 'maybe', category: 'adverb', minStage: 6 },
+  { word: 'sometimes', category: 'adverb', minStage: 6 },
+  { word: 'always', category: 'adverb', minStage: 6 },
+  { word: 'never', category: 'adverb', minStage: 6 },
+  { word: 'then', category: 'conjunction', minStage: 6 },
+  { word: 'or', category: 'conjunction', minStage: 6 },
+  { word: 'if', category: 'conjunction', minStage: 6 },
+  { word: 'before', category: 'preposition', minStage: 6 },
+  { word: 'after', category: 'preposition', minStage: 6 },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Get all words available at a given GLP stage (includes all lower stages) */
+export function getWordsForStage(stageId: number): VocabWord[] {
+  return VOCABULARY.filter((w) => w.minStage <= stageId);
+}
+
+/** Get words for a specific category at a given stage */
+export function getWordsByCategory(stageId: number, category: string): VocabWord[] {
+  return VOCABULARY.filter((w) => w.minStage <= stageId && w.category === category);
+}
+
+/** Get just the word strings for a stage */
+export function getWordStringsForStage(stageId: number): string[] {
+  return getWordsForStage(stageId).map((w) => w.word);
+}
+
+/** Count words available at each stage */
+export function getStageWordCounts(): Record<number, number> {
+  const counts: Record<number, number> = {};
+  for (let i = 1; i <= 6; i++) {
+    counts[i] = getWordsForStage(i).length;
+  }
+  return counts;
+}

--- a/src/lib/tts.ts
+++ b/src/lib/tts.ts
@@ -1,0 +1,190 @@
+/**
+ * 8gent Jr — ElevenLabs TTS with Web Speech API fallback
+ *
+ * Uses the /api/tts proxy endpoint for ElevenLabs synthesis.
+ * Falls back to browser SpeechSynthesis when:
+ *   - ElevenLabs API key is not configured
+ *   - Server returns non-200
+ *   - Network is offline
+ *
+ * Issue: #53
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TTSOptions {
+  /** Text to speak */
+  text: string;
+  /** ElevenLabs voice ID (optional — server uses default if omitted) */
+  voiceId?: string;
+  /** Speech rate 0.5–2.0 (default 1.0) */
+  rate?: number;
+  /** Volume 0.0–1.0 (default 1.0) */
+  volume?: number;
+  /** Stability 0.0–1.0 for ElevenLabs (default 0.5) */
+  stability?: number;
+  /** Similarity boost 0.0–1.0 for ElevenLabs (default 0.75) */
+  similarityBoost?: number;
+}
+
+export type TTSEngine = 'elevenlabs' | 'browser' | 'none';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let currentAudio: HTMLAudioElement | null = null;
+let currentUtterance: SpeechSynthesisUtterance | null = null;
+
+// ---------------------------------------------------------------------------
+// Stop any playing audio
+// ---------------------------------------------------------------------------
+
+export function stopSpeaking(): void {
+  if (currentAudio) {
+    currentAudio.pause();
+    currentAudio.src = '';
+    currentAudio = null;
+  }
+  if (typeof window !== 'undefined' && window.speechSynthesis) {
+    window.speechSynthesis.cancel();
+  }
+  currentUtterance = null;
+}
+
+// ---------------------------------------------------------------------------
+// Check if currently speaking
+// ---------------------------------------------------------------------------
+
+export function isSpeaking(): boolean {
+  if (currentAudio && !currentAudio.paused && !currentAudio.ended) {
+    return true;
+  }
+  if (typeof window !== 'undefined' && window.speechSynthesis?.speaking) {
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Detect available engine
+// ---------------------------------------------------------------------------
+
+export function getAvailableEngine(): TTSEngine {
+  if (typeof window === 'undefined') return 'none';
+  // ElevenLabs is always available via proxy — actual availability
+  // is determined at call time by server response
+  return 'elevenlabs';
+}
+
+// ---------------------------------------------------------------------------
+// Main speak function
+// ---------------------------------------------------------------------------
+
+export async function speak(options: TTSOptions): Promise<TTSEngine> {
+  const { text, voiceId, rate = 1.0, volume = 1.0, stability = 0.5, similarityBoost = 0.75 } = options;
+
+  if (!text || typeof window === 'undefined') return 'none';
+
+  // Stop anything currently playing
+  stopSpeaking();
+
+  // Try ElevenLabs first (if online)
+  if (navigator.onLine) {
+    try {
+      const engine = await speakElevenLabs(text, { voiceId, stability, similarityBoost, volume });
+      if (engine === 'elevenlabs') return 'elevenlabs';
+    } catch {
+      // Fall through to browser TTS
+    }
+  }
+
+  // Fallback: Web Speech API
+  return speakBrowser(text, { rate, volume });
+}
+
+// ---------------------------------------------------------------------------
+// ElevenLabs via /api/tts proxy
+// ---------------------------------------------------------------------------
+
+async function speakElevenLabs(
+  text: string,
+  opts: { voiceId?: string; stability: number; similarityBoost: number; volume: number }
+): Promise<TTSEngine> {
+  const res = await fetch('/api/tts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      text,
+      voiceId: opts.voiceId,
+      stability: opts.stability,
+      similarityBoost: opts.similarityBoost,
+    }),
+  });
+
+  // 204 = not configured, 4xx/5xx = error — fall back
+  if (!res.ok || res.status === 204) {
+    return 'none';
+  }
+
+  const blob = await res.blob();
+  if (blob.size === 0) return 'none';
+
+  const url = URL.createObjectURL(blob);
+  const audio = new Audio(url);
+  audio.volume = Math.max(0, Math.min(1, opts.volume));
+  currentAudio = audio;
+
+  return new Promise<TTSEngine>((resolve) => {
+    audio.onended = () => {
+      URL.revokeObjectURL(url);
+      currentAudio = null;
+      resolve('elevenlabs');
+    };
+    audio.onerror = () => {
+      URL.revokeObjectURL(url);
+      currentAudio = null;
+      resolve('none');
+    };
+    audio.play().catch(() => {
+      URL.revokeObjectURL(url);
+      currentAudio = null;
+      resolve('none');
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Browser Web Speech API fallback
+// ---------------------------------------------------------------------------
+
+function speakBrowser(
+  text: string,
+  opts: { rate: number; volume: number }
+): Promise<TTSEngine> {
+  return new Promise<TTSEngine>((resolve) => {
+    if (!window.speechSynthesis) {
+      resolve('none');
+      return;
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.rate = Math.max(0.5, Math.min(2, opts.rate));
+    utterance.volume = Math.max(0, Math.min(1, opts.volume));
+    utterance.lang = 'en-US';
+    currentUtterance = utterance;
+
+    utterance.onend = () => {
+      currentUtterance = null;
+      resolve('browser');
+    };
+    utterance.onerror = () => {
+      currentUtterance = null;
+      resolve('none');
+    };
+
+    window.speechSynthesis.speak(utterance);
+  });
+}

--- a/src/lib/vocabulary.ts
+++ b/src/lib/vocabulary.ts
@@ -1,0 +1,600 @@
+/**
+ * 8gent Jr AAC Vocabulary System
+ *
+ * Complete vocabulary with ARASAAC pictographic symbols, organized by
+ * Fitzgerald Key color categories and GLP (Gestalt Language Processing) principles.
+ *
+ * Two systems combined:
+ * 1. Robust Core Vocabulary — ~100 high-frequency core words (pronouns, verbs,
+ *    adjectives, etc.) that cover 80% of daily communication
+ * 2. Topic Vocabulary — 200+ fringe words organized by category (food, places, etc.)
+ *
+ * Total: 500+ words with ARASAAC symbol URLs, category metadata, and phrase data.
+ */
+
+import type { WordCategory } from './fitzgerald-key';
+
+// =============================================================================
+// ARASAAC Helper
+// =============================================================================
+
+const ARASAAC = (id: number) => `https://static.arasaac.org/pictograms/${id}/${id}_500.png`;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface AACCategory {
+  id: string;
+  name: string;
+  color: string; // Fitzgerald Key color
+  imageUrl: string;
+}
+
+export interface AACPhrase {
+  id: string;
+  text: string;
+  spokenText?: string; // Optional different text to speak
+  imageUrl: string;
+  categoryId: string;
+}
+
+/** Communication functions a word can serve */
+export type CommunicationFunction =
+  | 'request'
+  | 'reject'
+  | 'comment'
+  | 'question'
+  | 'greet'
+  | 'respond'
+  | 'express'
+  | 'describe'
+  | 'direct'
+  | 'narrate'
+  | 'joke'
+  | 'opinion';
+
+/** A single core vocabulary word with clinical metadata */
+export interface CoreWord {
+  /** Unique identifier */
+  id: string;
+  /** Display text */
+  text: string;
+  /** Spoken text if different from display */
+  spokenText?: string;
+  /** Grammatical word type (maps to Fitzgerald Key) */
+  wordType: WordCategory;
+  /** Communication functions this word supports */
+  communicationFunctions: CommunicationFunction[];
+  /** Usage frequency tier */
+  frequency: 'essential' | 'high' | 'medium';
+  /** Minimum GLP stage where this word appears */
+  glpStage: 1 | 2 | 3 | 4 | 5 | 6;
+  /** ARASAAC pictogram symbol ID */
+  arasaacId?: number;
+  /** Fixed grid position for motor planning */
+  coreGridPosition?: { row: number; col: number };
+  /** Morphological word forms */
+  morphForms?: {
+    base: string;
+    present?: string;
+    past?: string;
+    plural?: string;
+    comparative?: string;
+    superlative?: string;
+    negative?: string;
+  };
+  /** Word types that typically follow this word */
+  typicallyFollowedBy?: WordCategory[];
+  /** Word types that typically precede this word */
+  typicallyPrecedeBy?: WordCategory[];
+}
+
+// =============================================================================
+// Fitzgerald Key Colors (Topic Vocabulary)
+// =============================================================================
+
+export const TOPIC_FITZGERALD_COLORS = {
+  people: '#FFD700',      // Yellow - People/Pronouns
+  verbs: '#4CAF50',       // Green - Actions/Verbs
+  descriptors: '#2196F3', // Blue - Descriptors/Adjectives
+  nouns: '#FF9800',       // Orange - Things/Nouns
+  places: '#8B6914',      // Warm brown - Places
+  feelings: '#E8610A',    // Warm orange - Feelings/Social
+  questions: '#00BCD4',   // Cyan - Questions
+  misc: '#9E9E9E',        // Gray - Miscellaneous
+} as const;
+
+// =============================================================================
+// CORE VOCABULARY — Essential Words (~100 high-frequency words)
+// =============================================================================
+
+export const CORE_PRONOUNS: CoreWord[] = [
+  { id: 'core-i',    text: 'I',    wordType: 'pronoun', communicationFunctions: ['request', 'express', 'comment', 'narrate'], frequency: 'essential', glpStage: 2, arasaacId: 6632, coreGridPosition: { row: 0, col: 0 }, typicallyFollowedBy: ['verb', 'adverb'] },
+  { id: 'core-you',  text: 'you',  wordType: 'pronoun', communicationFunctions: ['question', 'direct', 'comment'], frequency: 'essential', glpStage: 2, arasaacId: 7116, coreGridPosition: { row: 0, col: 1 }, typicallyFollowedBy: ['verb', 'adverb'] },
+  { id: 'core-he',   text: 'he',   wordType: 'pronoun', communicationFunctions: ['comment', 'narrate', 'describe'], frequency: 'high', glpStage: 3, arasaacId: 31146, typicallyFollowedBy: ['verb'] },
+  { id: 'core-she',  text: 'she',  wordType: 'pronoun', communicationFunctions: ['comment', 'narrate', 'describe'], frequency: 'high', glpStage: 3, arasaacId: 2458, typicallyFollowedBy: ['verb'] },
+  { id: 'core-it',   text: 'it',   wordType: 'pronoun', communicationFunctions: ['comment', 'describe', 'narrate'], frequency: 'essential', glpStage: 2, coreGridPosition: { row: 0, col: 2 }, typicallyFollowedBy: ['verb'] },
+  { id: 'core-we',   text: 'we',   wordType: 'pronoun', communicationFunctions: ['request', 'narrate', 'comment'], frequency: 'high', glpStage: 3, arasaacId: 7116, typicallyFollowedBy: ['verb'] },
+  { id: 'core-they', text: 'they', wordType: 'pronoun', communicationFunctions: ['comment', 'narrate'], frequency: 'medium', glpStage: 4, typicallyFollowedBy: ['verb'] },
+  { id: 'core-me',   text: 'me',   wordType: 'pronoun', communicationFunctions: ['request', 'express'], frequency: 'essential', glpStage: 2, arasaacId: 6632, typicallyPrecedeBy: ['verb', 'preposition'] },
+  { id: 'core-my',   text: 'my',   wordType: 'determiner', communicationFunctions: ['request', 'comment'], frequency: 'essential', glpStage: 2, arasaacId: 6632, coreGridPosition: { row: 0, col: 3 } },
+  { id: 'core-your', text: 'your', wordType: 'determiner', communicationFunctions: ['question', 'comment'], frequency: 'high', glpStage: 3, arasaacId: 7116 },
+];
+
+export const CORE_VERBS: CoreWord[] = [
+  { id: 'core-want',  text: 'want',  wordType: 'verb', communicationFunctions: ['request'], frequency: 'essential', glpStage: 2, arasaacId: 5441, coreGridPosition: { row: 1, col: 0 }, morphForms: { base: 'want', present: 'wants', past: 'wanted', negative: "don't want" }, typicallyPrecedeBy: ['pronoun'] },
+  { id: 'core-need',  text: 'need',  wordType: 'verb', communicationFunctions: ['request'], frequency: 'essential', glpStage: 2, arasaacId: 32648, morphForms: { base: 'need', present: 'needs', past: 'needed', negative: "don't need" } },
+  { id: 'core-like',  text: 'like',  wordType: 'verb', communicationFunctions: ['express', 'comment', 'opinion'], frequency: 'essential', glpStage: 2, arasaacId: 37721, coreGridPosition: { row: 1, col: 1 }, morphForms: { base: 'like', present: 'likes', past: 'liked', negative: "don't like" } },
+  { id: 'core-go',    text: 'go',    wordType: 'verb', communicationFunctions: ['request', 'direct', 'narrate'], frequency: 'essential', glpStage: 2, arasaacId: 29951, coreGridPosition: { row: 1, col: 2 }, morphForms: { base: 'go', present: 'goes', past: 'went', negative: "don't go" } },
+  { id: 'core-is',    text: 'is',    wordType: 'verb', communicationFunctions: ['describe', 'comment'], frequency: 'essential', glpStage: 2, coreGridPosition: { row: 1, col: 3 }, morphForms: { base: 'be', present: 'is', past: 'was', negative: "isn't" } },
+  { id: 'core-have',  text: 'have',  wordType: 'verb', communicationFunctions: ['comment', 'request'], frequency: 'essential', glpStage: 2, morphForms: { base: 'have', present: 'has', past: 'had', negative: "don't have" } },
+  { id: 'core-do',    text: 'do',    wordType: 'verb', communicationFunctions: ['question', 'direct'], frequency: 'essential', glpStage: 2, morphForms: { base: 'do', present: 'does', past: 'did', negative: "don't" } },
+  { id: 'core-get',   text: 'get',   wordType: 'verb', communicationFunctions: ['request', 'narrate'], frequency: 'essential', glpStage: 2, morphForms: { base: 'get', present: 'gets', past: 'got' } },
+  { id: 'core-see',   text: 'see',   wordType: 'verb', communicationFunctions: ['comment', 'request'], frequency: 'essential', glpStage: 2, arasaacId: 6573, morphForms: { base: 'see', present: 'sees', past: 'saw' } },
+  { id: 'core-come',  text: 'come',  wordType: 'verb', communicationFunctions: ['request', 'direct'], frequency: 'essential', glpStage: 2, morphForms: { base: 'come', present: 'comes', past: 'came' } },
+  { id: 'core-put',   text: 'put',   wordType: 'verb', communicationFunctions: ['direct', 'request'], frequency: 'high', glpStage: 3, morphForms: { base: 'put', present: 'puts', past: 'put' } },
+  { id: 'core-make',  text: 'make',  wordType: 'verb', communicationFunctions: ['request', 'narrate'], frequency: 'high', glpStage: 3, morphForms: { base: 'make', present: 'makes', past: 'made' } },
+  { id: 'core-play',  text: 'play',  wordType: 'verb', communicationFunctions: ['request', 'narrate'], frequency: 'high', glpStage: 2, arasaacId: 23392, morphForms: { base: 'play', present: 'plays', past: 'played' } },
+  { id: 'core-eat',   text: 'eat',   wordType: 'verb', communicationFunctions: ['request'], frequency: 'high', glpStage: 2, arasaacId: 6456, morphForms: { base: 'eat', present: 'eats', past: 'ate' } },
+  { id: 'core-drink', text: 'drink', wordType: 'verb', communicationFunctions: ['request'], frequency: 'high', glpStage: 2, arasaacId: 6061, morphForms: { base: 'drink', present: 'drinks', past: 'drank' } },
+  { id: 'core-help',  text: 'help',  wordType: 'verb', communicationFunctions: ['request'], frequency: 'essential', glpStage: 2, arasaacId: 32648, morphForms: { base: 'help', present: 'helps', past: 'helped' } },
+  { id: 'core-stop',  text: 'stop',  wordType: 'verb', communicationFunctions: ['reject', 'direct'], frequency: 'essential', glpStage: 2, arasaacId: 7196, morphForms: { base: 'stop', present: 'stops', past: 'stopped' } },
+  { id: 'core-look',  text: 'look',  wordType: 'verb', communicationFunctions: ['direct', 'comment'], frequency: 'high', glpStage: 2, arasaacId: 6573, morphForms: { base: 'look', present: 'looks', past: 'looked' } },
+  { id: 'core-think', text: 'think', wordType: 'verb', communicationFunctions: ['opinion', 'express'], frequency: 'high', glpStage: 3, morphForms: { base: 'think', present: 'thinks', past: 'thought' } },
+  { id: 'core-know',  text: 'know',  wordType: 'verb', communicationFunctions: ['respond', 'express'], frequency: 'high', glpStage: 3, morphForms: { base: 'know', present: 'knows', past: 'knew', negative: "don't know" } },
+  { id: 'core-feel',  text: 'feel',  wordType: 'verb', communicationFunctions: ['express'], frequency: 'high', glpStage: 3, morphForms: { base: 'feel', present: 'feels', past: 'felt' } },
+  { id: 'core-can',   text: 'can',   wordType: 'verb', communicationFunctions: ['request', 'question'], frequency: 'essential', glpStage: 2, morphForms: { base: 'can', past: 'could', negative: "can't" } },
+  { id: 'core-will',  text: 'will',  wordType: 'verb', communicationFunctions: ['narrate', 'request'], frequency: 'high', glpStage: 3, morphForms: { base: 'will', negative: "won't" } },
+  { id: 'core-love',  text: 'love',  wordType: 'verb', communicationFunctions: ['express'], frequency: 'high', glpStage: 2, arasaacId: 37721, morphForms: { base: 'love', present: 'loves', past: 'loved' } },
+];
+
+export const CORE_ADJECTIVES: CoreWord[] = [
+  { id: 'core-big',       text: 'big',       wordType: 'adjective', communicationFunctions: ['describe', 'comment'], frequency: 'essential', glpStage: 2, morphForms: { base: 'big', comparative: 'bigger', superlative: 'biggest' } },
+  { id: 'core-little',    text: 'little',    wordType: 'adjective', communicationFunctions: ['describe', 'comment'], frequency: 'essential', glpStage: 2, morphForms: { base: 'little', comparative: 'littler', superlative: 'littlest' } },
+  { id: 'core-good',      text: 'good',      wordType: 'adjective', communicationFunctions: ['describe', 'opinion', 'respond'], frequency: 'essential', glpStage: 2, arasaacId: 4581, morphForms: { base: 'good', comparative: 'better', superlative: 'best' } },
+  { id: 'core-bad',       text: 'bad',       wordType: 'adjective', communicationFunctions: ['describe', 'express'], frequency: 'high', glpStage: 2, arasaacId: 35545, morphForms: { base: 'bad', comparative: 'worse', superlative: 'worst' } },
+  { id: 'core-happy',     text: 'happy',     wordType: 'adjective', communicationFunctions: ['express', 'describe'], frequency: 'essential', glpStage: 2, arasaacId: 35533, morphForms: { base: 'happy', comparative: 'happier', superlative: 'happiest' } },
+  { id: 'core-sad',       text: 'sad',       wordType: 'adjective', communicationFunctions: ['express', 'describe'], frequency: 'essential', glpStage: 2, arasaacId: 35545, morphForms: { base: 'sad', comparative: 'sadder', superlative: 'saddest' } },
+  { id: 'core-hot',       text: 'hot',       wordType: 'adjective', communicationFunctions: ['describe', 'express'], frequency: 'high', glpStage: 2, arasaacId: 2300, morphForms: { base: 'hot', comparative: 'hotter', superlative: 'hottest' } },
+  { id: 'core-cold',      text: 'cold',      wordType: 'adjective', communicationFunctions: ['describe', 'express'], frequency: 'high', glpStage: 2, arasaacId: 4652, morphForms: { base: 'cold', comparative: 'colder', superlative: 'coldest' } },
+  { id: 'core-new',       text: 'new',       wordType: 'adjective', communicationFunctions: ['describe'], frequency: 'high', glpStage: 3, morphForms: { base: 'new', comparative: 'newer', superlative: 'newest' } },
+  { id: 'core-old',       text: 'old',       wordType: 'adjective', communicationFunctions: ['describe'], frequency: 'high', glpStage: 3, morphForms: { base: 'old', comparative: 'older', superlative: 'oldest' } },
+  { id: 'core-more',      text: 'more',      wordType: 'adjective', communicationFunctions: ['request'], frequency: 'essential', glpStage: 2, arasaacId: 5508, coreGridPosition: { row: 2, col: 0 } },
+  { id: 'core-all',       text: 'all',       wordType: 'adjective', communicationFunctions: ['describe', 'request'], frequency: 'high', glpStage: 2 },
+  { id: 'core-same',      text: 'same',      wordType: 'adjective', communicationFunctions: ['describe', 'comment'], frequency: 'medium', glpStage: 3 },
+  { id: 'core-different', text: 'different', wordType: 'adjective', communicationFunctions: ['describe', 'comment'], frequency: 'medium', glpStage: 3 },
+  { id: 'core-tired',     text: 'tired',     wordType: 'adjective', communicationFunctions: ['express'], frequency: 'high', glpStage: 2, arasaacId: 35537 },
+  { id: 'core-hungry',    text: 'hungry',    wordType: 'adjective', communicationFunctions: ['express', 'request'], frequency: 'high', glpStage: 2 },
+  { id: 'core-funny',     text: 'funny',     wordType: 'adjective', communicationFunctions: ['describe', 'joke'], frequency: 'high', glpStage: 2, arasaacId: 13354 },
+  { id: 'core-silly',     text: 'silly',     wordType: 'adjective', communicationFunctions: ['describe', 'joke'], frequency: 'high', glpStage: 2 },
+  { id: 'core-scary',     text: 'scary',     wordType: 'adjective', communicationFunctions: ['describe', 'express'], frequency: 'medium', glpStage: 3, arasaacId: 6916 },
+  { id: 'core-cool',      text: 'cool',      wordType: 'adjective', communicationFunctions: ['describe', 'express', 'opinion'], frequency: 'high', glpStage: 2 },
+];
+
+export const CORE_ADVERBS: CoreWord[] = [
+  { id: 'core-here',   text: 'here',   wordType: 'adverb', communicationFunctions: ['direct', 'comment'], frequency: 'essential', glpStage: 2, coreGridPosition: { row: 2, col: 1 } },
+  { id: 'core-there',  text: 'there',  wordType: 'adverb', communicationFunctions: ['direct', 'comment'], frequency: 'essential', glpStage: 2, coreGridPosition: { row: 2, col: 2 } },
+  { id: 'core-now',    text: 'now',    wordType: 'adverb', communicationFunctions: ['request', 'narrate'], frequency: 'essential', glpStage: 2 },
+  { id: 'core-later',  text: 'later',  wordType: 'adverb', communicationFunctions: ['narrate', 'respond'], frequency: 'high', glpStage: 3 },
+  { id: 'core-again',  text: 'again',  wordType: 'adverb', communicationFunctions: ['request'], frequency: 'essential', glpStage: 2 },
+  { id: 'core-too',    text: 'too',    wordType: 'adverb', communicationFunctions: ['describe'], frequency: 'high', glpStage: 3 },
+  { id: 'core-very',   text: 'very',   wordType: 'adverb', communicationFunctions: ['describe'], frequency: 'high', glpStage: 3 },
+  { id: 'core-not',    text: 'not',    wordType: 'negation', communicationFunctions: ['reject', 'respond'], frequency: 'essential', glpStage: 2, coreGridPosition: { row: 2, col: 3 } },
+  { id: 'core-maybe',  text: 'maybe',  wordType: 'adverb', communicationFunctions: ['respond', 'opinion'], frequency: 'high', glpStage: 3 },
+  { id: 'core-please', text: 'please', wordType: 'adverb', communicationFunctions: ['request'], frequency: 'essential', glpStage: 2 },
+];
+
+export const CORE_PREPOSITIONS: CoreWord[] = [
+  { id: 'core-in',   text: 'in',   wordType: 'preposition', communicationFunctions: ['describe', 'narrate'], frequency: 'essential', glpStage: 3 },
+  { id: 'core-on',   text: 'on',   wordType: 'preposition', communicationFunctions: ['describe', 'narrate'], frequency: 'essential', glpStage: 3 },
+  { id: 'core-to',   text: 'to',   wordType: 'preposition', communicationFunctions: ['narrate', 'request'], frequency: 'essential', glpStage: 2 },
+  { id: 'core-with', text: 'with', wordType: 'preposition', communicationFunctions: ['describe', 'request'], frequency: 'essential', glpStage: 3 },
+  { id: 'core-for',  text: 'for',  wordType: 'preposition', communicationFunctions: ['request', 'narrate'], frequency: 'high', glpStage: 3 },
+  { id: 'core-up',   text: 'up',   wordType: 'preposition', communicationFunctions: ['direct', 'describe'], frequency: 'high', glpStage: 2 },
+  { id: 'core-down', text: 'down', wordType: 'preposition', communicationFunctions: ['direct', 'describe'], frequency: 'high', glpStage: 2 },
+  { id: 'core-out',  text: 'out',  wordType: 'preposition', communicationFunctions: ['direct', 'request'], frequency: 'high', glpStage: 2 },
+  { id: 'core-off',  text: 'off',  wordType: 'preposition', communicationFunctions: ['direct', 'request'], frequency: 'high', glpStage: 2 },
+];
+
+export const CORE_QUESTIONS: CoreWord[] = [
+  { id: 'core-what',  text: 'what',  wordType: 'question', communicationFunctions: ['question'], frequency: 'essential', glpStage: 2, coreGridPosition: { row: 3, col: 0 } },
+  { id: 'core-where', text: 'where', wordType: 'question', communicationFunctions: ['question'], frequency: 'essential', glpStage: 2, coreGridPosition: { row: 3, col: 1 } },
+  { id: 'core-who',   text: 'who',   wordType: 'question', communicationFunctions: ['question'], frequency: 'high', glpStage: 3, coreGridPosition: { row: 3, col: 2 } },
+  { id: 'core-when',  text: 'when',  wordType: 'question', communicationFunctions: ['question'], frequency: 'high', glpStage: 3, coreGridPosition: { row: 3, col: 3 } },
+  { id: 'core-why',   text: 'why',   wordType: 'question', communicationFunctions: ['question'], frequency: 'high', glpStage: 3 },
+  { id: 'core-how',   text: 'how',   wordType: 'question', communicationFunctions: ['question'], frequency: 'high', glpStage: 3 },
+];
+
+export const CORE_CONJUNCTIONS: CoreWord[] = [
+  { id: 'core-and',     text: 'and',     wordType: 'conjunction', communicationFunctions: ['narrate', 'describe'], frequency: 'essential', glpStage: 3 },
+  { id: 'core-but',     text: 'but',     wordType: 'conjunction', communicationFunctions: ['narrate', 'opinion'], frequency: 'high', glpStage: 4 },
+  { id: 'core-or',      text: 'or',      wordType: 'conjunction', communicationFunctions: ['question', 'narrate'], frequency: 'high', glpStage: 4 },
+  { id: 'core-because', text: 'because', wordType: 'conjunction', communicationFunctions: ['narrate', 'express'], frequency: 'medium', glpStage: 4 },
+  { id: 'core-then',    text: 'then',    wordType: 'conjunction', communicationFunctions: ['narrate'], frequency: 'high', glpStage: 3 },
+];
+
+export const CORE_SOCIAL: CoreWord[] = [
+  { id: 'core-yes',       text: 'yes',       wordType: 'interjection', communicationFunctions: ['respond'], frequency: 'essential', glpStage: 1, arasaacId: 5584, coreGridPosition: { row: 4, col: 0 } },
+  { id: 'core-no',        text: 'no',        wordType: 'interjection', communicationFunctions: ['respond', 'reject'], frequency: 'essential', glpStage: 1, arasaacId: 5526, coreGridPosition: { row: 4, col: 1 } },
+  { id: 'core-hello',     text: 'hello',     wordType: 'social', communicationFunctions: ['greet'], frequency: 'essential', glpStage: 1, arasaacId: 6522, coreGridPosition: { row: 4, col: 2 } },
+  { id: 'core-goodbye',   text: 'goodbye',   wordType: 'social', communicationFunctions: ['greet'], frequency: 'essential', glpStage: 1, coreGridPosition: { row: 4, col: 3 } },
+  { id: 'core-thank-you', text: 'thank you', wordType: 'social', communicationFunctions: ['respond'], frequency: 'essential', glpStage: 2, arasaacId: 38783 },
+  { id: 'core-sorry',     text: 'sorry',     wordType: 'social', communicationFunctions: ['express'], frequency: 'high', glpStage: 2 },
+  { id: 'core-okay',      text: 'okay',      wordType: 'interjection', communicationFunctions: ['respond'], frequency: 'essential', glpStage: 1, arasaacId: 5584 },
+  { id: 'core-wow',       text: 'wow',       wordType: 'interjection', communicationFunctions: ['express', 'comment'], frequency: 'high', glpStage: 1 },
+  { id: 'core-uh-oh',     text: 'uh-oh',     wordType: 'interjection', communicationFunctions: ['comment', 'express'], frequency: 'high', glpStage: 1 },
+  { id: 'core-yay',       text: 'yay',       wordType: 'interjection', communicationFunctions: ['express'], frequency: 'high', glpStage: 1 },
+];
+
+// =============================================================================
+// Combined Core Words
+// =============================================================================
+
+/** All core vocabulary words combined (~100 words) */
+export const ALL_CORE_WORDS: CoreWord[] = [
+  ...CORE_PRONOUNS,
+  ...CORE_VERBS,
+  ...CORE_ADJECTIVES,
+  ...CORE_ADVERBS,
+  ...CORE_PREPOSITIONS,
+  ...CORE_QUESTIONS,
+  ...CORE_CONJUNCTIONS,
+  ...CORE_SOCIAL,
+];
+
+// =============================================================================
+// TOPIC VOCABULARY — Fringe words organized by category (400+ words)
+// =============================================================================
+
+export const AAC_CATEGORIES: AACCategory[] = [
+  // Core Communication
+  { id: 'general', name: 'General', color: TOPIC_FITZGERALD_COLORS.misc, imageUrl: ARASAAC(6964) },
+  { id: 'feelings', name: 'Feelings', color: TOPIC_FITZGERALD_COLORS.feelings, imageUrl: ARASAAC(37190) },
+  { id: 'actions', name: 'Actions', color: TOPIC_FITZGERALD_COLORS.verbs, imageUrl: ARASAAC(6503) },
+  { id: 'questions', name: 'Questions', color: TOPIC_FITZGERALD_COLORS.questions, imageUrl: ARASAAC(22620) },
+
+  // Daily Life
+  { id: 'food', name: 'Food', color: TOPIC_FITZGERALD_COLORS.nouns, imageUrl: ARASAAC(4610) },
+  { id: 'drinks', name: 'Drinks', color: TOPIC_FITZGERALD_COLORS.nouns, imageUrl: ARASAAC(6061) },
+  { id: 'clothes', name: 'Clothes', color: TOPIC_FITZGERALD_COLORS.nouns, imageUrl: ARASAAC(7233) },
+  { id: 'body', name: 'Body', color: TOPIC_FITZGERALD_COLORS.nouns, imageUrl: ARASAAC(6473) },
+
+  // Fun & Learning
+  { id: 'play', name: 'Play', color: TOPIC_FITZGERALD_COLORS.verbs, imageUrl: ARASAAC(23392) },
+  { id: 'colours', name: 'Colours', color: TOPIC_FITZGERALD_COLORS.descriptors, imageUrl: ARASAAC(5968) },
+  { id: 'numbers', name: 'Numbers', color: TOPIC_FITZGERALD_COLORS.descriptors, imageUrl: ARASAAC(2879) },
+  { id: 'shapes', name: 'Shapes', color: TOPIC_FITZGERALD_COLORS.descriptors, imageUrl: ARASAAC(4651) },
+
+  // People & Places
+  { id: 'people', name: 'People', color: TOPIC_FITZGERALD_COLORS.people, imageUrl: ARASAAC(7116) },
+  { id: 'places', name: 'Places', color: TOPIC_FITZGERALD_COLORS.places, imageUrl: ARASAAC(32757) },
+  { id: 'school', name: 'School', color: TOPIC_FITZGERALD_COLORS.places, imageUrl: ARASAAC(32446) },
+  { id: 'home', name: 'Home', color: TOPIC_FITZGERALD_COLORS.places, imageUrl: ARASAAC(6964) },
+];
+
+// =============================================================================
+// Topic Phrase Data
+// =============================================================================
+
+export const GENERAL_PHRASES: AACPhrase[] = [
+  { id: 'gen-i', text: 'I', imageUrl: ARASAAC(6867), categoryId: 'general' },
+  { id: 'gen-you', text: 'you', imageUrl: ARASAAC(6866), categoryId: 'general' },
+  { id: 'gen-yes', text: 'yes', imageUrl: ARASAAC(5584), categoryId: 'general' },
+  { id: 'gen-no', text: 'no', imageUrl: ARASAAC(5526), categoryId: 'general' },
+  { id: 'gen-help', text: 'help', imageUrl: ARASAAC(7171), categoryId: 'general' },
+  { id: 'gen-stop', text: 'stop', imageUrl: ARASAAC(7196), categoryId: 'general' },
+  { id: 'gen-more', text: 'more', imageUrl: ARASAAC(32753), categoryId: 'general' },
+  { id: 'gen-done', text: 'done', imageUrl: ARASAAC(28429), categoryId: 'general' },
+  { id: 'gen-want', text: 'I want', imageUrl: ARASAAC(5441), categoryId: 'general' },
+  { id: 'gen-dont-want', text: "I don't want", imageUrl: ARASAAC(5442), categoryId: 'general' },
+  { id: 'gen-please', text: 'please', imageUrl: ARASAAC(8195), categoryId: 'general' },
+  { id: 'gen-thanks', text: 'thank you', imageUrl: ARASAAC(8129), categoryId: 'general' },
+  { id: 'gen-ok', text: 'ok', imageUrl: ARASAAC(5584), categoryId: 'general' },
+  { id: 'gen-wait', text: 'wait', imageUrl: ARASAAC(36914), categoryId: 'general' },
+  { id: 'gen-look', text: 'look', imageUrl: ARASAAC(6564), categoryId: 'general' },
+  { id: 'gen-listen', text: 'listen', imageUrl: ARASAAC(6572), categoryId: 'general' },
+];
+
+export const FEELINGS_PHRASES: AACPhrase[] = [
+  { id: 'feel-happy', text: 'happy', imageUrl: ARASAAC(35533), categoryId: 'feelings' },
+  { id: 'feel-sad', text: 'sad', imageUrl: ARASAAC(35545), categoryId: 'feelings' },
+  { id: 'feel-angry', text: 'angry', imageUrl: ARASAAC(35539), categoryId: 'feelings' },
+  { id: 'feel-scared', text: 'scared', imageUrl: ARASAAC(35535), categoryId: 'feelings' },
+  { id: 'feel-tired', text: 'tired', imageUrl: ARASAAC(35537), categoryId: 'feelings' },
+  { id: 'feel-sick', text: 'sick', imageUrl: ARASAAC(7040), categoryId: 'feelings' },
+  { id: 'feel-good', text: 'good', imageUrl: ARASAAC(35541), categoryId: 'feelings' },
+  { id: 'feel-bad', text: 'bad', imageUrl: ARASAAC(35543), categoryId: 'feelings' },
+  { id: 'feel-love', text: 'love', imageUrl: ARASAAC(8020), categoryId: 'feelings' },
+  { id: 'feel-excited', text: 'excited', imageUrl: ARASAAC(39090), categoryId: 'feelings' },
+  { id: 'feel-nervous', text: 'nervous', imageUrl: ARASAAC(35549), categoryId: 'feelings' },
+  { id: 'feel-hot', text: 'hot', imageUrl: ARASAAC(32179), categoryId: 'feelings' },
+  { id: 'feel-cold', text: 'cold', imageUrl: ARASAAC(32178), categoryId: 'feelings' },
+  { id: 'feel-hungry', text: 'hungry', imageUrl: ARASAAC(35525), categoryId: 'feelings' },
+  { id: 'feel-thirsty', text: 'thirsty', imageUrl: ARASAAC(35523), categoryId: 'feelings' },
+];
+
+export const ACTIONS_PHRASES: AACPhrase[] = [
+  { id: 'act-go', text: 'go', imageUrl: ARASAAC(8142), categoryId: 'actions' },
+  { id: 'act-come', text: 'come', imageUrl: ARASAAC(32669), categoryId: 'actions' },
+  { id: 'act-eat', text: 'eat', imageUrl: ARASAAC(6456), categoryId: 'actions' },
+  { id: 'act-drink', text: 'drink', imageUrl: ARASAAC(6061), categoryId: 'actions' },
+  { id: 'act-play', text: 'play', imageUrl: ARASAAC(23392), categoryId: 'actions' },
+  { id: 'act-sleep', text: 'sleep', imageUrl: ARASAAC(6479), categoryId: 'actions' },
+  { id: 'act-sit', text: 'sit', imageUrl: ARASAAC(6611), categoryId: 'actions' },
+  { id: 'act-stand', text: 'stand', imageUrl: ARASAAC(8152), categoryId: 'actions' },
+  { id: 'act-walk', text: 'walk', imageUrl: ARASAAC(6044), categoryId: 'actions' },
+  { id: 'act-run', text: 'run', imageUrl: ARASAAC(6465), categoryId: 'actions' },
+  { id: 'act-jump', text: 'jump', imageUrl: ARASAAC(6607), categoryId: 'actions' },
+  { id: 'act-read', text: 'read', imageUrl: ARASAAC(6463), categoryId: 'actions' },
+  { id: 'act-write', text: 'write', imageUrl: ARASAAC(2380), categoryId: 'actions' },
+  { id: 'act-watch', text: 'watch', imageUrl: ARASAAC(6564), categoryId: 'actions' },
+  { id: 'act-give', text: 'give', imageUrl: ARASAAC(28431), categoryId: 'actions' },
+  { id: 'act-take', text: 'take', imageUrl: ARASAAC(10148), categoryId: 'actions' },
+];
+
+export const QUESTIONS_PHRASES: AACPhrase[] = [
+  { id: 'q-what', text: 'what?', imageUrl: ARASAAC(22620), categoryId: 'questions' },
+  { id: 'q-where', text: 'where?', imageUrl: ARASAAC(7764), categoryId: 'questions' },
+  { id: 'q-when', text: 'when?', imageUrl: ARASAAC(32874), categoryId: 'questions' },
+  { id: 'q-who', text: 'who?', imageUrl: ARASAAC(9853), categoryId: 'questions' },
+  { id: 'q-why', text: 'why?', imageUrl: ARASAAC(36719), categoryId: 'questions' },
+  { id: 'q-how', text: 'how?', imageUrl: ARASAAC(22619), categoryId: 'questions' },
+  { id: 'q-can-i', text: 'can I?', imageUrl: ARASAAC(7667), categoryId: 'questions' },
+  { id: 'q-do-you', text: 'do you?', imageUrl: ARASAAC(22620), categoryId: 'questions' },
+  { id: 'q-is-it', text: 'is it?', imageUrl: ARASAAC(22620), categoryId: 'questions' },
+  { id: 'q-dont-know', text: "I don't know", imageUrl: ARASAAC(28248), categoryId: 'questions' },
+];
+
+export const FOOD_PHRASES: AACPhrase[] = [
+  { id: 'food-eat', text: 'I want to eat', imageUrl: ARASAAC(6456), categoryId: 'food' },
+  { id: 'food-apple', text: 'apple', imageUrl: ARASAAC(2462), categoryId: 'food' },
+  { id: 'food-banana', text: 'banana', imageUrl: ARASAAC(2530), categoryId: 'food' },
+  { id: 'food-bread', text: 'bread', imageUrl: ARASAAC(2494), categoryId: 'food' },
+  { id: 'food-cheese', text: 'cheese', imageUrl: ARASAAC(2541), categoryId: 'food' },
+  { id: 'food-chicken', text: 'chicken', imageUrl: ARASAAC(2825), categoryId: 'food' },
+  { id: 'food-pizza', text: 'pizza', imageUrl: ARASAAC(2527), categoryId: 'food' },
+  { id: 'food-pasta', text: 'pasta', imageUrl: ARASAAC(8652), categoryId: 'food' },
+  { id: 'food-rice', text: 'rice', imageUrl: ARASAAC(6911), categoryId: 'food' },
+  { id: 'food-soup', text: 'soup', imageUrl: ARASAAC(2573), categoryId: 'food' },
+  { id: 'food-sandwich', text: 'sandwich', imageUrl: ARASAAC(2281), categoryId: 'food' },
+  { id: 'food-cookie', text: 'cookie', imageUrl: ARASAAC(8312), categoryId: 'food' },
+  { id: 'food-icecream', text: 'ice cream', imageUrl: ARASAAC(3348), categoryId: 'food' },
+  { id: 'food-breakfast', text: 'breakfast', imageUrl: ARASAAC(4626), categoryId: 'food' },
+  { id: 'food-lunch', text: 'lunch', imageUrl: ARASAAC(4611), categoryId: 'food' },
+  { id: 'food-dinner', text: 'dinner', imageUrl: ARASAAC(4611), categoryId: 'food' },
+];
+
+export const DRINKS_PHRASES: AACPhrase[] = [
+  { id: 'drink-want', text: 'I want to drink', imageUrl: ARASAAC(6061), categoryId: 'drinks' },
+  { id: 'drink-water', text: 'water', imageUrl: ARASAAC(32464), categoryId: 'drinks' },
+  { id: 'drink-juice', text: 'juice', imageUrl: ARASAAC(11461), categoryId: 'drinks' },
+  { id: 'drink-milk', text: 'milk', imageUrl: ARASAAC(2445), categoryId: 'drinks' },
+  { id: 'drink-hot-choc', text: 'hot chocolate', imageUrl: ARASAAC(6448), categoryId: 'drinks' },
+  { id: 'drink-tea', text: 'tea', imageUrl: ARASAAC(29802), categoryId: 'drinks' },
+  { id: 'drink-cold', text: 'cold drink', imageUrl: ARASAAC(4652), categoryId: 'drinks' },
+  { id: 'drink-hot', text: 'hot drink', imageUrl: ARASAAC(2300), categoryId: 'drinks' },
+];
+
+export const CLOTHES_PHRASES: AACPhrase[] = [
+  { id: 'clothes-dress', text: 'get dressed', imageUrl: ARASAAC(7233), categoryId: 'clothes' },
+  { id: 'clothes-shirt', text: 'shirt', imageUrl: ARASAAC(13640), categoryId: 'clothes' },
+  { id: 'clothes-pants', text: 'pants', imageUrl: ARASAAC(2565), categoryId: 'clothes' },
+  { id: 'clothes-shoes', text: 'shoes', imageUrl: ARASAAC(2775), categoryId: 'clothes' },
+  { id: 'clothes-socks', text: 'socks', imageUrl: ARASAAC(2298), categoryId: 'clothes' },
+  { id: 'clothes-jacket', text: 'jacket', imageUrl: ARASAAC(4872), categoryId: 'clothes' },
+  { id: 'clothes-hat', text: 'hat', imageUrl: ARASAAC(2572), categoryId: 'clothes' },
+  { id: 'clothes-pjs', text: 'pajamas', imageUrl: ARASAAC(2522), categoryId: 'clothes' },
+];
+
+export const BODY_PHRASES: AACPhrase[] = [
+  { id: 'body-head', text: 'head', imageUrl: ARASAAC(2720), categoryId: 'body' },
+  { id: 'body-eyes', text: 'eyes', imageUrl: ARASAAC(6573), categoryId: 'body' },
+  { id: 'body-ears', text: 'ears', imageUrl: ARASAAC(5915), categoryId: 'body' },
+  { id: 'body-nose', text: 'nose', imageUrl: ARASAAC(2727), categoryId: 'body' },
+  { id: 'body-mouth', text: 'mouth', imageUrl: ARASAAC(2663), categoryId: 'body' },
+  { id: 'body-hands', text: 'hands', imageUrl: ARASAAC(6575), categoryId: 'body' },
+  { id: 'body-feet', text: 'feet', imageUrl: ARASAAC(2775), categoryId: 'body' },
+  { id: 'body-tummy', text: 'tummy', imageUrl: ARASAAC(2786), categoryId: 'body' },
+  { id: 'body-hurt', text: 'it hurts', imageUrl: ARASAAC(5484), categoryId: 'body' },
+  { id: 'body-toilet', text: 'toilet', imageUrl: ARASAAC(6473), categoryId: 'body' },
+  { id: 'body-bath', text: 'bath', imageUrl: ARASAAC(2272), categoryId: 'body' },
+  { id: 'body-brush', text: 'brush teeth', imageUrl: ARASAAC(10263), categoryId: 'body' },
+];
+
+export const PLAY_PHRASES: AACPhrase[] = [
+  { id: 'play-play', text: 'play', imageUrl: ARASAAC(23392), categoryId: 'play' },
+  { id: 'play-ball', text: 'ball', imageUrl: ARASAAC(3241), categoryId: 'play' },
+  { id: 'play-blocks', text: 'blocks', imageUrl: ARASAAC(7182), categoryId: 'play' },
+  { id: 'play-book', text: 'book', imageUrl: ARASAAC(25191), categoryId: 'play' },
+  { id: 'play-draw', text: 'draw', imageUrl: ARASAAC(37042), categoryId: 'play' },
+  { id: 'play-music', text: 'music', imageUrl: ARASAAC(7046), categoryId: 'play' },
+  { id: 'play-tv', text: 'TV', imageUrl: ARASAAC(26358), categoryId: 'play' },
+  { id: 'play-tablet', text: 'tablet', imageUrl: ARASAAC(7190), categoryId: 'play' },
+  { id: 'play-outside', text: 'go outside', imageUrl: ARASAAC(2666), categoryId: 'play' },
+  { id: 'play-swing', text: 'swing', imageUrl: ARASAAC(4608), categoryId: 'play' },
+  { id: 'play-slide', text: 'slide', imageUrl: ARASAAC(4692), categoryId: 'play' },
+  { id: 'play-swim', text: 'swim', imageUrl: ARASAAC(25038), categoryId: 'play' },
+];
+
+export const COLOURS_PHRASES: AACPhrase[] = [
+  { id: 'col-red', text: 'red', imageUrl: ARASAAC(2808), categoryId: 'colours' },
+  { id: 'col-blue', text: 'blue', imageUrl: ARASAAC(4869), categoryId: 'colours' },
+  { id: 'col-green', text: 'green', imageUrl: ARASAAC(4887), categoryId: 'colours' },
+  { id: 'col-yellow', text: 'yellow', imageUrl: ARASAAC(2648), categoryId: 'colours' },
+  { id: 'col-orange', text: 'orange', imageUrl: ARASAAC(2888), categoryId: 'colours' },
+  { id: 'col-purple', text: 'purple', imageUrl: ARASAAC(2907), categoryId: 'colours' },
+  { id: 'col-pink', text: 'pink', imageUrl: ARASAAC(2807), categoryId: 'colours' },
+  { id: 'col-brown', text: 'brown', imageUrl: ARASAAC(2923), categoryId: 'colours' },
+  { id: 'col-black', text: 'black', imageUrl: ARASAAC(2886), categoryId: 'colours' },
+  { id: 'col-white', text: 'white', imageUrl: ARASAAC(8043), categoryId: 'colours' },
+];
+
+export const NUMBERS_PHRASES: AACPhrase[] = [
+  { id: 'num-1', text: 'one', imageUrl: ARASAAC(2627), categoryId: 'numbers' },
+  { id: 'num-2', text: 'two', imageUrl: ARASAAC(2628), categoryId: 'numbers' },
+  { id: 'num-3', text: 'three', imageUrl: ARASAAC(2629), categoryId: 'numbers' },
+  { id: 'num-4', text: 'four', imageUrl: ARASAAC(2630), categoryId: 'numbers' },
+  { id: 'num-5', text: 'five', imageUrl: ARASAAC(2631), categoryId: 'numbers' },
+  { id: 'num-6', text: 'six', imageUrl: ARASAAC(2632), categoryId: 'numbers' },
+  { id: 'num-7', text: 'seven', imageUrl: ARASAAC(2633), categoryId: 'numbers' },
+  { id: 'num-8', text: 'eight', imageUrl: ARASAAC(2634), categoryId: 'numbers' },
+  { id: 'num-9', text: 'nine', imageUrl: ARASAAC(2635), categoryId: 'numbers' },
+  { id: 'num-10', text: 'ten', imageUrl: ARASAAC(2636), categoryId: 'numbers' },
+];
+
+export const SHAPES_PHRASES: AACPhrase[] = [
+  { id: 'shape-circle', text: 'circle', imageUrl: ARASAAC(4603), categoryId: 'shapes' },
+  { id: 'shape-square', text: 'square', imageUrl: ARASAAC(4616), categoryId: 'shapes' },
+  { id: 'shape-triangle', text: 'triangle', imageUrl: ARASAAC(2604), categoryId: 'shapes' },
+  { id: 'shape-rectangle', text: 'rectangle', imageUrl: ARASAAC(4731), categoryId: 'shapes' },
+  { id: 'shape-star', text: 'star', imageUrl: ARASAAC(2752), categoryId: 'shapes' },
+  { id: 'shape-heart', text: 'heart', imageUrl: ARASAAC(4613), categoryId: 'shapes' },
+];
+
+export const PEOPLE_PHRASES: AACPhrase[] = [
+  { id: 'ppl-mom', text: 'mom', imageUrl: ARASAAC(2458), categoryId: 'people' },
+  { id: 'ppl-dad', text: 'dad', imageUrl: ARASAAC(31146), categoryId: 'people' },
+  { id: 'ppl-brother', text: 'brother', imageUrl: ARASAAC(2423), categoryId: 'people' },
+  { id: 'ppl-sister', text: 'sister', imageUrl: ARASAAC(2422), categoryId: 'people' },
+  { id: 'ppl-grandma', text: 'grandma', imageUrl: ARASAAC(23710), categoryId: 'people' },
+  { id: 'ppl-grandpa', text: 'grandpa', imageUrl: ARASAAC(23718), categoryId: 'people' },
+  { id: 'ppl-teacher', text: 'teacher', imageUrl: ARASAAC(6556), categoryId: 'people' },
+  { id: 'ppl-friend', text: 'friend', imageUrl: ARASAAC(25790), categoryId: 'people' },
+  { id: 'ppl-me', text: 'me', imageUrl: ARASAAC(24925), categoryId: 'people' },
+];
+
+export const PLACES_PHRASES: AACPhrase[] = [
+  { id: 'place-home', text: 'home', imageUrl: ARASAAC(6964), categoryId: 'places' },
+  { id: 'place-school', text: 'school', imageUrl: ARASAAC(32446), categoryId: 'places' },
+  { id: 'place-park', text: 'park', imageUrl: ARASAAC(4608), categoryId: 'places' },
+  { id: 'place-store', text: 'store', imageUrl: ARASAAC(35695), categoryId: 'places' },
+  { id: 'place-car', text: 'car', imageUrl: ARASAAC(2339), categoryId: 'places' },
+  { id: 'place-outside', text: 'outside', imageUrl: ARASAAC(2666), categoryId: 'places' },
+  { id: 'place-inside', text: 'inside', imageUrl: ARASAAC(5439), categoryId: 'places' },
+  { id: 'place-beach', text: 'beach', imageUrl: ARASAAC(2925), categoryId: 'places' },
+];
+
+export const SCHOOL_PHRASES: AACPhrase[] = [
+  { id: 'sch-school', text: 'school', imageUrl: ARASAAC(32446), categoryId: 'school' },
+  { id: 'sch-teacher', text: 'teacher', imageUrl: ARASAAC(6556), categoryId: 'school' },
+  { id: 'sch-class', text: 'class', imageUrl: ARASAAC(9815), categoryId: 'school' },
+  { id: 'sch-break', text: 'break time', imageUrl: ARASAAC(27339), categoryId: 'school' },
+  { id: 'sch-lunch', text: 'lunch time', imageUrl: ARASAAC(4611), categoryId: 'school' },
+  { id: 'sch-work', text: 'do work', imageUrl: ARASAAC(6624), categoryId: 'school' },
+];
+
+export const HOME_PHRASES: AACPhrase[] = [
+  { id: 'home-home', text: 'home', imageUrl: ARASAAC(6964), categoryId: 'home' },
+  { id: 'home-bedroom', text: 'bedroom', imageUrl: ARASAAC(5988), categoryId: 'home' },
+  { id: 'home-bathroom', text: 'bathroom', imageUrl: ARASAAC(2272), categoryId: 'home' },
+  { id: 'home-kitchen', text: 'kitchen', imageUrl: ARASAAC(10752), categoryId: 'home' },
+  { id: 'home-living', text: 'living room', imageUrl: ARASAAC(6211), categoryId: 'home' },
+  { id: 'home-garden', text: 'garden', imageUrl: ARASAAC(2666), categoryId: 'home' },
+];
+
+// =============================================================================
+// GLP Stage 1 — Sounds (earliest communicators)
+// =============================================================================
+
+export const GLP_STAGE1_SOUNDS_CATEGORY: AACCategory = {
+  id: 'sounds',
+  name: 'Sounds',
+  color: '#FF6B35',
+  imageUrl: ARASAAC(7046),
+};
+
+export const SOUNDS_PHRASES: AACPhrase[] = [
+  // Animal sounds
+  { id: 'snd-woof', text: 'woof', spokenText: 'woof woof', imageUrl: ARASAAC(5257), categoryId: 'sounds' },
+  { id: 'snd-meow', text: 'meow', spokenText: 'meow', imageUrl: ARASAAC(2466), categoryId: 'sounds' },
+  { id: 'snd-moo', text: 'moo', spokenText: 'mooo', imageUrl: ARASAAC(2353), categoryId: 'sounds' },
+  { id: 'snd-baa', text: 'baa', spokenText: 'baaaa', imageUrl: ARASAAC(2475), categoryId: 'sounds' },
+  { id: 'snd-quack', text: 'quack', spokenText: 'quack quack', imageUrl: ARASAAC(2359), categoryId: 'sounds' },
+  // Vehicle sounds
+  { id: 'snd-vroom', text: 'vroom', spokenText: 'vroom vroom', imageUrl: ARASAAC(2339), categoryId: 'sounds' },
+  { id: 'snd-beep', text: 'beep beep', spokenText: 'beep beep', imageUrl: ARASAAC(2339), categoryId: 'sounds' },
+  { id: 'snd-choo', text: 'choo choo', spokenText: 'choo choo', imageUrl: ARASAAC(3004), categoryId: 'sounds' },
+  // Silly sounds
+  { id: 'snd-boing', text: 'boing', spokenText: 'boing', imageUrl: ARASAAC(3241), categoryId: 'sounds' },
+  { id: 'snd-splash', text: 'splash', spokenText: 'splash', imageUrl: ARASAAC(3228), categoryId: 'sounds' },
+  { id: 'snd-pop', text: 'pop', spokenText: 'pop', imageUrl: ARASAAC(2881), categoryId: 'sounds' },
+  { id: 'snd-whoosh', text: 'whoosh', spokenText: 'whoooosh', imageUrl: ARASAAC(8142), categoryId: 'sounds' },
+];
+
+export const GLP_STAGE1_CATEGORIES: AACCategory[] = [
+  GLP_STAGE1_SOUNDS_CATEGORY,
+  { id: 'general', name: 'Words', color: '#4CAF50', imageUrl: ARASAAC(6964) },
+  { id: 'feelings', name: 'Feelings', color: TOPIC_FITZGERALD_COLORS.feelings, imageUrl: ARASAAC(37190) },
+  { id: 'food', name: 'Food', color: TOPIC_FITZGERALD_COLORS.nouns, imageUrl: ARASAAC(4610) },
+];
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/** Get phrases by topic category */
+export function getPhrasesByCategory(categoryId: string): AACPhrase[] {
+  switch (categoryId) {
+    case 'sounds': return SOUNDS_PHRASES;
+    case 'general': return GENERAL_PHRASES;
+    case 'feelings': return FEELINGS_PHRASES;
+    case 'actions': return ACTIONS_PHRASES;
+    case 'questions': return QUESTIONS_PHRASES;
+    case 'food': return FOOD_PHRASES;
+    case 'drinks': return DRINKS_PHRASES;
+    case 'clothes': return CLOTHES_PHRASES;
+    case 'body': return BODY_PHRASES;
+    case 'play': return PLAY_PHRASES;
+    case 'colours': return COLOURS_PHRASES;
+    case 'numbers': return NUMBERS_PHRASES;
+    case 'shapes': return SHAPES_PHRASES;
+    case 'people': return PEOPLE_PHRASES;
+    case 'places': return PLACES_PHRASES;
+    case 'school': return SCHOOL_PHRASES;
+    case 'home': return HOME_PHRASES;
+    default: return [];
+  }
+}
+
+/** Get all topic phrases combined */
+export function getAllPhrases(): AACPhrase[] {
+  return [
+    ...GENERAL_PHRASES,
+    ...FEELINGS_PHRASES,
+    ...ACTIONS_PHRASES,
+    ...QUESTIONS_PHRASES,
+    ...FOOD_PHRASES,
+    ...DRINKS_PHRASES,
+    ...CLOTHES_PHRASES,
+    ...BODY_PHRASES,
+    ...PLAY_PHRASES,
+    ...COLOURS_PHRASES,
+    ...NUMBERS_PHRASES,
+    ...SHAPES_PHRASES,
+    ...PEOPLE_PHRASES,
+    ...PLACES_PHRASES,
+    ...SCHOOL_PHRASES,
+    ...HOME_PHRASES,
+  ];
+}
+
+/** Get core words filtered by word type */
+export function getCoreWordsByType(wordType: WordCategory): CoreWord[] {
+  return ALL_CORE_WORDS.filter(w => w.wordType === wordType);
+}
+
+/** Get core words that support a specific communication function */
+export function getCoreWordsForFunction(fn: CommunicationFunction): CoreWord[] {
+  return ALL_CORE_WORDS.filter(w => w.communicationFunctions.includes(fn));
+}
+
+/** Get core words for a GLP stage (includes all lower stages) */
+export function getCoreWordsForGLPStage(stage: number): CoreWord[] {
+  return ALL_CORE_WORDS.filter(w => w.glpStage <= stage);
+}
+
+/** Total word count across both systems */
+export function getTotalWordCount(): number {
+  return ALL_CORE_WORDS.length + getAllPhrases().length + SOUNDS_PHRASES.length;
+}


### PR DESCRIPTION
## Summary
- **ElevenLabs TTS client** (`src/lib/tts.ts`) with automatic Web Speech API fallback when API key not configured or offline
- **Server-side proxy endpoint** (`src/app/api/tts/route.ts`) keeps ElevenLabs API key server-side, uses `eleven_turbo_v2_5` model
- **GLP stages 1-6** (`src/lib/glp/`) with stage definitions, vocabulary tiers based on AAC core vocabulary research, and barrel exports
- **`.env.example`** updated with `ELEVENLABS_API_KEY` and `ELEVENLABS_JR_VOICE_ID` placeholders

## Test plan
- [x] `npm run build` passes
- [ ] Verify TTS fallback works without API key (returns 204, client uses browser speech)
- [ ] Verify ElevenLabs synthesis with valid API key
- [ ] Verify GLP vocabulary filtering by stage

Generated with [Claude Code](https://claude.com/claude-code)