### PR TITLE
feat: port SchoolTube UI + AAC expansion (#63)

### DIFF
--- a/src/app/category/[id]/page.tsx
+++ b/src/app/category/[id]/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+/**
+ * Category Detail Page — shows all AAC phrases for a specific category.
+ * Navigated to from the AACHome browse view.
+ */
+
+import { useParams, useRouter } from "next/navigation";
+import { useState, useCallback, useMemo } from "react";
+import { AAC_CATEGORIES } from "@/components/AACHome";
+import {
+  GENERAL_PHRASES,
+  FEELINGS_PHRASES,
+  ACTIONS_PHRASES,
+} from "@/lib/vocabulary";
+
+/** Map category IDs to phrase lists (extend as vocab grows) */
+function getPhrasesForCategory(categoryId: string) {
+  switch (categoryId) {
+    case "feelings":
+      return FEELINGS_PHRASES;
+    case "actions":
+      return ACTIONS_PHRASES;
+    case "wants":
+    case "food":
+    case "people":
+    case "social":
+    default:
+      return GENERAL_PHRASES;
+  }
+}
+
+export default function CategoryDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const categoryId = params.id as string;
+
+  const category = AAC_CATEGORIES.find((c) => c.id === categoryId);
+  const phrases = useMemo(
+    () => getPhrasesForCategory(categoryId),
+    [categoryId]
+  );
+
+  const [selectedWords, setSelectedWords] = useState<string[]>([]);
+
+  const handleTap = useCallback((text: string) => {
+    setSelectedWords((prev) => [...prev, text]);
+
+    if ("speechSynthesis" in window) {
+      window.speechSynthesis.cancel();
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.rate = 0.9;
+      utterance.pitch = 1.1;
+      window.speechSynthesis.speak(utterance);
+    }
+  }, []);
+
+  const handleSpeak = useCallback(() => {
+    if (selectedWords.length === 0) return;
+    if ("speechSynthesis" in window) {
+      window.speechSynthesis.cancel();
+      const utterance = new SpeechSynthesisUtterance(
+        selectedWords.join(" ")
+      );
+      utterance.rate = 0.9;
+      utterance.pitch = 1.1;
+      window.speechSynthesis.speak(utterance);
+    }
+  }, [selectedWords]);
+
+  const handleClear = () => setSelectedWords([]);
+
+  if (!category) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <p className="text-5xl mb-4">{"\uD83D\uDD0D"}</p>
+          <p className="text-lg font-semibold text-gray-600">
+            Category not found
+          </p>
+          <button
+            onClick={() => router.push("/talk")}
+            className="mt-4 px-6 py-3 bg-cyan-500 text-white font-bold rounded-xl"
+          >
+            Back to Talk
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-cyan-500 to-teal-500 flex flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 pt-4 pb-2">
+        <button
+          onClick={() => router.push("/talk")}
+          className="flex items-center gap-1 text-white/80 hover:text-white"
+        >
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+        <span className="text-3xl">{category.emoji}</span>
+        <h1 className="text-white text-xl font-bold">{category.name}</h1>
+      </div>
+
+      {/* Sentence strip */}
+      <div className="mx-4 mb-3">
+        <div className="flex items-center gap-2 min-h-[48px] px-3 py-2 bg-white/90 rounded-xl text-lg flex-wrap">
+          {selectedWords.length === 0 ? (
+            <span className="text-gray-400 italic text-base">
+              Tap words to build a sentence...
+            </span>
+          ) : (
+            selectedWords.map((word, i) => (
+              <span
+                key={`${word}-${i}`}
+                className="inline-block px-2 py-1 rounded-lg font-semibold text-sm"
+                style={{
+                  backgroundColor: category.color + "22",
+                  border: `2px solid ${category.color}`,
+                  color: category.color,
+                }}
+              >
+                {word}
+              </span>
+            ))
+          )}
+        </div>
+        {selectedWords.length > 0 && (
+          <div className="flex gap-2 mt-2">
+            <button
+              onClick={handleClear}
+              className="flex-1 py-2 rounded-xl bg-red-500 text-white font-semibold text-sm"
+            >
+              Clear
+            </button>
+            <button
+              onClick={handleSpeak}
+              className="flex-[2] py-2 rounded-xl bg-green-500 text-white font-bold text-base"
+            >
+              Speak
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Phrase grid */}
+      <div className="flex-1 px-4 pb-24 overflow-y-auto">
+        <div className="grid grid-cols-3 gap-2.5 md:grid-cols-4">
+          {phrases.map((phrase) => (
+            <button
+              key={phrase.id}
+              onClick={() => handleTap(phrase.text)}
+              className="flex flex-col items-center justify-center gap-1.5 p-3 bg-white rounded-xl border-2 min-h-[100px] active:scale-95 transition-transform hover:shadow-md"
+              style={{ borderColor: category.color + "40" }}
+            >
+              {phrase.imageUrl ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img
+                  src={phrase.imageUrl}
+                  alt={phrase.text}
+                  className="w-14 h-14 object-contain"
+                />
+              ) : (
+                <div
+                  className="w-14 h-14 rounded-lg flex items-center justify-center text-2xl"
+                  style={{ backgroundColor: category.color + "15" }}
+                >
+                  {phrase.text.charAt(0).toUpperCase()}
+                </div>
+              )}
+              <span className="text-xs font-semibold text-gray-700 text-center leading-tight line-clamp-2">
+                {phrase.text}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -1,94 +1,29 @@
 "use client";
 
-import { useState } from "react";
-import GameCard from "@/components/games/GameCard";
-import AnimalSounds from "@/components/games/speech/AnimalSounds";
-import WordRepeat from "@/components/games/speech/WordRepeat";
-import RhymeTime from "@/components/games/speech/RhymeTime";
-import FeelingsExplorer from "@/components/games/speech/FeelingsExplorer";
+/**
+ * Games Page — SchoolTube layout with reels feed, topic filters,
+ * and the vibrant cyan gradient background from NickOS.
+ *
+ * Updated from basic game grid to full SchoolTube UI.
+ */
 
-type Category = "speech" | "maths" | "music";
-type GameId = "animal-sounds" | "word-repeat" | "rhyme-time" | "feelings";
-
-const categories: { id: Category; label: string; emoji: string }[] = [
-  { id: "speech", label: "Speech", emoji: "\u{1F5E3}\uFE0F" },
-  { id: "maths", label: "Maths", emoji: "\u{1F522}" },
-  { id: "music", label: "Music", emoji: "\u{1F3B5}" },
-];
-
-const games: { id: GameId; category: Category; emoji: string; title: string; description: string; color: string }[] = [
-  { id: "animal-sounds", category: "speech", emoji: "\u{1F43E}", title: "Animal Sounds", description: "Match animals to their sounds!", color: "#E8A87C" },
-  { id: "word-repeat", category: "speech", emoji: "\u{1F3A4}", title: "Word Repeat", description: "Hear a word and say it 3 times!", color: "#9B59B6" },
-  { id: "rhyme-time", category: "speech", emoji: "\u{1F3B5}", title: "Rhyme Time", description: "Find the words that rhyme!", color: "#6C5CE7" },
-  { id: "feelings", category: "speech", emoji: "\u{1F60A}", title: "Feelings Explorer", description: "Learn about emotions and feelings!", color: "#FFD93D" },
-];
-
-const gameComponents: Record<GameId, React.ComponentType> = {
-  "animal-sounds": AnimalSounds,
-  "word-repeat": WordRepeat,
-  "rhyme-time": RhymeTime,
-  "feelings": FeelingsExplorer,
-};
+import ReelsFeed from "@/components/schooltube/ReelsFeed";
 
 export default function GamesPage() {
-  const [tab, setTab] = useState<Category>("speech");
-  const [activeGame, setActiveGame] = useState<GameId | null>(null);
-
-  if (activeGame) {
-    const GameComponent = gameComponents[activeGame];
-    return (
-      <div className="min-h-screen bg-[#FFF8F0]">
-        <div className="flex items-center px-4 py-3 border-b border-[#F0DECA]">
-          <button onClick={() => setActiveGame(null)}
-            className="border-none bg-transparent text-xl cursor-pointer px-2 py-1 text-[#E8610A] font-bold">
-            &larr; Back
-          </button>
-          <span className="font-bold text-base text-gray-800 ml-2">
-            {games.find((g) => g.id === activeGame)?.title}
-          </span>
-        </div>
-        <GameComponent />
-      </div>
-    );
-  }
-
-  const filtered = games.filter((g) => g.category === tab);
-
   return (
-    <div className="min-h-screen bg-[#FFF8F0] px-4 pt-6 pb-24">
-      <h1 className="text-[32px] font-extrabold text-[#E8610A] text-center mb-1">
-        SchoolTube Games
-      </h1>
-      <p className="text-center text-gray-400 text-sm mb-5">Learn through play!</p>
-
-      {/* Category tabs */}
-      <div className="flex justify-center gap-2 mb-6">
-        {categories.map((c) => (
-          <button key={c.id} onClick={() => setTab(c.id)}
-            className={`px-5 py-2 rounded-[20px] border-none font-bold text-sm cursor-pointer transition-all duration-150 ${
-              tab === c.id
-                ? "bg-[#E8610A] text-white"
-                : "bg-[#F0DECA] text-gray-400"
-            }`}>
-            {c.emoji} {c.label}
-          </button>
-        ))}
+    <div className="min-h-screen bg-gradient-to-b from-cyan-400 via-cyan-500 to-teal-600">
+      {/* Header */}
+      <div className="px-4 pt-6 pb-2">
+        <h1 className="text-3xl font-extrabold text-white text-center drop-shadow-md">
+          SchoolTube
+        </h1>
+        <p className="text-center text-white/80 text-sm mt-1">
+          Learn through play!
+        </p>
       </div>
 
-      {/* Game grid */}
-      {filtered.length > 0 ? (
-        <div className="grid grid-cols-2 gap-3.5 max-w-[400px] mx-auto">
-          {filtered.map((g) => (
-            <GameCard key={g.id} emoji={g.emoji} title={g.title} description={g.description} color={g.color}
-              onClick={() => setActiveGame(g.id)} />
-          ))}
-        </div>
-      ) : (
-        <div className="text-center px-4 py-12 text-gray-300">
-          <div className="text-5xl mb-2">&#x1F6A7;</div>
-          <p className="font-semibold">Coming soon!</p>
-        </div>
-      )}
+      {/* Reels Feed */}
+      <ReelsFeed />
     </div>
   );
 }

--- a/src/app/talk/page.tsx
+++ b/src/app/talk/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+/**
+ * Talk Page — main AAC communication hub for 8gent Jr.
+ *
+ * Three modes:
+ * - "For You"  — contextual/frequent phrases
+ * - "All"      — full vocabulary grid
+ * - "Browse"   — browse by AAC category
+ *
+ * Includes safety phrases bar always visible at bottom.
+ * Ported from NickOS talk interface, adapted to 8gent Jr architecture.
+ */
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import AACBoard from "@/components/AACBoard";
+import AACHome from "@/components/AACHome";
+import AACKeyboard from "@/components/AACKeyboard";
+import AACEncouragement from "@/components/AACEncouragement";
+import SentenceBuilder from "@/components/SentenceBuilder";
+
+type ViewMode = "contextual" | "all" | "categories";
+
+// Safety phrases — always accessible
+const SAFETY_PHRASES = [
+  { id: "help", text: "Help me", color: "#F44336" },
+  { id: "stop", text: "Stop", color: "#F44336" },
+  { id: "hurt", text: "I'm hurt", color: "#FF5722" },
+  { id: "bathroom", text: "Bathroom", color: "#FF9800" },
+  { id: "water", text: "Water", color: "#2196F3" },
+  { id: "scared", text: "I'm scared", color: "#9C27B0" },
+];
+
+export default function TalkPage() {
+  const router = useRouter();
+  const [viewMode, setViewMode] = useState<ViewMode>("contextual");
+  const [spokenCount, setSpokenCount] = useState(0);
+
+  const handleSpeakSafety = useCallback((text: string) => {
+    if ("speechSynthesis" in window) {
+      window.speechSynthesis.cancel();
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.rate = 0.9;
+      utterance.pitch = 1.1;
+      window.speechSynthesis.speak(utterance);
+      setSpokenCount((c) => c + 1);
+    }
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-cyan-500 via-teal-500 to-green-500 flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 pt-4 pb-2">
+        <button
+          onClick={() => router.push("/")}
+          className="flex items-center gap-1 text-white/80 hover:text-white transition-colors"
+        >
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          <span className="text-lg font-medium">Back</span>
+        </button>
+        <h1 className="text-white text-xl font-bold">Talk</h1>
+        <div className="w-16" /> {/* Spacer */}
+      </div>
+
+      {/* Encouragement */}
+      <div className="px-4 py-1">
+        <AACEncouragement wordCount={spokenCount} />
+      </div>
+
+      {/* View Mode Tabs */}
+      <div className="px-4 py-2">
+        <div className="flex items-center gap-2 bg-white/10 rounded-xl p-1">
+          <button
+            onClick={() => setViewMode("contextual")}
+            className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
+              viewMode === "contextual"
+                ? "bg-white text-gray-900"
+                : "text-white/80 hover:bg-white/10"
+            }`}
+          >
+            For You
+          </button>
+          <button
+            onClick={() => setViewMode("all")}
+            className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
+              viewMode === "all"
+                ? "bg-white text-gray-900"
+                : "text-white/80 hover:bg-white/10"
+            }`}
+          >
+            All
+          </button>
+          <button
+            onClick={() => setViewMode("categories")}
+            className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
+              viewMode === "categories"
+                ? "bg-white text-gray-900"
+                : "text-white/80 hover:bg-white/10"
+            }`}
+          >
+            Browse
+          </button>
+        </div>
+      </div>
+
+      {/* AAC Keyboard input */}
+      <div className="px-4 py-2">
+        <AACKeyboard
+          onWordSelect={(word) => {
+            handleSpeakSafety(word);
+          }}
+        />
+      </div>
+
+      {/* Main content area */}
+      <div className="flex-1 px-4 py-2 overflow-y-auto">
+        {viewMode === "contextual" && (
+          <div className="space-y-4">
+            <SentenceBuilder />
+          </div>
+        )}
+
+        {viewMode === "all" && (
+          <div className="bg-white/10 rounded-2xl p-2">
+            <AACBoard columns={4} showDensitySelector />
+          </div>
+        )}
+
+        {viewMode === "categories" && <AACHome />}
+      </div>
+
+      {/* Safety phrases bar — always visible */}
+      <div className="sticky bottom-0 bg-white/95 backdrop-blur-sm border-t border-gray-200 px-3 py-2 safe-area-inset-bottom">
+        <div className="flex gap-2 overflow-x-auto no-scrollbar">
+          {SAFETY_PHRASES.map((phrase) => (
+            <button
+              key={phrase.id}
+              onClick={() => handleSpeakSafety(phrase.text)}
+              className="shrink-0 px-4 py-2.5 rounded-full font-bold text-sm text-white active:scale-95 transition-transform shadow-sm"
+              style={{ backgroundColor: phrase.color }}
+            >
+              {phrase.text}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AACEncouragement.tsx
+++ b/src/components/AACEncouragement.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * AACEncouragement — celebrates communication milestones.
+ * Shows encouraging messages and animations when the child reaches
+ * word count milestones during AAC use.
+ */
+
+import { useEffect, useState } from "react";
+
+const ENCOURAGEMENTS: Record<number, { message: string; emoji: string }> = {
+  1: { message: "Great start!", emoji: "\u2B50" },
+  3: { message: "You're doing amazing!", emoji: "\uD83C\uDF1F" },
+  5: { message: "Wow, five words!", emoji: "\uD83C\uDF89" },
+  7: { message: "Keep going!", emoji: "\uD83D\uDE80" },
+  10: { message: "Super communicator!", emoji: "\uD83C\uDFC6" },
+  15: { message: "Incredible sentence!", emoji: "\uD83E\uDD29" },
+  20: { message: "Communication champion!", emoji: "\uD83E\uDD47" },
+};
+
+interface AACEncouragementProps {
+  wordCount: number;
+}
+
+export default function AACEncouragement({
+  wordCount,
+}: AACEncouragementProps) {
+  const [visible, setVisible] = useState(false);
+  const [current, setCurrent] = useState<{
+    message: string;
+    emoji: string;
+  } | null>(null);
+
+  useEffect(() => {
+    const entry = ENCOURAGEMENTS[wordCount];
+    if (entry) {
+      setCurrent(entry);
+      setVisible(true);
+      const timer = setTimeout(() => setVisible(false), 2500);
+      return () => clearTimeout(timer);
+    }
+  }, [wordCount]);
+
+  if (!visible || !current) return null;
+
+  return (
+    <div className="flex items-center justify-center gap-2 px-4 py-2 bg-gradient-to-r from-cyan-50 to-teal-50 rounded-xl border border-cyan-200 animate-[fadeIn_0.3s_ease-in]">
+      <span className="text-2xl animate-bounce">{current.emoji}</span>
+      <span className="text-base font-bold text-cyan-700">
+        {current.message}
+      </span>
+    </div>
+  );
+}

--- a/src/components/AACHome.tsx
+++ b/src/components/AACHome.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+/**
+ * AACHome — category browser for the expanded AAC system.
+ * Shows all AAC categories as tappable cards with ARASAAC pictograms.
+ * Links to /category/[id] for detail views.
+ */
+
+import Link from "next/link";
+
+export interface AACCategoryDef {
+  id: string;
+  name: string;
+  emoji: string;
+  color: string;
+  count: number;
+}
+
+const AAC_CATEGORIES: AACCategoryDef[] = [
+  { id: "wants", name: "Wants", emoji: "\uD83C\uDF1F", color: "#FFD700", count: 12 },
+  { id: "feelings", name: "Feelings", emoji: "\uD83D\uDE0A", color: "#FF6B6B", count: 20 },
+  { id: "actions", name: "Actions", emoji: "\uD83C\uDFC3", color: "#4CAF50", count: 25 },
+  { id: "food", name: "Food", emoji: "\uD83C\uDF4E", color: "#FF9800", count: 30 },
+  { id: "people", name: "People", emoji: "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67", color: "#FFD700", count: 15 },
+  { id: "places", name: "Places", emoji: "\uD83C\uDFE0", color: "#8B6914", count: 12 },
+  { id: "animals", name: "Animals", emoji: "\uD83D\uDC36", color: "#A67C52", count: 18 },
+  { id: "body", name: "Body", emoji: "\uD83E\uDD35", color: "#E91E63", count: 14 },
+  { id: "clothes", name: "Clothes", emoji: "\uD83D\uDC55", color: "#9C27B0", count: 10 },
+  { id: "toys", name: "Toys", emoji: "\uD83E\uDDF8", color: "#E040FB", count: 16 },
+  { id: "nature", name: "Nature", emoji: "\uD83C\uDF33", color: "#2ECC71", count: 12 },
+  { id: "school", name: "School", emoji: "\uD83C\uDFEB", color: "#2196F3", count: 15 },
+  { id: "time", name: "Time", emoji: "\u23F0", color: "#00BCD4", count: 8 },
+  { id: "questions", name: "Questions", emoji: "\u2753", color: "#00BCD4", count: 10 },
+  { id: "describing", name: "Describing", emoji: "\uD83D\uDD35", color: "#2196F3", count: 20 },
+  { id: "social", name: "Social", emoji: "\uD83D\uDC4B", color: "#E8610A", count: 12 },
+  { id: "safety", name: "Safety", emoji: "\uD83D\uDEA8", color: "#F44336", count: 6 },
+  { id: "transport", name: "Transport", emoji: "\uD83D\uDE97", color: "#607D8B", count: 10 },
+];
+
+export { AAC_CATEGORIES };
+
+export default function AACHome() {
+  return (
+    <div className="grid grid-cols-3 gap-3 p-4 md:grid-cols-4 lg:grid-cols-6">
+      {AAC_CATEGORIES.map((cat) => (
+        <Link
+          key={cat.id}
+          href={`/category/${cat.id}`}
+          className="flex flex-col items-center gap-2 p-4 rounded-2xl transition-all active:scale-95 hover:shadow-md border-2"
+          style={{
+            borderColor: cat.color + "40",
+            backgroundColor: cat.color + "12",
+          }}
+        >
+          <span className="text-4xl">{cat.emoji}</span>
+          <span
+            className="text-sm font-bold text-center leading-tight"
+            style={{ color: cat.color }}
+          >
+            {cat.name}
+          </span>
+          <span className="text-[10px] text-gray-400">
+            {cat.count} words
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/components/AACKeyboard.tsx
+++ b/src/components/AACKeyboard.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+/**
+ * AACKeyboard — text input with word prediction for AAC sentence building.
+ * Provides typed word input alongside the symbol grid for faster communication.
+ */
+
+import { useState, useCallback, useRef } from "react";
+import { getAllWords, getWordColor } from "@/lib/sentence-engine";
+
+interface AACKeyboardProps {
+  onWordSelect: (word: string) => void;
+}
+
+export default function AACKeyboard({ onWordSelect }: AACKeyboardProps) {
+  const [input, setInput] = useState("");
+  const [predictions, setPredictions] = useState<string[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const allWords = getAllWords();
+
+  const handleInputChange = useCallback(
+    (value: string) => {
+      setInput(value);
+      if (value.length >= 1) {
+        const matches = allWords
+          .filter((w) => w.toLowerCase().startsWith(value.toLowerCase()))
+          .slice(0, 8);
+        setPredictions(matches);
+      } else {
+        setPredictions([]);
+      }
+    },
+    [allWords]
+  );
+
+  const handleSelect = useCallback(
+    (word: string) => {
+      onWordSelect(word);
+      setInput("");
+      setPredictions([]);
+      inputRef.current?.focus();
+    },
+    [onWordSelect]
+  );
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = input.trim();
+    if (trimmed) {
+      onWordSelect(trimmed);
+      setInput("");
+      setPredictions([]);
+    }
+  }, [input, onWordSelect]);
+
+  return (
+    <div className="space-y-2">
+      {/* Prediction chips */}
+      {predictions.length > 0 && (
+        <div className="flex gap-2 overflow-x-auto no-scrollbar py-1">
+          {predictions.map((word) => (
+            <button
+              key={word}
+              onClick={() => handleSelect(word)}
+              className="shrink-0 px-3 py-2 rounded-xl font-semibold text-sm bg-white active:scale-95 transition-transform"
+              style={{
+                border: `2px solid ${getWordColor(word)}`,
+                color: getWordColor(word),
+              }}
+            >
+              {word}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Input field */}
+      <div className="flex gap-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => handleInputChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSubmit();
+          }}
+          placeholder="Type a word..."
+          className="flex-1 px-4 py-3 rounded-xl border-2 border-gray-200 bg-white text-gray-800 text-base font-medium focus:border-cyan-400 focus:outline-none transition-colors"
+        />
+        <button
+          onClick={handleSubmit}
+          disabled={!input.trim()}
+          className="px-4 py-3 rounded-xl bg-cyan-500 text-white font-bold text-sm disabled:opacity-40 active:scale-95 transition-all"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/schooltube/DailyActivityBanner.tsx
+++ b/src/components/schooltube/DailyActivityBanner.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+/**
+ * DailyActivityBanner — shows the day's suggested learning activity.
+ * Ported from NickOS, simplified to work without external daily-routine lib.
+ */
+
+const DAILY_ACTIVITIES = [
+  {
+    day: "Monday",
+    theme: "Number Fun",
+    activity: "Counting & number games",
+    icon: "\uD83D\uDD22",
+    color: "#FF6B6B",
+    duration: 15,
+    gameTypes: ["counting", "bubblePop", "numberOrder", "numberBonds"],
+  },
+  {
+    day: "Tuesday",
+    theme: "Letter Land",
+    activity: "ABC tracing & sounds",
+    icon: "\uD83D\uDD24",
+    color: "#4ECDC4",
+    duration: 15,
+    gameTypes: ["letterTrace", "wordRepeat"],
+  },
+  {
+    day: "Wednesday",
+    theme: "Color Day",
+    activity: "Color sorting & mixing",
+    icon: "\uD83C\uDFA8",
+    color: "#FFE66D",
+    duration: 15,
+    gameTypes: ["colorSort", "colorMix"],
+  },
+  {
+    day: "Thursday",
+    theme: "Shape World",
+    activity: "Shape matching & patterns",
+    icon: "\u2B1B",
+    color: "#95E1D3",
+    duration: 15,
+    gameTypes: ["matching", "pattern", "sizeSort", "memory"],
+  },
+  {
+    day: "Friday",
+    theme: "Sensory Play",
+    activity: "Relaxing sensory experiences",
+    icon: "\uD83C\uDF08",
+    color: "#FF69B4",
+    duration: 20,
+    gameTypes: [
+      "ballRain",
+      "iceCream",
+      "bottleFill",
+      "fireworks",
+      "bubbleWrap",
+    ],
+  },
+  {
+    day: "Saturday",
+    theme: "Speech & Language",
+    activity: "Animal sounds & feelings",
+    icon: "\uD83D\uDDE3\uFE0F",
+    color: "#686DE0",
+    duration: 15,
+    gameTypes: ["animalSounds", "feelings", "rhymeTime", "sentenceBuilder"],
+  },
+  {
+    day: "Sunday",
+    theme: "Free Play",
+    activity: "Choose your own adventure!",
+    icon: "\u2B50",
+    color: "#F8B500",
+    duration: 20,
+    gameTypes: [],
+  },
+];
+
+function getTodayActivity() {
+  const day = new Date().getDay(); // 0=Sun..6=Sat
+  const idx = day === 0 ? 6 : day - 1; // remap so Monday=0
+  return DAILY_ACTIVITIES[idx];
+}
+
+interface DailyActivityBannerProps {
+  onStartActivity: (gameTypes: string[]) => void;
+}
+
+export default function DailyActivityBanner({
+  onStartActivity,
+}: DailyActivityBannerProps) {
+  const activity = getTodayActivity();
+
+  return (
+    <div
+      className="mx-4 mb-4 rounded-3xl p-4 shadow-lg overflow-hidden relative"
+      style={{ backgroundColor: activity.color }}
+    >
+      {/* Background decoration */}
+      <div className="absolute inset-0 opacity-20 pointer-events-none">
+        <div className="absolute -right-10 -top-10 w-40 h-40 rounded-full bg-white/30 animate-[spin_20s_linear_infinite]" />
+        <div className="absolute -left-5 -bottom-5 w-32 h-32 rounded-full bg-white/20 animate-[spin_25s_linear_infinite_reverse]" />
+      </div>
+
+      <div className="relative z-10 flex items-center gap-4">
+        {/* Icon */}
+        <div className="w-16 h-16 bg-white/30 rounded-2xl flex items-center justify-center text-4xl backdrop-blur-sm shrink-0">
+          {activity.icon}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <p className="text-white/80 text-sm font-medium">
+            {activity.day}&apos;s Activity
+          </p>
+          <h3 className="text-white font-bold text-lg truncate">
+            {activity.theme}
+          </h3>
+          <p className="text-white/90 text-sm">{activity.activity}</p>
+          <div className="flex items-center gap-1 mt-1 text-white/70 text-xs">
+            <svg
+              className="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <polyline points="12 6 12 12 16 14" />
+            </svg>
+            <span>{activity.duration} min</span>
+          </div>
+        </div>
+
+        {/* Play button */}
+        <button
+          onClick={() => onStartActivity(activity.gameTypes)}
+          className="h-14 w-14 rounded-2xl bg-white hover:bg-white/90 shadow-lg flex items-center justify-center shrink-0 active:scale-95 transition-transform"
+        >
+          <svg
+            className="w-6 h-6 text-gray-800"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/schooltube/GamePlayer.tsx
+++ b/src/components/schooltube/GamePlayer.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+/**
+ * GamePlayer — fullscreen game dialog for SchoolTube.
+ * Renders the selected game component with score tracking and completion celebration.
+ * Ported from NickOS — maps to existing game components in 8gent Jr.
+ */
+
+import { useState, useEffect, useRef } from "react";
+import type { Reel } from "@/lib/reels-data";
+
+// Import existing game components from the 8gentjr codebase
+import AnimalSounds from "@/components/games/speech/AnimalSounds";
+import WordRepeat from "@/components/games/speech/WordRepeat";
+import RhymeTime from "@/components/games/speech/RhymeTime";
+import FeelingsExplorer from "@/components/games/speech/FeelingsExplorer";
+
+interface GamePlayerProps {
+  reel: Reel;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** Map gameType strings to available game components */
+const AVAILABLE_GAMES: Record<string, React.ComponentType> = {
+  animalSounds: AnimalSounds,
+  wordRepeat: WordRepeat,
+  rhymeTime: RhymeTime,
+  feelings: FeelingsExplorer,
+};
+
+export default function GamePlayer({
+  reel,
+  open,
+  onOpenChange,
+}: GamePlayerProps) {
+  const [score, setScore] = useState(0);
+  const [showComplete, setShowComplete] = useState(false);
+  const [gameKey, setGameKey] = useState(0);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      dialogRef.current?.showModal();
+      setScore(0);
+      setShowComplete(false);
+      setGameKey((k) => k + 1);
+    } else {
+      dialogRef.current?.close();
+    }
+  }, [open]);
+
+  const handleRestart = () => {
+    setScore(0);
+    setShowComplete(false);
+    setGameKey((k) => k + 1);
+  };
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const GameComponent = AVAILABLE_GAMES[reel.gameType || ""];
+
+  if (!open) return null;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={handleClose}
+      className="fixed inset-0 m-0 p-0 w-full h-full max-w-full max-h-full bg-gradient-to-br from-cyan-500 to-teal-600 border-0"
+    >
+      <div className="relative h-full w-full flex flex-col p-4">
+        {/* Header */}
+        <div className="flex justify-between items-center mb-3">
+          <div className="bg-white rounded-2xl px-4 py-2 shadow-lg">
+            <span className="text-xl font-bold text-cyan-600">
+              Score: {score}
+            </span>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleRestart}
+              className="h-12 w-12 rounded-2xl bg-white hover:bg-white/90 shadow-lg flex items-center justify-center"
+            >
+              <svg
+                className="h-5 w-5 text-cyan-600"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+              >
+                <polyline points="1 4 1 10 7 10" />
+                <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+              </svg>
+            </button>
+            <button
+              onClick={handleClose}
+              className="h-12 w-12 rounded-2xl bg-white hover:bg-white/90 shadow-lg flex items-center justify-center"
+            >
+              <svg
+                className="h-5 w-5 text-cyan-600"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Game title */}
+        <h2 className="text-xl font-bold text-center text-white mb-3 drop-shadow-md">
+          {reel.title}
+        </h2>
+
+        {/* Game content */}
+        <div className="flex-1 bg-white rounded-3xl p-4 shadow-2xl overflow-hidden">
+          {GameComponent ? (
+            <GameComponent key={gameKey} />
+          ) : (
+            <div className="h-full flex flex-col items-center justify-center gap-4 text-gray-400">
+              <div className="text-6xl">
+                {reel.type === "game" ? "\uD83C\uDFAE" : "\uD83D\uDCFA"}
+              </div>
+              <p className="text-lg font-semibold">Coming Soon!</p>
+              <p className="text-sm">
+                This {reel.type} will be available in a future update.
+              </p>
+              <button
+                onClick={handleClose}
+                className="mt-4 px-6 py-3 bg-cyan-500 text-white font-bold rounded-2xl hover:bg-cyan-600 transition-colors"
+              >
+                Go Back
+              </button>
+            </div>
+          )}
+
+          {showComplete && (
+            <div className="absolute inset-0 bg-white rounded-3xl flex flex-col items-center justify-center gap-6">
+              <div className="text-6xl">
+                {"\uD83C\uDF89\uD83C\uDF8A\uD83E\uDD73"}
+              </div>
+              <h3 className="text-3xl font-bold text-cyan-600">Amazing!</h3>
+              <p className="text-xl text-gray-500">
+                You scored{" "}
+                <span className="font-bold text-cyan-600">{score}</span>{" "}
+                points!
+              </p>
+              <div className="flex gap-4">
+                <button
+                  onClick={handleRestart}
+                  className="px-8 py-4 text-lg font-bold rounded-2xl bg-cyan-500 hover:bg-cyan-600 text-white shadow-lg"
+                >
+                  Play Again
+                </button>
+                <button
+                  onClick={handleClose}
+                  className="px-8 py-4 text-lg font-bold rounded-2xl border-2 border-cyan-500 text-cyan-500 bg-white shadow-lg"
+                >
+                  Done
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/src/components/schooltube/PinDialog.tsx
+++ b/src/components/schooltube/PinDialog.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+/**
+ * PinDialog — parental PIN control for SchoolTube settings/admin access.
+ * Ported from NickOS. Uses native dialog element instead of shadcn Dialog.
+ */
+
+import { useState, useEffect, useRef } from "react";
+
+interface PinDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+}
+
+const CORRECT_PIN = "1234"; // Demo pin
+
+export default function PinDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+}: PinDialogProps) {
+  const [pin, setPin] = useState("");
+  const [error, setError] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      dialogRef.current?.showModal();
+    } else {
+      dialogRef.current?.close();
+    }
+  }, [open]);
+
+  const handleNumberClick = (num: string) => {
+    if (pin.length >= 4) return;
+    const newPin = pin + num;
+    setPin(newPin);
+    setError(false);
+
+    if (newPin.length === 4) {
+      if (newPin === CORRECT_PIN) {
+        setSuccess(true);
+        setTimeout(() => {
+          onSuccess?.();
+          handleClose();
+        }, 800);
+      } else {
+        setError(true);
+        setTimeout(() => {
+          setPin("");
+          setError(false);
+        }, 500);
+      }
+    }
+  };
+
+  const handleClear = () => {
+    setPin("");
+    setError(false);
+  };
+
+  const handleClose = () => {
+    setPin("");
+    setError(false);
+    setSuccess(false);
+    onOpenChange(false);
+  };
+
+  if (!open) return null;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={handleClose}
+      className="fixed inset-0 z-50 m-auto rounded-2xl p-6 max-w-sm w-full bg-white shadow-2xl backdrop:bg-black/50"
+    >
+      <div className="text-center mb-6">
+        <div className="flex items-center justify-center gap-2 text-2xl font-bold text-gray-800">
+          <svg
+            className="h-6 w-6 text-cyan-500"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+          </svg>
+          Parent PIN
+        </div>
+      </div>
+
+      {/* PIN dots */}
+      <div className="flex justify-center gap-4 mb-6">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className={`h-14 w-14 rounded-2xl border-2 flex items-center justify-center transition-colors ${
+              error
+                ? "border-red-500 bg-red-50"
+                : success
+                  ? "border-cyan-500 bg-cyan-50"
+                  : pin[i]
+                    ? "border-cyan-500 bg-cyan-50"
+                    : "border-gray-200 bg-gray-50"
+            } ${error ? "animate-[shake_0.3s_ease-in-out]" : ""}`}
+          >
+            {pin[i] && (
+              <div
+                className={`h-4 w-4 rounded-full ${
+                  error ? "bg-red-500" : "bg-cyan-500"
+                }`}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Success message */}
+      {success && (
+        <div className="flex items-center justify-center gap-2 text-cyan-600 font-semibold mb-4">
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+          Access Granted
+        </div>
+      )}
+
+      {/* Number pad */}
+      <div className="grid grid-cols-3 gap-3 mb-4">
+        {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((num) => (
+          <button
+            key={num}
+            onClick={() => handleNumberClick(num.toString())}
+            disabled={success}
+            className="h-16 text-2xl font-bold rounded-xl border-2 border-gray-200 bg-white hover:bg-cyan-500 hover:text-white hover:border-cyan-500 active:scale-95 transition-all disabled:opacity-50"
+          >
+            {num}
+          </button>
+        ))}
+        <button
+          onClick={handleClear}
+          disabled={success}
+          className="h-16 rounded-xl border-2 border-gray-200 bg-white hover:bg-gray-100 transition-all disabled:opacity-50 flex items-center justify-center"
+        >
+          <svg
+            className="h-6 w-6 text-gray-600"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <path d="M21 4H8l-7 8 7 8h13a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z" />
+            <line x1="18" y1="9" x2="12" y2="15" />
+            <line x1="12" y1="9" x2="18" y2="15" />
+          </svg>
+        </button>
+        <button
+          onClick={() => handleNumberClick("0")}
+          disabled={success}
+          className="h-16 text-2xl font-bold rounded-xl border-2 border-gray-200 bg-white hover:bg-cyan-500 hover:text-white hover:border-cyan-500 active:scale-95 transition-all disabled:opacity-50"
+        >
+          0
+        </button>
+        <div />
+      </div>
+
+      <p className="text-xs text-center text-gray-400">Demo PIN: 1234</p>
+    </dialog>
+  );
+}

--- a/src/components/schooltube/ReelCard.tsx
+++ b/src/components/schooltube/ReelCard.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * ReelCard — gradient card for SchoolTube content (video or game).
+ * Shows thumbnail, overlay gradient, play/game icon, and category badge.
+ * Ported from NickOS, adapted to Tailwind without framer-motion/shadcn deps.
+ */
+
+import { useState } from "react";
+import type { Reel } from "@/lib/reels-data";
+import GamePlayer from "./GamePlayer";
+
+function getGameCategory(
+  topics: string[]
+): "sensory" | "speech" | "game" {
+  if (topics.includes("sensory")) return "sensory";
+  if (topics.includes("speech")) return "speech";
+  return "game";
+}
+
+const CATEGORY_STYLES = {
+  sensory: { bg: "bg-yellow-300", text: "text-yellow-800", label: "SENSORY" },
+  speech: { bg: "bg-teal-300", text: "text-teal-800", label: "SPEECH" },
+  game: { bg: "bg-cyan-400", text: "text-white", label: "GAME" },
+} as const;
+
+export default function ReelCard({ reel }: { reel: Reel }) {
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const category = reel.type === "game" ? getGameCategory(reel.topics) : null;
+  const style = category
+    ? CATEGORY_STYLES[category]
+    : CATEGORY_STYLES.game;
+
+  const handleClick = () => {
+    if (reel.type === "video" && reel.videoUrl) {
+      window.open(reel.videoUrl, "_blank", "noopener");
+    } else {
+      setIsPlaying(true);
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={handleClick}
+        className="relative overflow-hidden rounded-2xl shadow-md group cursor-pointer transition-all hover:ring-2 hover:ring-cyan-400 active:scale-[0.97] w-full text-left"
+      >
+        <div className="aspect-[3/4] relative bg-gray-100">
+          {/* Thumbnail */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={reel.thumbnail || "/placeholder.svg"}
+            alt={reel.title}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+
+          {/* Gradient overlay */}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+
+          {/* Center play icon */}
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="h-14 w-14 rounded-full bg-white/90 flex items-center justify-center shadow-xl">
+              {reel.type === "video" ? (
+                <svg
+                  className="h-7 w-7 text-cyan-500 ml-0.5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              ) : (
+                <svg
+                  className="h-7 w-7 text-cyan-500"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                >
+                  <rect x="2" y="6" width="20" height="12" rx="2" />
+                  <path d="M12 12h.01M6 12h.01M18 12h.01" />
+                </svg>
+              )}
+            </div>
+          </div>
+
+          {/* Title + duration */}
+          <div className="absolute bottom-0 left-0 right-0 p-3">
+            <h3 className="text-white font-bold text-sm leading-snug line-clamp-2">
+              {reel.title}
+            </h3>
+            {reel.duration && (
+              <span className="text-white/90 text-xs font-semibold mt-1 inline-block bg-black/30 px-2 py-0.5 rounded-full">
+                {reel.duration}
+              </span>
+            )}
+          </div>
+
+          {/* Category badge */}
+          {reel.type === "game" && (
+            <div className="absolute top-2 right-2">
+              <span
+                className={`${style.bg} ${style.text} text-[10px] font-bold px-2 py-1 rounded-full shadow-md`}
+              >
+                {style.label}
+              </span>
+            </div>
+          )}
+        </div>
+      </button>
+
+      {isPlaying && reel.type === "game" && (
+        <GamePlayer
+          reel={reel}
+          open={isPlaying}
+          onOpenChange={setIsPlaying}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/schooltube/ReelsFeed.tsx
+++ b/src/components/schooltube/ReelsFeed.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * ReelsFeed — main content feed for SchoolTube.
+ * Combines topic filters, daily activity banner, and a grid of reels.
+ * Ported from NickOS.
+ */
+
+import { useState } from "react";
+import { REELS_DATA } from "@/lib/reels-data";
+import ReelCard from "./ReelCard";
+import TopicFilter from "./TopicFilter";
+import DailyActivityBanner from "./DailyActivityBanner";
+
+export default function ReelsFeed() {
+  const [selectedTopics, setSelectedTopics] = useState<string[]>([]);
+  const [filterByGames, setFilterByGames] = useState<string[] | null>(null);
+
+  const handleStartActivity = (gameTypes: string[]) => {
+    if (gameTypes.length === 0) {
+      setFilterByGames(null);
+      setSelectedTopics([]);
+    } else {
+      setFilterByGames(gameTypes);
+    }
+  };
+
+  const filteredReels = (() => {
+    let reels = REELS_DATA;
+
+    // Filter by daily activity game types if set
+    if (filterByGames && filterByGames.length > 0) {
+      reels = reels.filter(
+        (reel) =>
+          reel.type === "game" && filterByGames.includes(reel.gameType || "")
+      );
+    }
+
+    // Then filter by topics
+    if (selectedTopics.length > 0) {
+      reels = reels.filter((reel) =>
+        reel.topics.some((topic) => selectedTopics.includes(topic))
+      );
+    }
+
+    return reels;
+  })();
+
+  return (
+    <div className="h-full flex flex-col">
+      <DailyActivityBanner onStartActivity={handleStartActivity} />
+
+      <div className="px-4 mb-2">
+        <TopicFilter
+          selectedTopics={selectedTopics}
+          onTopicsChange={setSelectedTopics}
+        />
+      </div>
+
+      {/* Active filter indicator */}
+      {filterByGames && (
+        <div className="mx-4 mb-2 flex items-center gap-2">
+          <span className="text-sm text-gray-500">
+            Showing today&apos;s activity games
+          </span>
+          <button
+            onClick={() => setFilterByGames(null)}
+            className="text-xs px-2 py-1 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors"
+          >
+            Show all
+          </button>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="grid grid-cols-2 gap-3 p-4 md:grid-cols-3 lg:grid-cols-4">
+          {filteredReels.map((reel) => (
+            <ReelCard key={reel.id} reel={reel} />
+          ))}
+        </div>
+        {filteredReels.length === 0 && (
+          <div className="text-center py-12 text-gray-400">
+            <div className="text-5xl mb-2">{"\uD83D\uDD0D"}</div>
+            <p className="font-semibold">No content for this filter</p>
+            <p className="text-sm">Try a different topic!</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/schooltube/TopicFilter.tsx
+++ b/src/components/schooltube/TopicFilter.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+/**
+ * TopicFilter — horizontal scrollable filter chips for SchoolTube topics.
+ * Ported from NickOS, adapted to Tailwind (no shadcn Button dependency).
+ */
+
+const TOPICS = [
+  { id: "all", label: "All", emoji: "\u2728", color: "#FF6B6B" },
+  { id: "numbers", label: "Numbers", emoji: "\uD83D\uDD22", color: "#FF6B6B" },
+  { id: "letters", label: "ABC", emoji: "\uD83D\uDD24", color: "#4ECDC4" },
+  { id: "colors", label: "Colors", emoji: "\uD83C\uDFA8", color: "#FFE66D" },
+  { id: "shapes", label: "Shapes", emoji: "\u2B1B", color: "#95E1D3" },
+  { id: "patterns", label: "Patterns", emoji: "\uD83D\uDD04", color: "#DDA0DD" },
+  { id: "sensory", label: "Sensory", emoji: "\uD83C\uDF08", color: "#FF69B4" },
+  { id: "speech", label: "Speech", emoji: "\uD83D\uDDE3\uFE0F", color: "#686DE0" },
+  { id: "creative", label: "Creative", emoji: "\uD83C\uDFAD", color: "#E056FD" },
+  { id: "music", label: "Music", emoji: "\uD83C\uDFB5", color: "#22A6B3" },
+  { id: "movement", label: "Body", emoji: "\uD83D\uDD7A", color: "#2ECC71" },
+] as const;
+
+interface TopicFilterProps {
+  selectedTopics: string[];
+  onTopicsChange: (topics: string[]) => void;
+}
+
+export default function TopicFilter({
+  selectedTopics,
+  onTopicsChange,
+}: TopicFilterProps) {
+  const toggleTopic = (topicId: string) => {
+    if (topicId === "all") {
+      onTopicsChange([]);
+      return;
+    }
+    if (selectedTopics.includes(topicId)) {
+      onTopicsChange(selectedTopics.filter((id) => id !== topicId));
+    } else {
+      onTopicsChange([...selectedTopics, topicId]);
+    }
+  };
+
+  return (
+    <div className="flex gap-2 overflow-x-auto no-scrollbar py-1">
+      {TOPICS.map((topic) => {
+        const isSelected =
+          topic.id === "all"
+            ? selectedTopics.length === 0
+            : selectedTopics.includes(topic.id);
+
+        return (
+          <button
+            key={topic.id}
+            onClick={() => toggleTopic(topic.id)}
+            className="shrink-0 flex items-center gap-1.5 px-4 py-2 rounded-full font-semibold text-sm min-h-[44px] transition-all border-2 active:scale-95"
+            style={{
+              backgroundColor: isSelected ? topic.color : "transparent",
+              borderColor: topic.color,
+              color: isSelected ? "white" : topic.color,
+            }}
+          >
+            <span className="text-lg">{topic.emoji}</span>
+            {topic.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/reels-data.ts
+++ b/src/lib/reels-data.ts
@@ -1,0 +1,404 @@
+/**
+ * SchoolTube Reels Data
+ *
+ * Game and video content catalog for the SchoolTube reels feed.
+ * Ported from NickOS and adapted for 8gent Jr.
+ */
+
+export type ReelType = "video" | "game";
+
+export type ReelTopic =
+  | "numbers"
+  | "letters"
+  | "colors"
+  | "shapes"
+  | "patterns"
+  | "sensory"
+  | "speech"
+  | "feelings"
+  | "animals"
+  | "nature"
+  | "movement"
+  | "music";
+
+export interface Reel {
+  id: number;
+  type: ReelType;
+  title: string;
+  thumbnail: string;
+  duration?: string;
+  topics: ReelTopic[];
+  videoUrl?: string;
+  gameType?: string;
+}
+
+// =============================================================================
+// Full reels catalog
+// =============================================================================
+
+export const REELS_DATA: Reel[] = [
+  // VIDEOS - Numbers
+  {
+    id: 1,
+    type: "video",
+    title: "Learn Numbers with Colorful Balls",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Numbers",
+    duration: "21:40",
+    topics: ["numbers", "colors"],
+    videoUrl: "https://www.youtube.com/watch?v=jJ1oH59faX4",
+  },
+  {
+    id: 5,
+    type: "video",
+    title: "Counting 1 to 10 with Colorful Objects",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Counting",
+    duration: "8:32",
+    topics: ["numbers"],
+    videoUrl: "https://www.youtube.com/watch?v=IIiet2JJVcA",
+  },
+
+  // VIDEOS - Letters/ABC
+  {
+    id: 2,
+    type: "video",
+    title: "ABC Song with Dancing Letters",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=ABC",
+    duration: "3:45",
+    topics: ["letters"],
+    videoUrl: "https://www.youtube.com/watch?v=Kp0bTDOnkzgrQ",
+  },
+  {
+    id: 6,
+    type: "video",
+    title: "Alphabet Dance Party",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Alphabet",
+    duration: "4:20",
+    topics: ["letters", "movement"],
+    videoUrl: "https://www.youtube.com/watch?v=c3m0-6K1bY0",
+  },
+
+  // VIDEOS - Colors
+  {
+    id: 3,
+    type: "video",
+    title: "Colors of the Rainbow",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Colors",
+    duration: "5:20",
+    topics: ["colors"],
+    videoUrl: "https://www.youtube.com/watch?v=PN0u1hqfZXw",
+  },
+  {
+    id: 7,
+    type: "video",
+    title: "Rainbow Song - Learn All Colors",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Rainbow",
+    duration: "3:15",
+    topics: ["colors", "music"],
+    videoUrl: "https://www.youtube.com/watch?v=wW1iKYKhLyY",
+  },
+
+  // VIDEOS - Shapes
+  {
+    id: 4,
+    type: "video",
+    title: "Shapes All Around Us",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Shapes",
+    duration: "8:15",
+    topics: ["shapes"],
+    videoUrl: "https://www.youtube.com/watch?v=jlzX8jt0Now",
+  },
+  {
+    id: 9,
+    type: "video",
+    title: "Squares, Circles & Triangles Song",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=ShapeSong",
+    duration: "3:50",
+    topics: ["shapes", "music"],
+    videoUrl: "https://www.youtube.com/watch?v=BwFmDGOAS6s",
+  },
+
+  // COUNTING & NUMBERS GAMES
+  {
+    id: 10,
+    type: "game",
+    title: "Count the Balls",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Count",
+    topics: ["numbers"],
+    gameType: "counting",
+  },
+  {
+    id: 11,
+    type: "game",
+    title: "Pop Numbers in Order",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=BubblePop",
+    topics: ["numbers"],
+    gameType: "bubblePop",
+  },
+  {
+    id: 12,
+    type: "game",
+    title: "Put Numbers in Order",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=NumberOrder",
+    topics: ["numbers", "patterns"],
+    gameType: "numberOrder",
+  },
+  {
+    id: 13,
+    type: "game",
+    title: "Number Bonds",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Bonds",
+    topics: ["numbers"],
+    gameType: "numberBonds",
+  },
+
+  // SHAPES GAMES
+  {
+    id: 20,
+    type: "game",
+    title: "Match the Shapes",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=ShapeMatch",
+    topics: ["shapes"],
+    gameType: "matching",
+  },
+  {
+    id: 21,
+    type: "game",
+    title: "Shape Memory",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Memory",
+    topics: ["shapes"],
+    gameType: "memory",
+  },
+  {
+    id: 22,
+    type: "game",
+    title: "Sort by Size",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=SizeSort",
+    topics: ["shapes", "patterns"],
+    gameType: "sizeSort",
+  },
+
+  // COLORS GAMES
+  {
+    id: 30,
+    type: "game",
+    title: "Sort by Color",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=ColorSort",
+    topics: ["colors"],
+    gameType: "colorSort",
+  },
+  {
+    id: 31,
+    type: "game",
+    title: "Mix Colors Together",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=ColorMix",
+    topics: ["colors"],
+    gameType: "colorMix",
+  },
+
+  // LETTERS GAMES
+  {
+    id: 40,
+    type: "game",
+    title: "Trace the Letters",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=LetterTrace",
+    topics: ["letters"],
+    gameType: "letterTrace",
+  },
+
+  // PATTERNS GAMES
+  {
+    id: 50,
+    type: "game",
+    title: "Complete the Pattern",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Pattern",
+    topics: ["patterns", "shapes"],
+    gameType: "pattern",
+  },
+
+  // SENSORY GAMES
+  {
+    id: 100,
+    type: "game",
+    title: "Ball Rain",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=BallRain",
+    topics: ["sensory", "numbers"],
+    gameType: "ballRain",
+  },
+  {
+    id: 101,
+    type: "game",
+    title: "Ice Cream Builder",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=IceCream",
+    topics: ["sensory", "colors"],
+    gameType: "iceCream",
+  },
+  {
+    id: 102,
+    type: "game",
+    title: "Fill the Bottles",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Bottles",
+    topics: ["sensory", "colors"],
+    gameType: "bottleFill",
+  },
+  {
+    id: 103,
+    type: "game",
+    title: "Shape Tower",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Tower",
+    topics: ["sensory", "shapes"],
+    gameType: "shapeTower",
+  },
+  {
+    id: 104,
+    type: "game",
+    title: "Fireworks Show",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Fireworks",
+    topics: ["sensory", "colors"],
+    gameType: "fireworks",
+  },
+  {
+    id: 105,
+    type: "game",
+    title: "Musical Balls",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Musical",
+    topics: ["sensory", "numbers"],
+    gameType: "musical",
+  },
+  {
+    id: 106,
+    type: "game",
+    title: "Rainbow Painting",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=RainbowPaint",
+    topics: ["sensory", "colors"],
+    gameType: "rainbowPaint",
+  },
+  {
+    id: 107,
+    type: "game",
+    title: "Bubble Wrap Pop",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=BubbleWrap",
+    topics: ["sensory"],
+    gameType: "bubbleWrap",
+  },
+  {
+    id: 108,
+    type: "game",
+    title: "Pour the Water",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=WaterPour",
+    topics: ["sensory", "colors"],
+    gameType: "waterPour",
+  },
+  {
+    id: 109,
+    type: "game",
+    title: "Fidget Spinner",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Fidget",
+    topics: ["sensory"],
+    gameType: "fidget",
+  },
+  {
+    id: 110,
+    type: "game",
+    title: "Marble Run",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=MarbleRun",
+    topics: ["sensory", "colors"],
+    gameType: "marbleRun",
+  },
+
+  // SPEECH & LANGUAGE GAMES
+  {
+    id: 200,
+    type: "game",
+    title: "Animal Names & Sounds",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Animals",
+    topics: ["speech", "animals"],
+    gameType: "animalSounds",
+  },
+  {
+    id: 201,
+    type: "game",
+    title: "Explore Feelings",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Feelings",
+    topics: ["speech", "feelings"],
+    gameType: "feelings",
+  },
+  {
+    id: 202,
+    type: "game",
+    title: "Word Repetition",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=WordRepeat",
+    topics: ["speech", "letters"],
+    gameType: "wordRepeat",
+  },
+  {
+    id: 203,
+    type: "game",
+    title: "Copy the Move",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=CopyMove",
+    topics: ["speech", "movement"],
+    gameType: "copyMove",
+  },
+  {
+    id: 204,
+    type: "game",
+    title: "Build Sentences",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Sentences",
+    topics: ["speech", "letters"],
+    gameType: "sentenceBuilder",
+  },
+  {
+    id: 205,
+    type: "game",
+    title: "Rhyme Time",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=RhymeTime",
+    topics: ["speech", "music"],
+    gameType: "rhymeTime",
+  },
+  {
+    id: 206,
+    type: "game",
+    title: "Nature Explorer",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=Nature",
+    topics: ["speech", "nature"],
+    gameType: "natureExplore",
+  },
+  {
+    id: 207,
+    type: "game",
+    title: "Jump & Count",
+    thumbnail: "/placeholder.svg?height=300&width=200&text=JumpCount",
+    topics: ["speech", "movement", "numbers"],
+    gameType: "jumpCount",
+  },
+];
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+export function getReelsByTopic(topic: string): Reel[] {
+  if (topic === "all") return REELS_DATA;
+  return REELS_DATA.filter((r) => r.topics.includes(topic as ReelTopic));
+}
+
+export function getReelsByType(type: ReelType): Reel[] {
+  return REELS_DATA.filter((r) => r.type === type);
+}
+
+export function getTopics(): string[] {
+  return [
+    "all",
+    "numbers",
+    "letters",
+    "colors",
+    "shapes",
+    "patterns",
+    "sensory",
+    "speech",
+    "feelings",
+    "animals",
+    "nature",
+    "movement",
+    "music",
+  ];
+}


### PR DESCRIPTION
## Summary
- Port SchoolTube reels-based UI framework from NickOS: ReelsFeed, ReelCard, TopicFilter, DailyActivityBanner, GamePlayer, PinDialog
- Expand AAC system with AACHome category browser (18 categories), AACKeyboard with word prediction, AACEncouragement milestone celebrations
- New /talk page with For You / All / Browse modes and always-visible safety phrases bar
- New /category/[id] detail pages for browsing phrases by category
- Games page updated to full SchoolTube layout with cyan gradient and reels grid

## Test plan
- [ ] Navigate to /games — verify SchoolTube layout renders with topic filter chips, daily banner, and reel cards
- [ ] Tap a game card — verify GamePlayer opens for available games (AnimalSounds, WordRepeat, RhymeTime, Feelings)
- [ ] Tap a video card — verify it opens YouTube link in new tab
- [ ] Use topic filters — verify grid filters correctly by topic
- [ ] Navigate to /talk — verify three view modes work (For You, All, Browse)
- [ ] Tap safety phrases in talk page — verify they speak via Web Speech API
- [ ] Navigate to /talk Browse mode — tap a category — verify /category/[id] loads with phrase grid
- [ ] Tap phrases in category view — verify they speak and build sentence strip

Generated with [Claude Code](https://claude.com/claude-code)