### PR TITLE
feat: music hub with Suno song creation

### DIFF
--- a/src/app/api/generate-song/route.ts
+++ b/src/app/api/generate-song/route.ts
@@ -1,0 +1,231 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * POST /api/generate-song
+ *
+ * Music generation for 8gent Jr.
+ * Dual-provider: Suno (polling) -> ElevenLabs (direct audio) fallback.
+ *
+ * Body: { sentences: string[], style?: string, tempo?: string }
+ * Returns: { taskId, title, lyrics } (Suno) or { audioUrl, title, lyrics } (ElevenLabs)
+ *
+ * Issue: #10
+ */
+
+export const maxDuration = 60;
+
+const SONG_PROMPT_SYSTEM = `You are a children's songwriter. Given a list of sentences and words that a child has been communicating through their AAC device, create a fun, simple song.
+
+Rules:
+1. Use the child's OWN words and themes as much as possible
+2. Keep lyrics simple, repetitive, and age-appropriate (ages 4-10)
+3. Make it fun and uplifting
+4. Use common children's song structures (verse, chorus, verse, chorus)
+5. Each line should be short (5-8 words max)
+6. Include [Verse] and [Chorus] tags
+7. The song should be 1-2 minutes when sung
+
+Respond with JSON only:
+{
+  "title": "Song Title (2-4 words, fun and catchy)",
+  "style": "children's pop, happy, playful, simple melody, acoustic guitar",
+  "lyrics": "[Verse]\\nLine 1\\nLine 2\\n\\n[Chorus]\\nLine 1\\nLine 2\\n\\n[Verse]\\nLine 1\\nLine 2\\n\\n[Chorus]\\nLine 1\\nLine 2"
+}`;
+
+interface GenerateSongRequest {
+  sentences: string[];
+  style?: string;
+  tempo?: string;
+}
+
+function jsonResponse(data: Record<string, unknown>, status = 200) {
+  return NextResponse.json(data, { status });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body: GenerateSongRequest = await request.json();
+
+    if (!body.sentences || body.sentences.length === 0) {
+      return jsonResponse({ error: 'No prompt provided' }, 400);
+    }
+
+    const groqKey = process.env.GROQ_API_KEY;
+    const openaiKey = process.env.OPENAI_API_KEY;
+
+    if (!groqKey && !openaiKey) {
+      return jsonResponse({ error: 'Music creation not configured' }, 500);
+    }
+
+    // ── Step 1: LLM generates song structure from prompt ──────────
+    const styleHint = body.style ? `\n\nThe song should feel: ${body.style}.` : '';
+    const tempoHint = body.tempo ? ` Tempo: ${body.tempo}.` : '';
+    const userMessage = `Here are things the child has been saying:\n\n${body.sentences.map((s, i) => `${i + 1}. "${s}"`).join('\n')}\n\nCreate a fun children's song using these themes and words.${styleHint}${tempoHint}`;
+
+    let songData: { title: string; style: string; lyrics: string } | null = null;
+
+    // Try Groq first (fast + free)
+    if (groqKey) {
+      try {
+        const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${groqKey}`,
+          },
+          body: JSON.stringify({
+            model: 'llama-3.1-8b-instant',
+            max_tokens: 1024,
+            messages: [
+              { role: 'system', content: SONG_PROMPT_SYSTEM },
+              { role: 'user', content: userMessage },
+            ],
+          }),
+        });
+
+        if (res.ok) {
+          const data = await res.json();
+          const content = data.choices?.[0]?.message?.content;
+          if (content) songData = parseSongData(content);
+        }
+      } catch (err) {
+        console.error('[generate-song] Groq error:', err);
+      }
+    }
+
+    // Fallback to OpenAI
+    if (!songData && openaiKey) {
+      try {
+        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${openaiKey}`,
+          },
+          body: JSON.stringify({
+            model: 'gpt-4o-mini',
+            max_tokens: 1024,
+            messages: [
+              { role: 'system', content: SONG_PROMPT_SYSTEM },
+              { role: 'user', content: userMessage },
+            ],
+          }),
+        });
+
+        if (res.ok) {
+          const data = await res.json();
+          const content = data.choices?.[0]?.message?.content;
+          if (content) songData = parseSongData(content);
+        }
+      } catch (err) {
+        console.error('[generate-song] OpenAI error:', err);
+      }
+    }
+
+    if (!songData) {
+      return jsonResponse({ error: 'Could not generate song lyrics' }, 500);
+    }
+
+    // ── Step 2: Try Suno (polling-based) ──────────────────────────
+    const sunoKey = process.env.SUNO_API_KEY;
+    if (sunoKey) {
+      try {
+        const sunoRes = await fetch('https://api.sunoapi.org/api/v1/generate', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${sunoKey}`,
+          },
+          body: JSON.stringify({
+            customMode: true,
+            instrumental: false,
+            title: songData.title,
+            style: body.style || songData.style,
+            prompt: songData.lyrics,
+            model: 'V4_5',
+          }),
+        });
+
+        if (sunoRes.ok) {
+          const sunoData = await sunoRes.json();
+          if (sunoData.code === 200 && sunoData.data?.taskId) {
+            return jsonResponse({
+              taskId: sunoData.data.taskId,
+              title: songData.title,
+              style: songData.style,
+              lyrics: songData.lyrics,
+            });
+          }
+        }
+        console.error('[generate-song] Suno failed, trying fallback');
+      } catch (err) {
+        console.error('[generate-song] Suno error:', err);
+      }
+    }
+
+    // ── Step 3: Fallback to ElevenLabs (direct audio) ─────────────
+    const elevenLabsKey = process.env.ELEVENLABS_API_KEY;
+    if (elevenLabsKey) {
+      try {
+        const musicPrompt = `A children's song called "${songData.title}".
+Style: ${body.style || songData.style}${body.tempo ? `, ${body.tempo}` : ''}.
+For kids ages 4-10, fun and singable.
+
+${songData.lyrics}`;
+
+        const elRes = await fetch('https://api.elevenlabs.io/v1/music', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'xi-api-key': elevenLabsKey,
+          },
+          body: JSON.stringify({
+            prompt: musicPrompt,
+            music_length_ms: 60000,
+            model_id: 'music_v1',
+          }),
+        });
+
+        if (elRes.ok) {
+          const audioBuffer = await elRes.arrayBuffer();
+          const base64 = Buffer.from(audioBuffer).toString('base64');
+          const dataUrl = `data:audio/mpeg;base64,${base64}`;
+
+          return jsonResponse({
+            audioUrl: dataUrl,
+            title: songData.title,
+            lyrics: songData.lyrics,
+            duration: 60,
+          });
+        }
+
+        console.error('[generate-song] ElevenLabs failed:', elRes.status);
+      } catch (err) {
+        console.error('[generate-song] ElevenLabs error:', err);
+      }
+    }
+
+    // Both providers failed
+    return jsonResponse({ error: 'Music generation unavailable' }, 500);
+  } catch (error) {
+    console.error('[generate-song] Unexpected error:', error);
+    return jsonResponse({ error: 'Internal server error' }, 500);
+  }
+}
+
+function parseSongData(content: string): { title: string; style: string; lyrics: string } | null {
+  try {
+    let jsonStr = content;
+    const jsonMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (jsonMatch) {
+      jsonStr = jsonMatch[1].trim();
+    }
+    const parsed = JSON.parse(jsonStr);
+    if (parsed.title && parsed.style && parsed.lyrics) {
+      return { title: parsed.title, style: parsed.style, lyrics: parsed.lyrics };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/app/api/song-status/route.ts
+++ b/src/app/api/song-status/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * GET /api/song-status?taskId=xxx
+ *
+ * Polls Suno for song generation progress.
+ * Returns: { status: 'complete'|'processing'|'failed', audioUrl?, title?, duration? }
+ *
+ * Issue: #10
+ */
+
+export const runtime = 'edge';
+
+export async function GET(request: NextRequest) {
+  try {
+    const taskId = request.nextUrl.searchParams.get('taskId');
+
+    if (!taskId) {
+      return NextResponse.json({ error: 'taskId required' }, { status: 400 });
+    }
+
+    const sunoKey = process.env.SUNO_API_KEY;
+    if (!sunoKey) {
+      return NextResponse.json({ error: 'Music service not configured' }, { status: 500 });
+    }
+
+    const res = await fetch(
+      `https://api.sunoapi.org/api/v1/generate/record-info?taskId=${encodeURIComponent(taskId)}`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${sunoKey}` },
+      },
+    );
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Status check failed' }, { status: 500 });
+    }
+
+    const data = await res.json();
+
+    if (data.code !== 200) {
+      return NextResponse.json({ error: 'Status check failed' }, { status: 500 });
+    }
+
+    const status = data.data?.status;
+    const sunoTracks = data.data?.response?.sunoData || [];
+
+    // Complete — return first track
+    if (status === 'SUCCESS' && sunoTracks.length > 0) {
+      const track = sunoTracks[0];
+      return NextResponse.json({
+        status: 'complete',
+        audioUrl: track.audioUrl,
+        streamUrl: track.streamAudioUrl,
+        imageUrl: track.imageUrl,
+        title: track.title,
+        duration: track.duration,
+        tags: track.tags,
+      });
+    }
+
+    // Failed states
+    if (
+      status === 'CREATE_TASK_FAILED' ||
+      status === 'GENERATE_AUDIO_FAILED' ||
+      status === 'CALLBACK_EXCEPTION' ||
+      status === 'SENSITIVE_WORD_ERROR'
+    ) {
+      return NextResponse.json({ status: 'failed', error: status });
+    }
+
+    // Still processing
+    return NextResponse.json({
+      status: 'processing',
+      sunoStatus: status,
+    });
+  } catch (error) {
+    console.error('[song-status] Error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import SongCreator from '@/components/SongCreator';
+
+/* ── Music Hub Tabs ──────────────────────────────────────── */
+
+const TABS = [
+  { id: 'instruments', label: 'Instruments', icon: '🎹' },
+  { id: 'moods',       label: 'Moods',       icon: '🎭' },
+  { id: 'create',      label: 'Create Song',  icon: '🎤' },
+] as const;
+
+type TabId = (typeof TABS)[number]['id'];
+
+/* ── Page ─────────────────────────────────────────────────── */
+
+export default function MusicHubPage() {
+  const [tab, setTab] = useState<TabId>('instruments');
+
+  return (
+    <div className="min-h-dvh flex flex-col items-center bg-[#FFF8F0] pb-24">
+      {/* Header */}
+      <h1 className="text-[22px] font-extrabold mt-5 mb-1 text-[#1a1a2e]">
+        Music
+      </h1>
+
+      {/* Tab bar */}
+      <div className="flex gap-2 my-3 mb-5 p-1 rounded-[14px] bg-[#f0e6d6]">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={`px-4 py-2 border-none rounded-[10px] font-bold text-[14px] cursor-pointer transition-all duration-150 ${
+              tab === t.id
+                ? 'bg-white text-[#1a1a2e] shadow-md'
+                : 'bg-transparent text-[#8a7e70]'
+            }`}
+          >
+            {t.icon} {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {tab === 'instruments' && (
+        <div className="flex flex-col items-center gap-4 w-full max-w-md px-4">
+          <p className="text-[#8a7e70] text-center text-[15px]">
+            Play drums, xylophone, and more!
+          </p>
+          <Link
+            href="/music/instruments"
+            className="w-full flex items-center justify-center gap-3 px-6 py-4 rounded-2xl bg-gradient-to-r from-[#FF6B35] to-[#E8610A] text-white font-bold text-lg shadow-lg active:scale-95 transition-transform no-underline"
+          >
+            🎹 Open Instruments
+          </Link>
+        </div>
+      )}
+
+      {tab === 'moods' && (
+        <div className="flex flex-col items-center gap-4 w-full max-w-md px-4">
+          <p className="text-[#8a7e70] text-center text-[15px]">
+            Pick a mood and listen to matching music!
+          </p>
+          <Link
+            href="/music/moods"
+            className="w-full flex items-center justify-center gap-3 px-6 py-4 rounded-2xl bg-gradient-to-r from-[#8B5CF6] to-[#6D28D9] text-white font-bold text-lg shadow-lg active:scale-95 transition-transform no-underline"
+          >
+            🎭 Browse Moods
+          </Link>
+        </div>
+      )}
+
+      {tab === 'create' && <SongCreator />}
+    </div>
+  );
+}

--- a/src/components/Dock.tsx
+++ b/src/components/Dock.tsx
@@ -9,7 +9,7 @@ import { useState, useCallback, type ReactNode } from 'react';
  *
  * Routes:
  *   Talk     → /talk/core
- *   Music    → /music/instruments
+ *   Music    → /music
  *   Games    → /games
  *   Speech   → /speech
  *   More     → overlay with remaining routes
@@ -129,7 +129,7 @@ const MORE_ITEMS: MoreItem[] = [
 
 const DOCK_ITEMS: DockItem[] = [
   { id: 'talk', label: 'Talk', icon: IconSpeechBubble, href: '/talk/core' },
-  { id: 'music', label: 'Music', icon: IconMusic, href: '/music/instruments' },
+  { id: 'music', label: 'Music', icon: IconMusic, href: '/music' },
   { id: 'games', label: 'Games', icon: IconGamepad, href: '/games' },
   { id: 'speech', label: 'Speech', icon: IconWaveform, href: '/speech' },
 ];

--- a/src/components/SongCreator.tsx
+++ b/src/components/SongCreator.tsx
@@ -1,0 +1,297 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+/* ── Types ───────────────────────────────────────────────── */
+
+interface GenerateResponse {
+  taskId?: string;
+  audioUrl?: string;
+  title?: string;
+  lyrics?: string;
+  duration?: number;
+  error?: string;
+}
+
+interface StatusResponse {
+  status: 'complete' | 'processing' | 'failed';
+  audioUrl?: string;
+  streamUrl?: string;
+  title?: string;
+  duration?: number;
+  error?: string;
+  sunoStatus?: string;
+}
+
+type Phase = 'idle' | 'generating' | 'polling' | 'ready' | 'error';
+
+/* ── Suggested prompts for kids ──────────────────────────── */
+
+const SUGGESTIONS = [
+  'A happy song about going to the park',
+  'A silly song about a dancing dinosaur',
+  'A bedtime song about the moon and stars',
+  'A fun song about eating ice cream',
+  'A brave song about being a superhero',
+];
+
+/* ── Component ───────────────────────────────────────────── */
+
+export default function SongCreator() {
+  const [prompt, setPrompt] = useState('');
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [songTitle, setSongTitle] = useState('');
+  const [songLyrics, setSongLyrics] = useState('');
+  const [audioUrl, setAudioUrl] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [pollCount, setPollCount] = useState(0);
+
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  // Cleanup polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    };
+  }, []);
+
+  /* ── Poll for song status ──────────────────────────────── */
+
+  const pollStatus = useCallback(
+    async (taskId: string, attempt: number) => {
+      if (attempt > 60) {
+        setPhase('error');
+        setErrorMsg('Song is taking too long. Please try again.');
+        return;
+      }
+
+      try {
+        const res = await fetch(`/api/song-status?taskId=${encodeURIComponent(taskId)}`);
+        const data: StatusResponse = await res.json();
+
+        if (data.status === 'complete' && data.audioUrl) {
+          setAudioUrl(data.audioUrl);
+          if (data.title) setSongTitle(data.title);
+          setPhase('ready');
+          return;
+        }
+
+        if (data.status === 'failed') {
+          setPhase('error');
+          setErrorMsg('Song generation failed. Try a different prompt!');
+          return;
+        }
+
+        // Still processing — poll again
+        setPollCount(attempt);
+        pollTimerRef.current = setTimeout(() => pollStatus(taskId, attempt + 1), 3000);
+      } catch {
+        setPhase('error');
+        setErrorMsg('Connection error. Please try again.');
+      }
+    },
+    [],
+  );
+
+  /* ── Submit song request ───────────────────────────────── */
+
+  const handleCreate = async () => {
+    if (!prompt.trim()) return;
+
+    setPhase('generating');
+    setErrorMsg('');
+    setAudioUrl('');
+    setSongTitle('');
+    setSongLyrics('');
+    setPollCount(0);
+
+    try {
+      const res = await fetch('/api/generate-song', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sentences: [prompt.trim()] }),
+      });
+
+      const data: GenerateResponse = await res.json();
+
+      if (data.error) {
+        setPhase('error');
+        setErrorMsg('Could not create song. Try again!');
+        return;
+      }
+
+      if (data.title) setSongTitle(data.title);
+      if (data.lyrics) setSongLyrics(data.lyrics);
+
+      // Path A: polling-based (Suno)
+      if (data.taskId) {
+        setPhase('polling');
+        pollStatus(data.taskId, 1);
+        return;
+      }
+
+      // Path B: direct audio (ElevenLabs fallback)
+      if (data.audioUrl) {
+        setAudioUrl(data.audioUrl);
+        setPhase('ready');
+        return;
+      }
+
+      setPhase('error');
+      setErrorMsg('Unexpected response. Try again!');
+    } catch {
+      setPhase('error');
+      setErrorMsg('Connection error. Please try again.');
+    }
+  };
+
+  /* ── Reset ─────────────────────────────────────────────── */
+
+  const handleReset = () => {
+    if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    setPhase('idle');
+    setPrompt('');
+    setAudioUrl('');
+    setSongTitle('');
+    setSongLyrics('');
+    setErrorMsg('');
+    setPollCount(0);
+  };
+
+  /* ── Render ────────────────────────────────────────────── */
+
+  return (
+    <div className="w-full max-w-md px-4 flex flex-col gap-4">
+      {/* Prompt input (idle or error) */}
+      {(phase === 'idle' || phase === 'error') && (
+        <>
+          <label className="text-[15px] font-semibold text-[#1a1a2e]">
+            What should the song be about?
+          </label>
+
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="A fun song about..."
+            rows={3}
+            maxLength={300}
+            className="w-full px-4 py-3 rounded-xl border-2 border-[#f0e6d6] bg-white text-[16px] text-[#1a1a2e] resize-none focus:outline-none focus:border-[#E8610A] transition-colors"
+          />
+
+          {/* Suggestion chips */}
+          <div className="flex flex-wrap gap-2">
+            {SUGGESTIONS.map((s) => (
+              <button
+                key={s}
+                onClick={() => setPrompt(s)}
+                className="px-3 py-1.5 rounded-full bg-[#f0e6d6] text-[13px] text-[#8a7e70] font-medium border-none cursor-pointer hover:bg-[#e8dcc8] active:scale-95 transition-all"
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+
+          {/* Error message */}
+          {phase === 'error' && errorMsg && (
+            <p className="text-red-500 text-sm font-medium text-center">{errorMsg}</p>
+          )}
+
+          {/* Create button */}
+          <button
+            onClick={handleCreate}
+            disabled={!prompt.trim()}
+            className="w-full py-4 rounded-2xl bg-gradient-to-r from-[#10B981] to-[#059669] text-white font-bold text-lg shadow-lg border-none cursor-pointer active:scale-95 transition-transform disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Create My Song
+          </button>
+        </>
+      )}
+
+      {/* Loading state */}
+      {(phase === 'generating' || phase === 'polling') && (
+        <div className="flex flex-col items-center gap-4 py-8">
+          {/* Animated music notes */}
+          <div className="flex gap-3 text-4xl animate-bounce">
+            <span className="animate-[bounce_1s_ease-in-out_infinite]">🎵</span>
+            <span className="animate-[bounce_1s_ease-in-out_0.2s_infinite]">🎶</span>
+            <span className="animate-[bounce_1s_ease-in-out_0.4s_infinite]">🎵</span>
+          </div>
+
+          <p className="text-[#1a1a2e] font-bold text-lg">
+            {phase === 'generating' ? 'Writing your song...' : 'Creating the music...'}
+          </p>
+
+          {songTitle && (
+            <p className="text-[#8a7e70] text-sm">
+              &quot;{songTitle}&quot;
+            </p>
+          )}
+
+          {phase === 'polling' && (
+            <p className="text-[#8a7e70] text-xs">
+              This can take up to 2 minutes
+              {pollCount > 0 && ` (check ${pollCount}/60)`}
+            </p>
+          )}
+
+          {/* Pulse animation bar */}
+          <div className="w-48 h-2 rounded-full bg-[#f0e6d6] overflow-hidden">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-[#10B981] to-[#059669] animate-[progress_2s_ease-in-out_infinite]"
+              style={{ width: phase === 'polling' ? `${Math.min(95, pollCount * 3)}%` : '30%' }}
+            />
+          </div>
+
+          <style>{`
+            @keyframes progress {
+              0%, 100% { opacity: 0.6; }
+              50% { opacity: 1; }
+            }
+          `}</style>
+        </div>
+      )}
+
+      {/* Song ready */}
+      {phase === 'ready' && audioUrl && (
+        <div className="flex flex-col items-center gap-4 py-4">
+          <div className="text-5xl">🎉</div>
+
+          <h2 className="text-[#1a1a2e] font-extrabold text-xl text-center">
+            {songTitle || 'Your Song is Ready!'}
+          </h2>
+
+          {/* Audio player */}
+          <audio
+            ref={audioRef}
+            src={audioUrl}
+            controls
+            autoPlay
+            className="w-full rounded-xl"
+            style={{ maxWidth: '100%' }}
+          />
+
+          {/* Lyrics (collapsible) */}
+          {songLyrics && (
+            <details className="w-full bg-white rounded-xl p-4 border border-[#f0e6d6]">
+              <summary className="font-semibold text-[#1a1a2e] cursor-pointer text-sm">
+                Show Lyrics
+              </summary>
+              <pre className="mt-3 text-[13px] text-[#8a7e70] whitespace-pre-wrap font-sans leading-relaxed">
+                {songLyrics}
+              </pre>
+            </details>
+          )}
+
+          {/* Create another */}
+          <button
+            onClick={handleReset}
+            className="w-full py-3 rounded-2xl bg-[#f0e6d6] text-[#1a1a2e] font-bold text-base border-none cursor-pointer active:scale-95 transition-transform"
+          >
+            Create Another Song
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/music` hub page with 3 tabs: Instruments, Moods, Create Song
- Build `SongCreator` component with prompt input, suggestion chips, loading animation, and audio player
- Port `generate-song` and `song-status` API routes from NickOS with dual-provider Suno/ElevenLabs fallback
- Update Dock to link to `/music` hub instead of `/music/instruments`

Closes #10

## Test plan
- [ ] Verify `/music` renders with all 3 tabs
- [ ] Instruments tab links to `/music/instruments`
- [ ] Moods tab links to `/music/moods`
- [ ] Create Song tab shows prompt input and suggestion chips
- [ ] Song generation works with SUNO_API_KEY configured
- [ ] ElevenLabs fallback works when Suno unavailable
- [ ] Audio player renders and plays generated songs
- [ ] Dock Music button now goes to `/music`

Generated with [Claude Code](https://claude.com/claude-code)