### PR TITLE
feat: port vocabulary system — 500+ words with Fitzgerald Key (#53)

### DIFF
--- a/src/components/AACBoard.tsx
+++ b/src/components/AACBoard.tsx
@@ -12,7 +12,7 @@ export type GridDensity = (typeof GRID_DENSITY_OPTIONS)[number];
 const DEFAULT_COLUMNS: GridDensity = 4;
 
 // ---------------------------------------------------------------------------
-// AAC symbols from vocabulary system (replaces hardcoded SAMPLE_SYMBOLS)
+// AAC symbols from vocabulary system (replaces hardcoded placeholder set)
 // ---------------------------------------------------------------------------
 const AAC_SYMBOLS = [
   ...GENERAL_PHRASES,
@@ -89,12 +89,12 @@ export default function AACBoard({
         </div>
       )}
 
-      {/* Symbol grid */}
+      {/* Symbol grid — uses ARASAAC pictograms from vocabulary system */}
       <div
         className="grid gap-2.5"
         style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
       >
-        {SAMPLE_SYMBOLS.map((sym) => (
+        {AAC_SYMBOLS.map((sym) => (
           <button
             key={sym.id}
             onClick={() => handleSymbolTap(sym.label)}
@@ -107,9 +107,12 @@ export default function AACBoard({
             "
             style={{ minHeight: 88 }}
           >
-            <span className="text-[39px] leading-none min-w-[60px] min-h-[60px] flex items-center justify-center">
-              {sym.emoji}
-            </span>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={sym.imageUrl}
+              alt={sym.label}
+              className="w-[60px] h-[60px] object-contain"
+            />
             <span className="text-xs font-semibold text-[--brand-text-soft]">
               {sym.label}
             </span>

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -24,9 +24,10 @@
  */
 
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { FITZGERALD_COLORS, type WordCategory } from '@/lib/fitzgerald-key';
 
 // =============================================================================
-// Fitzgerald Key Color Definitions
+// Fitzgerald Key Color Definitions (mapped from shared vocabulary system)
 // =============================================================================
 
 type FitzgeraldCategory =
@@ -38,6 +39,18 @@ type FitzgeraldCategory =
   | 'questions'
   | 'determiners'
   | 'negation';
+
+/** Map grid categories to canonical Fitzgerald Key word categories */
+const CATEGORY_TO_WORD_TYPE: Record<FitzgeraldCategory, WordCategory> = {
+  people: 'pronoun',
+  verbs: 'verb',
+  descriptors: 'adjective',
+  prepositions: 'preposition',
+  social: 'social',
+  questions: 'question',
+  determiners: 'determiner',
+  negation: 'negation',
+};
 
 /**
  * Maps each Fitzgerald category to Tailwind class strings using CSS variables.
@@ -53,6 +66,11 @@ const FITZGERALD_CLASSES: Record<FitzgeraldCategory, { bg: string; text: string;
   determiners:  { bg: 'bg-fitzgerald-white',   text: 'text-fitzgerald-white-text',  border: 'border-fitzgerald-white-border' },
   negation:     { bg: 'bg-fitzgerald-red',    text: 'text-fitzgerald-red-text',    border: 'border-fitzgerald-red-border' },
 };
+
+/** Get inline Fitzgerald Key color for a grid category (used by non-Tailwind contexts) */
+export function getGridCategoryColor(category: FitzgeraldCategory) {
+  return FITZGERALD_COLORS[CATEGORY_TO_WORD_TYPE[category]];
+}
 
 // =============================================================================
 // Core Word Data — FIXED positions, NEVER reorder


### PR DESCRIPTION
## Summary
- Port complete AAC vocabulary system from `packages/jnr` with 500+ words
- `src/lib/fitzgerald-key.ts` — 12 word categories with WCAG-compliant color definitions, lookup helpers, and legend groupings
- `src/lib/vocabulary.ts` — ~100 core words (with GLP stages, morphological forms, ARASAAC IDs) plus 400+ topic phrases across 16 categories (food, drinks, clothes, body, play, colours, numbers, shapes, people, places, school, home, sounds)
- Replace hardcoded DEMO_CARDS (12 items) in `page.tsx` with real GENERAL_PHRASES from vocabulary system
- Replace placeholder SAMPLE_SYMBOLS (emoji-based) in `AACBoard.tsx` with ARASAAC pictogram images from vocabulary
- Wire `SupercoreGrid.tsx` to shared Fitzgerald Key color definitions via import bridge

## Test plan
- [x] `next build` passes clean
- [ ] Verify ARASAAC pictogram images render in AACBoard grid
- [ ] Verify PhraseBoard cards display real vocabulary labels
- [ ] Verify SupercoreGrid still renders 50 fixed-position words with correct colors

Generated with [Claude Code](https://claude.com/claude-code)