### PR TITLE
feat: port lock screen, toolshed, timer, intuition, VSD, add card (#63)

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,0 +1,329 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useState, useRef, useCallback, useEffect, Suspense } from 'react';
+
+/**
+ * Add Card — ARASAAC search + create card flow.
+ * Simplified v1: ARASAAC symbol search + upload, no camera.
+ * No Convex dependency — saves to localStorage for now.
+ */
+
+const PRIMARY = '#E8610A';
+
+interface ArasaacSymbol {
+  _id: number;
+  keywords: { keyword: string }[];
+}
+
+interface SavedCard {
+  id: string;
+  label: string;
+  imageUrl: string | null;
+  arasaacId: number | null;
+  category: string;
+  createdAt: number;
+}
+
+function AddPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const category = searchParams.get('category') || 'general';
+
+  const [label, setLabel] = useState('');
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [arasaacId, setArasaacId] = useState<number | null>(null);
+  const [arasaacSearch, setArasaacSearch] = useState('');
+  const [arasaacResults, setArasaacResults] = useState<ArasaacSymbol[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [showArasaacSearch, setShowArasaacSearch] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // ARASAAC search
+  const searchArasaac = useCallback(async (query: string) => {
+    if (!query.trim()) { setArasaacResults([]); return; }
+    setIsSearching(true);
+    try {
+      const res = await fetch(`https://api.arasaac.org/api/pictograms/en/search/${encodeURIComponent(query)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setArasaacResults(data.slice(0, 20));
+      } else {
+        setArasaacResults([]);
+      }
+    } catch {
+      setArasaacResults([]);
+    }
+    setIsSearching(false);
+  }, []);
+
+  // Debounced search
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (arasaacSearch) searchArasaac(arasaacSearch);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [arasaacSearch, searchArasaac]);
+
+  // File upload
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        setImageUrl(ev.target?.result as string);
+        setArasaacId(null);
+        setShowArasaacSearch(false);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  // Select ARASAAC symbol
+  const selectSymbol = (symbolId: number) => {
+    setImageUrl(`https://static.arasaac.org/pictograms/${symbolId}/${symbolId}_500.png`);
+    setArasaacId(symbolId);
+    setShowArasaacSearch(false);
+  };
+
+  // Save card to localStorage
+  const handleSave = useCallback(() => {
+    if (!label.trim() || isSaving) return;
+    setIsSaving(true);
+
+    const card: SavedCard = {
+      id: crypto.randomUUID(),
+      label: label.trim(),
+      imageUrl,
+      arasaacId,
+      category,
+      createdAt: Date.now(),
+    };
+
+    try {
+      const existing = JSON.parse(localStorage.getItem('8gentjr-custom-cards') || '[]');
+      existing.push(card);
+      localStorage.setItem('8gentjr-custom-cards', JSON.stringify(existing));
+      router.back();
+    } catch (err) {
+      console.error('[8gent Jr] Failed to save card:', err);
+      setIsSaving(false);
+    }
+  }, [label, imageUrl, arasaacId, category, isSaving, router]);
+
+  return (
+    <div className="min-h-screen flex flex-col" style={{ backgroundColor: '#ECEFF1' }}>
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 relative" style={{ backgroundColor: PRIMARY }}>
+        <button onClick={() => router.back()} className="flex items-center gap-0.5 text-white font-medium text-lg">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          <span>Cancel</span>
+        </button>
+        <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-white font-semibold text-xl">
+          Add Card
+        </span>
+        <button
+          onClick={handleSave}
+          disabled={!label.trim() || isSaving}
+          className={`text-white font-medium text-lg ${(!label.trim() || isSaving) ? 'opacity-50' : ''}`}
+        >
+          {isSaving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4 pb-32">
+        {/* Category */}
+        <div className="bg-green-50 border border-green-200 rounded-lg px-4 py-3">
+          <span className="text-green-700 text-sm">Adding to: <strong>{category}</strong></span>
+        </div>
+
+        {/* Image Section */}
+        <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+          <div className="px-4 py-3 border-b border-gray-100">
+            <span className="font-medium text-gray-900">Image</span>
+          </div>
+
+          <div className="p-4">
+            <div className="w-32 h-32 mx-auto bg-gray-100 rounded-lg flex items-center justify-center overflow-hidden">
+              {imageUrl ? (
+                <div className="relative w-full h-full">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={imageUrl} alt="Preview" className="w-full h-full object-contain" />
+                  <button
+                    onClick={() => { setImageUrl(null); setArasaacId(null); }}
+                    className="absolute top-1 right-1 w-6 h-6 bg-red-500 text-white rounded-full flex items-center justify-center text-xs font-bold"
+                  >
+                    X
+                  </button>
+                </div>
+              ) : (
+                <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="#ccc" strokeWidth="1.5">
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                  <circle cx="12" cy="7" r="4" />
+                </svg>
+              )}
+            </div>
+          </div>
+
+          {/* Image source buttons */}
+          <div className="px-4 pb-4 grid grid-cols-2 gap-2">
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="flex flex-col items-center gap-1 py-3 bg-gray-100 rounded-lg active:bg-gray-200"
+            >
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#666" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                <circle cx="8.5" cy="8.5" r="1.5" />
+                <polyline points="21 15 16 10 5 21" />
+              </svg>
+              <span className="text-xs text-gray-600">Gallery</span>
+            </button>
+            <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleFileChange} />
+
+            <button
+              onClick={() => setShowArasaacSearch(!showArasaacSearch)}
+              className={`flex flex-col items-center gap-1 py-3 rounded-lg active:bg-gray-200 ${showArasaacSearch ? 'bg-green-100' : 'bg-gray-100'}`}
+            >
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#666" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+              <span className="text-xs text-gray-600">Symbols</span>
+            </button>
+          </div>
+
+          {/* ARASAAC search panel */}
+          {showArasaacSearch && (
+            <div className="px-4 pb-4 border-t border-gray-100">
+              <div className="relative mt-3">
+                <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="11" cy="11" r="8" />
+                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                </svg>
+                <input
+                  type="text"
+                  value={arasaacSearch}
+                  onChange={(e) => setArasaacSearch(e.target.value)}
+                  placeholder="Search ARASAAC symbols..."
+                  className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-green-500"
+                />
+              </div>
+
+              {isSearching && <div className="text-center py-4 text-gray-500">Searching...</div>}
+
+              {!isSearching && arasaacResults.length > 0 && (
+                <div className="mt-3 grid grid-cols-4 gap-2 max-h-48 overflow-y-auto">
+                  {arasaacResults.map((symbol) => (
+                    <button
+                      key={symbol._id}
+                      onClick={() => selectSymbol(symbol._id)}
+                      className="aspect-square bg-white border border-gray-200 rounded-lg overflow-hidden hover:border-green-500 active:border-green-600"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={`https://static.arasaac.org/pictograms/${symbol._id}/${symbol._id}_300.png`}
+                        alt={symbol.keywords[0]?.keyword || 'Symbol'}
+                        className="w-full h-full object-contain p-1"
+                      />
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {!isSearching && arasaacSearch && arasaacResults.length === 0 && (
+                <div className="text-center py-4 text-gray-500 text-sm">
+                  No symbols found. Try a different search term.
+                </div>
+              )}
+
+              <div className="mt-2 text-center text-xs text-gray-400">
+                Symbols from ARASAAC (CC BY-NC-SA)
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Label */}
+        <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+          <div className="px-4 py-3 border-b border-gray-100">
+            <span className="font-medium text-gray-900">Label</span>
+          </div>
+          <div className="p-4">
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Enter word or phrase"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:border-green-500 text-lg"
+              autoFocus
+            />
+            <p className="mt-2 text-sm text-gray-500">This is what will be spoken when tapped</p>
+          </div>
+        </div>
+
+        {/* Preview */}
+        {label && (
+          <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+            <div className="px-4 py-3 border-b border-gray-100">
+              <span className="font-medium text-gray-900">Preview</span>
+            </div>
+            <div className="p-4 flex justify-center">
+              <div className="w-24 bg-white rounded-md shadow-md flex flex-col items-center" style={{ aspectRatio: '1 / 1.1' }}>
+                <div className="flex-1 w-full p-2 flex items-center justify-center">
+                  {imageUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={imageUrl} alt={label} className="max-w-full max-h-full object-contain" />
+                  ) : (
+                    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="#ccc" strokeWidth="1.5">
+                      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                      <circle cx="12" cy="7" r="4" />
+                    </svg>
+                  )}
+                </div>
+                <div className="w-full px-1 pb-2">
+                  <span className="block text-center text-sm font-medium text-gray-900 truncate">{label}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Bottom save button */}
+      <div className="fixed bottom-20 left-0 right-0 p-4 bg-white border-t border-gray-200">
+        <button
+          onClick={handleSave}
+          disabled={!label.trim() || isSaving}
+          className={`w-full py-4 rounded-lg font-semibold text-lg flex items-center justify-center gap-2 ${
+            label.trim() && !isSaving ? 'text-white active:opacity-80' : 'bg-gray-200 text-gray-400'
+          }`}
+          style={label.trim() && !isSaving ? { backgroundColor: PRIMARY } : undefined}
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+          {isSaving ? 'Saving...' : 'Save Card'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function AddPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center" style={{ backgroundColor: '#ECEFF1' }}>
+          <div className="text-gray-500">Loading...</div>
+        </div>
+      }
+    >
+      <AddPageContent />
+    </Suspense>
+  );
+}

--- a/src/app/intuition/page.tsx
+++ b/src/app/intuition/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useCallback } from 'react';
+import { speak } from '@/lib/tts';
+
+/**
+ * Intuition Game — color card pattern recognition with scoring.
+ * Pick which color you "feel" — tracks score, streak, and accuracy.
+ * CSS-only (no Framer Motion).
+ */
+
+const COLORS = [
+  { name: 'red', hex: '#F44336' },
+  { name: 'blue', hex: '#2196F3' },
+  { name: 'green', hex: '#4CAF50' },
+  { name: 'yellow', hex: '#FFC107' },
+];
+
+const PRIMARY = '#E8610A';
+
+interface GameState {
+  targetColor: number;
+  score: number;
+  streak: number;
+  totalGuesses: number;
+  correctGuesses: number;
+  lastResult: 'correct' | 'wrong' | null;
+  isRevealing: boolean;
+}
+
+export default function IntuitionPage() {
+  const router = useRouter();
+  const [game, setGame] = useState<GameState>({
+    targetColor: Math.floor(Math.random() * 4),
+    score: 0,
+    streak: 0,
+    totalGuesses: 0,
+    correctGuesses: 0,
+    lastResult: null,
+    isRevealing: false,
+  });
+  const [showCelebration, setShowCelebration] = useState(false);
+
+  const pickNewTarget = useCallback(() => {
+    setGame((prev) => ({
+      ...prev,
+      targetColor: Math.floor(Math.random() * 4),
+      isRevealing: false,
+      lastResult: null,
+    }));
+  }, []);
+
+  const handleGuess = useCallback(
+    (colorIndex: number) => {
+      if (game.isRevealing) return;
+
+      const isCorrect = colorIndex === game.targetColor;
+
+      if (navigator.vibrate) {
+        navigator.vibrate(isCorrect ? [50, 50, 50] : 100);
+      }
+
+      if (isCorrect) {
+        const phrases = ['Great job!', 'You got it!', 'Amazing!', 'Correct!'];
+        speak({ text: phrases[Math.floor(Math.random() * phrases.length)] });
+      }
+
+      setGame((prev) => ({
+        ...prev,
+        score: isCorrect ? prev.score + 10 * (prev.streak + 1) : prev.score,
+        streak: isCorrect ? prev.streak + 1 : 0,
+        totalGuesses: prev.totalGuesses + 1,
+        correctGuesses: isCorrect ? prev.correctGuesses + 1 : prev.correctGuesses,
+        lastResult: isCorrect ? 'correct' : 'wrong',
+        isRevealing: true,
+      }));
+
+      if (isCorrect && game.streak + 1 >= 3) {
+        setShowCelebration(true);
+        setTimeout(() => setShowCelebration(false), 1500);
+      }
+
+      setTimeout(pickNewTarget, 1500);
+    },
+    [game.targetColor, game.streak, game.isRevealing, pickNewTarget],
+  );
+
+  const resetGame = useCallback(() => {
+    setGame({
+      targetColor: Math.floor(Math.random() * 4),
+      score: 0,
+      streak: 0,
+      totalGuesses: 0,
+      correctGuesses: 0,
+      lastResult: null,
+      isRevealing: false,
+    });
+  }, []);
+
+  const accuracy =
+    game.totalGuesses > 0 ? Math.round((game.correctGuesses / game.totalGuesses) * 100) : 0;
+
+  return (
+    <div className="min-h-screen flex flex-col pb-24" style={{ backgroundColor: '#ECEFF1' }}>
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 relative" style={{ backgroundColor: PRIMARY }}>
+        <button
+          onClick={() => router.push('/')}
+          className="flex items-center gap-0.5 text-white font-medium text-lg"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          <span>Home</span>
+        </button>
+
+        <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-white font-semibold text-xl">
+          Intuition
+        </span>
+
+        <button onClick={resetGame} className="text-white p-2">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="23 4 23 10 17 10" />
+            <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Score Bar */}
+      <div className="bg-white shadow-sm px-6 py-4 flex justify-between items-center">
+        <div className="text-center">
+          <div className="text-3xl font-bold" style={{ color: PRIMARY }}>{game.score}</div>
+          <div className="text-sm text-gray-500">Score</div>
+        </div>
+        <div className="text-center">
+          <div className="text-3xl font-bold text-orange-500">{game.streak}🔥</div>
+          <div className="text-sm text-gray-500">Streak</div>
+        </div>
+        <div className="text-center">
+          <div className="text-3xl font-bold text-blue-500">{accuracy}%</div>
+          <div className="text-sm text-gray-500">Accuracy</div>
+        </div>
+      </div>
+
+      {/* Game Area */}
+      <div className="flex-1 flex flex-col items-center justify-center p-6 relative">
+        {/* Celebration */}
+        {showCelebration && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
+            <span className="text-8xl animate-celebration">🎉</span>
+          </div>
+        )}
+
+        {/* Instructions */}
+        <div className={`text-center mb-8 transition-transform ${game.isRevealing ? 'scale-110' : ''}`}>
+          <h2 className="text-2xl font-semibold text-gray-700 mb-2">
+            {game.isRevealing
+              ? game.lastResult === 'correct'
+                ? 'You got it!'
+                : `It was ${COLORS[game.targetColor].name}`
+              : 'Which color do you feel?'}
+          </h2>
+          <p className="text-gray-500">Trust your intuition!</p>
+        </div>
+
+        {/* Color Cards */}
+        <div className="grid grid-cols-2 gap-4 w-full max-w-sm">
+          {COLORS.map((color, index) => (
+            <button
+              key={color.name}
+              onClick={() => handleGuess(index)}
+              disabled={game.isRevealing}
+              className={`
+                aspect-square rounded-3xl shadow-lg relative overflow-hidden
+                active:scale-95 transition-all
+                ${game.isRevealing && index === game.targetColor ? 'ring-4 ring-white scale-105' : ''}
+              `}
+              style={{ backgroundColor: color.hex }}
+            >
+              {game.isRevealing && game.lastResult === 'wrong' && index !== game.targetColor && (
+                <div className="absolute inset-0 bg-black/30 rounded-3xl" />
+              )}
+            </button>
+          ))}
+        </div>
+
+        {/* Stats */}
+        <div className="mt-8 text-center text-gray-500">
+          <p>{game.totalGuesses} guesses · {game.correctGuesses} correct</p>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes celebration {
+          0%   { transform: scale(1) rotate(0deg); }
+          25%  { transform: scale(1.5) rotate(10deg); }
+          50%  { transform: scale(1.5) rotate(-10deg); }
+          100% { transform: scale(1) rotate(0deg); }
+        }
+        .animate-celebration { animation: celebration 0.5s ease-in-out; }
+      `}</style>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import { Providers } from './providers';
 import { OfflineBanner } from '../components/OfflineBanner';
 import Dock from '../components/Dock';
+import { LockScreenGate } from '../components/LockScreenGate';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -51,9 +52,11 @@ export default function RootLayout({
     <html lang="en" className={`${inter.variable} ${fraunces.variable}`} data-theme="light">
       <body className="antialiased">
         <Providers>
-          <OfflineBanner />
-          <main className="pb-safe-dock">{children}</main>
-          <Dock />
+          <LockScreenGate>
+            <OfflineBanner />
+            <main className="pb-safe-dock">{children}</main>
+            <Dock />
+          </LockScreenGate>
         </Providers>
       </body>
     </html>

--- a/src/app/timer/page.tsx
+++ b/src/app/timer/page.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { speak } from '@/lib/tts';
+
+/**
+ * Bubble Timer — visual countdown with presets (1, 2, 5, 10 min),
+ * progress circle, and completion celebration.
+ * CSS-only animations (no Framer Motion).
+ */
+
+const PRESETS = [
+  { label: '1 min', seconds: 60 },
+  { label: '2 min', seconds: 120 },
+  { label: '5 min', seconds: 300 },
+  { label: '10 min', seconds: 600 },
+];
+
+const PRIMARY = '#E8610A';
+
+interface Bubble {
+  id: number;
+  x: number;
+  size: number;
+  duration: number;
+}
+
+export default function TimerPage() {
+  const router = useRouter();
+  const [selectedPreset, setSelectedPreset] = useState(0);
+  const [timeRemaining, setTimeRemaining] = useState(PRESETS[0].seconds);
+  const [isRunning, setIsRunning] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const [bubbles, setBubbles] = useState<Bubble[]>([]);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const bubbleId = useRef(0);
+
+  const totalTime = PRESETS[selectedPreset].seconds;
+
+  // Bubbles while running
+  useEffect(() => {
+    if (!isRunning) return;
+    const bi = setInterval(() => {
+      setBubbles((prev) => [
+        ...prev.slice(-20),
+        {
+          id: bubbleId.current++,
+          x: Math.random() * 80 + 10,
+          size: Math.random() * 40 + 20,
+          duration: Math.random() * 2 + 3,
+        },
+      ]);
+    }, 500);
+    return () => clearInterval(bi);
+  }, [isRunning]);
+
+  // Timer countdown
+  useEffect(() => {
+    if (isRunning && timeRemaining > 0) {
+      intervalRef.current = setInterval(() => {
+        setTimeRemaining((prev) => {
+          if (prev <= 1) {
+            setIsRunning(false);
+            setIsComplete(true);
+            if (navigator.vibrate) navigator.vibrate([200, 100, 200]);
+            speak({ text: 'Time is up!' });
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [isRunning]);
+
+  const handleStart = useCallback(() => {
+    if (isComplete) {
+      setTimeRemaining(totalTime);
+      setIsComplete(false);
+    }
+    setIsRunning(true);
+  }, [isComplete, totalTime]);
+
+  const handlePause = useCallback(() => setIsRunning(false), []);
+
+  const handleReset = useCallback(() => {
+    setIsRunning(false);
+    setIsComplete(false);
+    setTimeRemaining(totalTime);
+    setBubbles([]);
+  }, [totalTime]);
+
+  const handlePresetChange = useCallback((i: number) => {
+    setSelectedPreset(i);
+    setTimeRemaining(PRESETS[i].seconds);
+    setIsRunning(false);
+    setIsComplete(false);
+    setBubbles([]);
+  }, []);
+
+  const formatTime = (s: number) => {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return `${m}:${sec.toString().padStart(2, '0')}`;
+  };
+
+  const progress = ((totalTime - timeRemaining) / totalTime) * 100;
+  const circumference = 2 * Math.PI * 140;
+
+  return (
+    <div className="min-h-screen flex flex-col pb-24" style={{ backgroundColor: '#ECEFF1' }}>
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 relative" style={{ backgroundColor: PRIMARY }}>
+        <button
+          onClick={() => router.push('/')}
+          className="flex items-center gap-0.5 text-white font-medium text-lg"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          <span>Home</span>
+        </button>
+        <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-white font-semibold text-xl">
+          Timer
+        </span>
+        <div className="w-12" />
+      </div>
+
+      {/* Timer Display */}
+      <div className="flex-1 flex flex-col items-center justify-center p-8 relative overflow-hidden">
+        {/* Bubbles */}
+        {bubbles.map((b) => (
+          <div
+            key={b.id}
+            className="absolute rounded-full animate-bubble-rise"
+            style={{
+              left: `${b.x}%`,
+              width: b.size,
+              height: b.size,
+              backgroundColor: `${PRIMARY}40`,
+              border: `2px solid ${PRIMARY}60`,
+              animationDuration: `${b.duration}s`,
+            }}
+          />
+        ))}
+
+        {/* Progress Circle */}
+        <div className="relative w-80 h-80">
+          <svg className="w-full h-full -rotate-90" viewBox="0 0 320 320">
+            <circle cx="160" cy="160" r="140" fill="none" stroke="#E0E0E0" strokeWidth="16" />
+            <circle
+              cx="160"
+              cy="160"
+              r="140"
+              fill="none"
+              stroke={isComplete ? '#4CAF50' : PRIMARY}
+              strokeWidth="16"
+              strokeLinecap="round"
+              strokeDasharray={circumference}
+              strokeDashoffset={circumference - (progress / 100) * circumference}
+              className="transition-[stroke-dashoffset] duration-500"
+            />
+          </svg>
+
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span
+              className={`text-6xl font-bold transition-transform ${isComplete ? 'scale-110' : ''}`}
+              style={{ color: isComplete ? '#4CAF50' : PRIMARY }}
+            >
+              {formatTime(timeRemaining)}
+            </span>
+            {isComplete && (
+              <span className="text-2xl font-medium text-green-600 mt-2 animate-fade-in-up">
+                Done!
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Presets */}
+        <div className="flex gap-3 mt-8">
+          {PRESETS.map((preset, i) => (
+            <button
+              key={preset.label}
+              onClick={() => handlePresetChange(i)}
+              disabled={isRunning}
+              className="px-5 py-3 rounded-full text-lg font-medium transition-colors active:scale-95"
+              style={{
+                backgroundColor: selectedPreset === i ? PRIMARY : 'white',
+                color: selectedPreset === i ? 'white' : '#666',
+                boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+              }}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Controls */}
+        <div className="flex gap-4 mt-8">
+          <button
+            onClick={handleReset}
+            className="w-16 h-16 rounded-full bg-white shadow-lg flex items-center justify-center active:scale-90 transition-transform"
+          >
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#666" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="1 4 1 10 7 10" />
+              <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+            </svg>
+          </button>
+
+          <button
+            onClick={isRunning ? handlePause : handleStart}
+            className="w-24 h-24 rounded-full shadow-xl flex items-center justify-center text-white active:scale-90 transition-transform"
+            style={{ backgroundColor: PRIMARY }}
+          >
+            {isRunning ? (
+              <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
+                <rect x="6" y="4" width="4" height="16" rx="1" />
+                <rect x="14" y="4" width="4" height="16" rx="1" />
+              </svg>
+            ) : (
+              <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
+                <polygon points="5 3 19 12 5 21 5 3" />
+              </svg>
+            )}
+          </button>
+
+          <div className="w-16 h-16" />
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes bubbleRise {
+          from { bottom: -50px; transform: scale(0); }
+          to   { bottom: 100%; transform: scale(1); }
+        }
+        @keyframes fadeInUp {
+          from { opacity: 0; transform: translateY(10px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .animate-bubble-rise { animation: bubbleRise linear forwards; bottom: -50px; }
+        .animate-fade-in-up { animation: fadeInUp 0.3s ease-out forwards; }
+      `}</style>
+    </div>
+  );
+}

--- a/src/app/toolshed/page.tsx
+++ b/src/app/toolshed/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { Toolshed } from '@/components/Toolshed';
+
+export default function ToolshedPage() {
+  return <Toolshed />;
+}

--- a/src/app/vsd/page.tsx
+++ b/src/app/vsd/page.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { speak } from '@/lib/tts';
+import type { VisualScene, Hotspot } from '@/lib/vsd/types';
+import { DEFAULT_SCENES } from '@/lib/vsd/scenes';
+
+/**
+ * Visual Scene Display — scene-based vocabulary.
+ * Tap hotspots on scene images to hear gestalt phrases.
+ * CSS-only (no Framer Motion).
+ */
+
+const SCENE_GRADIENTS: Record<string, string> = {
+  kitchen: 'from-amber-200 via-orange-100 to-yellow-50',
+  playground: 'from-sky-300 via-green-200 to-emerald-100',
+  bedroom: 'from-indigo-200 via-purple-100 to-blue-50',
+  school: 'from-yellow-200 via-amber-100 to-orange-50',
+  park: 'from-green-300 via-lime-200 to-emerald-100',
+};
+
+const SCENE_ICONS: Record<string, string> = {
+  kitchen: '🍳',
+  playground: '🛝',
+  bedroom: '🛏️',
+  school: '🏫',
+  park: '🌳',
+};
+
+export default function VSDPage() {
+  const router = useRouter();
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [activeHotspot, setActiveHotspot] = useState<string | null>(null);
+  const [imgLoaded, setImgLoaded] = useState<Record<string, boolean>>({});
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scenes = DEFAULT_SCENES;
+  const scene = scenes[activeIndex];
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleHotspotTap = useCallback(async (hotspot: Hotspot) => {
+    setActiveHotspot(hotspot.id);
+
+    if (hotspot.audioUrl) {
+      try {
+        const audio = new Audio(hotspot.audioUrl);
+        audio.onended = () => {
+          timeoutRef.current = setTimeout(() => setActiveHotspot(null), 400);
+        };
+        await audio.play();
+        return;
+      } catch { /* fall through to TTS */ }
+    }
+
+    await speak({ text: hotspot.phrase });
+    timeoutRef.current = setTimeout(() => setActiveHotspot(null), 400);
+  }, []);
+
+  const goNext = useCallback(() => {
+    setActiveHotspot(null);
+    setActiveIndex((i) => (i + 1) % scenes.length);
+  }, [scenes.length]);
+
+  const goPrev = useCallback(() => {
+    setActiveHotspot(null);
+    setActiveIndex((i) => (i - 1 + scenes.length) % scenes.length);
+  }, [scenes.length]);
+
+  const hasImage = imgLoaded[scene.id] === true;
+  const gradient = SCENE_GRADIENTS[scene.id] ?? 'from-slate-300 via-slate-200 to-slate-100';
+
+  return (
+    <div className="flex flex-col h-full min-h-screen bg-gray-900 pb-24">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 pt-4 pb-2">
+        <button
+          onClick={() => router.push('/')}
+          className="flex items-center gap-1 text-white/80 hover:text-white active:scale-95 transition-transform"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          <span className="text-lg font-medium">Back</span>
+        </button>
+
+        <h1 className="text-white text-xl font-bold flex items-center gap-2">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-60">
+            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+            <path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07" />
+          </svg>
+          {scene.title}
+        </h1>
+
+        <div className="flex items-center gap-1">
+          <button onClick={goPrev} className="p-2 text-white/60 hover:text-white active:scale-90 transition-transform" aria-label="Previous scene">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+          <span className="text-white/40 text-sm font-medium tabular-nums">
+            {activeIndex + 1}/{scenes.length}
+          </span>
+          <button onClick={goNext} className="p-2 text-white/60 hover:text-white active:scale-90 transition-transform" aria-label="Next scene">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Scene Area */}
+      <div className="flex-1 px-4 pb-2">
+        <div className="relative w-full h-full rounded-3xl overflow-hidden shadow-2xl min-h-[300px]">
+          {/* Background */}
+          {hasImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={scene.imageUrl} alt={scene.title} className="absolute inset-0 w-full h-full object-cover" />
+          ) : (
+            <div className={`absolute inset-0 bg-gradient-to-br ${gradient}`}>
+              <div className="absolute inset-0 flex items-center justify-center opacity-20">
+                <span className="text-[120px]">{SCENE_ICONS[scene.id] ?? '📷'}</span>
+              </div>
+            </div>
+          )}
+
+          {/* Hidden img to detect load */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={scene.imageUrl}
+            alt=""
+            className="hidden"
+            onLoad={() => setImgLoaded((prev) => ({ ...prev, [scene.id]: true }))}
+            onError={() => setImgLoaded((prev) => ({ ...prev, [scene.id]: false }))}
+          />
+
+          {/* Hotspots */}
+          {scene.hotspots.map((hotspot) => {
+            const isActive = activeHotspot === hotspot.id;
+            return (
+              <button
+                key={hotspot.id}
+                onClick={() => handleHotspotTap(hotspot)}
+                className={`
+                  absolute rounded-2xl border-4 transition-all
+                  flex items-center justify-center
+                  focus:outline-none focus-visible:ring-4 focus-visible:ring-white
+                  ${isActive
+                    ? 'border-white bg-white/40 shadow-lg shadow-white/30'
+                    : 'border-white/50 bg-white/15 hover:bg-white/30 hover:border-white/80'
+                  }
+                `}
+                style={{
+                  left: `${hotspot.x}%`,
+                  top: `${hotspot.y}%`,
+                  width: `${hotspot.width}%`,
+                  height: `${hotspot.height}%`,
+                }}
+                aria-label={hotspot.phrase}
+              >
+                {isActive && (
+                  <div className="absolute -bottom-10 left-1/2 -translate-x-1/2 whitespace-nowrap bg-white text-gray-900 font-bold text-base px-4 py-2 rounded-xl shadow-lg pointer-events-none z-10 animate-fade-in-up">
+                    {hotspot.phrase}
+                  </div>
+                )}
+                <span className={`text-white font-semibold text-sm drop-shadow-md text-center px-1 leading-tight select-none pointer-events-none ${isActive ? 'opacity-0' : 'opacity-90'}`}>
+                  {hotspot.phrase}
+                </span>
+              </button>
+            );
+          })}
+
+          {/* Instruction hint */}
+          {activeHotspot === null && (
+            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-black/50 text-white text-sm font-medium px-4 py-2 rounded-full backdrop-blur-sm animate-hint">
+              Tap a spot to hear a phrase
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Scene Picker */}
+      <div className="flex items-center gap-3 overflow-x-auto px-4 py-3" style={{ scrollbarWidth: 'none' }}>
+        {scenes.map((s, i) => (
+          <button
+            key={s.id}
+            onClick={() => { setActiveHotspot(null); setActiveIndex(i); }}
+            className={`
+              flex-shrink-0 flex items-center gap-2 px-5 py-3 rounded-2xl font-bold text-base transition-colors active:scale-95
+              ${i === activeIndex ? 'bg-white text-gray-900 shadow-lg' : 'bg-white/20 text-white hover:bg-white/30'}
+            `}
+          >
+            <span className="text-xl">{SCENE_ICONS[s.id] ?? '📷'}</span>
+            {s.title}
+          </button>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes fadeInUp { from { opacity: 0; transform: translate(-50%, 6px); } to { opacity: 1; transform: translate(-50%, 0); } }
+        @keyframes hint { from { opacity: 0; } to { opacity: 1; } }
+        .animate-fade-in-up { animation: fadeInUp 0.2s ease-out forwards; }
+        .animate-hint { animation: hint 0.5s ease-out 1.5s both; }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/Dock.tsx
+++ b/src/components/Dock.tsx
@@ -120,11 +120,65 @@ function IconFlask({ color }: { color: string }) {
   );
 }
 
+function IconTimer({ color }: { color: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="13" r="8" />
+      <path d="M12 9v4l2 2" />
+      <path d="M5 3L2 6" />
+      <path d="M22 6l-3-3" />
+      <path d="M12 5V3" />
+      <path d="M10 3h4" />
+    </svg>
+  );
+}
+
+function IconToolshed({ color }: { color: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+    </svg>
+  );
+}
+
+function IconBrain({ color }: { color: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 2a7 7 0 0 0-7 7c0 3 2 5.5 5 7v4h4v-4c3-1.5 5-4 5-7a7 7 0 0 0-7-7z" />
+    </svg>
+  );
+}
+
+function IconImage({ color }: { color: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+      <circle cx="8.5" cy="8.5" r="1.5" />
+      <polyline points="21 15 16 10 5 21" />
+    </svg>
+  );
+}
+
+function IconPlus({ color }: { color: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
 const MORE_ITEMS: MoreItem[] = [
   { id: 'draw', label: 'Draw', icon: IconPalette, href: '/draw' },
   { id: 'schedule', label: 'Schedule', icon: IconClock, href: '/schedule' },
   { id: 'stories', label: 'Stories', icon: IconBook, href: '/stories' },
   { id: 'science', label: 'Science', icon: IconFlask, href: '/science' },
+  { id: 'timer', label: 'Timer', icon: IconTimer, href: '/timer' },
+  { id: 'toolshed', label: 'Toolshed', icon: IconToolshed, href: '/toolshed' },
+  { id: 'intuition', label: 'Intuition', icon: IconBrain, href: '/intuition' },
+  { id: 'vsd', label: 'Scenes', icon: IconImage, href: '/vsd' },
+  { id: 'add', label: 'Add Card', icon: IconPlus, href: '/add' },
 ];
 
 const DOCK_ITEMS: DockItem[] = [

--- a/src/components/LockScreen.tsx
+++ b/src/components/LockScreen.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+/**
+ * Lock Screen — tap-to-unlock overlay.
+ * Simplified port from NickOS (no Framer Motion, CSS transitions only).
+ */
+
+interface LockScreenProps {
+  onUnlock: () => void;
+  childName?: string;
+}
+
+export function LockScreen({ onUnlock, childName = 'Friend' }: LockScreenProps) {
+  const [currentTime, setCurrentTime] = useState(new Date());
+  const [unlocking, setUnlocking] = useState(false);
+  const hasUnlockedRef = useRef(false);
+
+  // Update time every minute
+  useEffect(() => {
+    const interval = setInterval(() => setCurrentTime(new Date()), 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleUnlock = useCallback(() => {
+    if (hasUnlockedRef.current) return;
+    hasUnlockedRef.current = true;
+    setUnlocking(true);
+    setTimeout(onUnlock, 350);
+  }, [onUnlock]);
+
+  // Keyboard support
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'Escape') {
+        e.preventDefault();
+        handleUnlock();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [handleUnlock]);
+
+  const formatTime = (d: Date) =>
+    d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+
+  const formatDate = (d: Date) =>
+    d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+
+  return (
+    <div
+      className={`
+        fixed inset-0 z-[60] flex flex-col items-center justify-between
+        bg-gradient-to-b from-blue-600 via-teal-500 to-green-500
+        overflow-hidden cursor-pointer select-none
+        transition-all duration-300
+        ${unlocking ? 'opacity-0 scale-95' : 'opacity-100 scale-100'}
+      `}
+      onClick={handleUnlock}
+      onTouchEnd={handleUnlock}
+      tabIndex={0}
+      role="button"
+      aria-label="Tap anywhere to unlock"
+    >
+      {/* Background decoration */}
+      <div className="absolute inset-0 opacity-20 pointer-events-none">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(255,255,255,0.1)_0%,transparent_50%)]" />
+        <div className="absolute top-20 left-10 w-32 h-32 rounded-full bg-white/10 animate-float" />
+        <div className="absolute bottom-40 right-10 w-24 h-24 rounded-full bg-white/10 animate-float-delayed" />
+      </div>
+
+      {/* Top — Time */}
+      <div className="flex flex-col items-center pt-16 sm:pt-24 animate-fade-in">
+        <div className="text-white/80 text-lg sm:text-xl font-medium">
+          {formatDate(currentTime)}
+        </div>
+        <div className="text-white text-6xl sm:text-8xl font-bold mt-2">
+          {formatTime(currentTime)}
+        </div>
+      </div>
+
+      {/* Center — Avatar/Greeting */}
+      <div className="flex flex-col items-center animate-fade-in">
+        <div className="w-32 h-32 sm:w-40 sm:h-40 rounded-full bg-white/20 border-4 border-white/30 shadow-2xl flex items-center justify-center">
+          <span className="text-6xl">👋</span>
+        </div>
+        <h1 className="text-white text-3xl sm:text-4xl font-bold mt-4">
+          Hi {childName}!
+        </h1>
+        <p className="text-white/70 text-lg mt-2">Ready to talk?</p>
+      </div>
+
+      {/* Bottom — Hint */}
+      <div className="pb-12 sm:pb-16 flex flex-col items-center">
+        <div className="animate-bounce-slow">
+          <svg className="w-8 h-8 text-white/80" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <polyline points="18 15 12 9 6 15" />
+          </svg>
+          <svg className="w-8 h-8 text-white/60 -mt-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <polyline points="18 15 12 9 6 15" />
+          </svg>
+        </div>
+        <p className="text-white/80 text-xl font-medium mt-2">
+          Tap anywhere to start
+        </p>
+      </div>
+
+      {/* Drag handle */}
+      <div className="absolute top-4 left-1/2 -translate-x-1/2 w-12 h-1.5 bg-white/30 rounded-full" />
+
+      <style>{`
+        @keyframes float {
+          0%, 100% { transform: translateY(0) translateX(0); }
+          50% { transform: translateY(-20px) translateX(10px); }
+        }
+        @keyframes floatDelayed {
+          0%, 100% { transform: translateY(0) translateX(0); }
+          50% { transform: translateY(20px) translateX(-10px); }
+        }
+        @keyframes fadeIn {
+          from { opacity: 0; transform: translateY(-10px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes bounceSlow {
+          0%, 100% { transform: translateY(0); }
+          50% { transform: translateY(-10px); }
+        }
+        .animate-float { animation: float 6s ease-in-out infinite; }
+        .animate-float-delayed { animation: floatDelayed 5s ease-in-out infinite; }
+        .animate-fade-in { animation: fadeIn 0.5s ease-out forwards; }
+        .animate-bounce-slow { animation: bounceSlow 1.5s ease-in-out infinite; }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/LockScreenGate.tsx
+++ b/src/components/LockScreenGate.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import { LockScreen } from './LockScreen';
+
+/**
+ * Wraps the app in a lock screen overlay on first visit per session.
+ * Once unlocked, stays unlocked until the tab is closed.
+ */
+export function LockScreenGate({ children }: { children: ReactNode }) {
+  const [unlocked, setUnlocked] = useState(false);
+
+  return (
+    <>
+      {!unlocked && <LockScreen onUnlock={() => setUnlocked(true)} />}
+      {children}
+    </>
+  );
+}

--- a/src/components/Toolshed.tsx
+++ b/src/components/Toolshed.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  TOOLS,
+  TOOL_CATEGORIES,
+  TOOLSHED_NAME,
+  getToolsByCategory,
+  getTotalStars,
+  type Tool,
+  type ToolCategory,
+} from '@/lib/toolshed';
+
+/**
+ * Toolshed — visual grid of tools with categories, star counts,
+ * and unlock states. CSS-only animations (no Framer Motion).
+ */
+
+export function Toolshed() {
+  const router = useRouter();
+  const [selectedCategory, setSelectedCategory] = useState<ToolCategory | null>(null);
+  const totalStars = getTotalStars();
+
+  const handleToolTap = useCallback(
+    (tool: Tool) => {
+      if (!tool.unlocked) return;
+      router.push(tool.route);
+    },
+    [router],
+  );
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-blue-100 to-purple-100 flex flex-col">
+      {/* Header */}
+      <header className="bg-white/80 backdrop-blur-sm shadow-sm px-4 py-3 flex items-center justify-between">
+        <div className="w-12">
+          {selectedCategory && (
+            <button
+              onClick={() => setSelectedCategory(null)}
+              className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center text-2xl active:scale-90 transition-transform"
+            >
+              ←
+            </button>
+          )}
+        </div>
+        <h1 className="text-2xl font-bold text-gray-800">
+          {selectedCategory
+            ? TOOL_CATEGORIES.find((c) => c.id === selectedCategory)?.name ?? selectedCategory
+            : TOOLSHED_NAME}
+        </h1>
+        <div className="flex items-center gap-2 bg-yellow-100 px-3 py-2 rounded-full">
+          <span className="text-2xl">⭐</span>
+          <span className="text-xl font-bold text-yellow-700">{totalStars}</span>
+        </div>
+      </header>
+
+      {/* Content */}
+      <div className="flex-1 p-4 overflow-hidden">
+        {selectedCategory ? (
+          <ToolGrid
+            tools={getToolsByCategory(selectedCategory)}
+            onToolTap={handleToolTap}
+          />
+        ) : (
+          <CategoryGrid
+            onCategoryTap={setSelectedCategory}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ---- Category Grid ---- */
+
+function CategoryGrid({ onCategoryTap }: { onCategoryTap: (c: ToolCategory) => void }) {
+  return (
+    <div className="grid grid-cols-2 gap-4 max-w-lg mx-auto">
+      {TOOL_CATEGORIES.map((cat) => {
+        const tools = getToolsByCategory(cat.id);
+        const unlocked = tools.filter((t) => t.unlocked).length;
+        return (
+          <button
+            key={cat.id}
+            onClick={() => onCategoryTap(cat.id)}
+            className="aspect-square rounded-3xl shadow-lg flex flex-col items-center justify-center gap-3 p-4 active:scale-95 transition-transform"
+            style={{ backgroundColor: cat.color }}
+          >
+            <span className="text-5xl">{cat.icon}</span>
+            <span className="text-xl font-bold text-white drop-shadow-sm">{cat.name}</span>
+            <span className="text-sm text-white/80">
+              {unlocked} / {tools.length}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ---- Tool Grid ---- */
+
+function ToolGrid({ tools, onToolTap }: { tools: Tool[]; onToolTap: (t: Tool) => void }) {
+  return (
+    <div className="grid grid-cols-3 gap-4 max-w-lg mx-auto">
+      {tools.map((tool) => (
+        <button
+          key={tool.id}
+          onClick={() => onToolTap(tool)}
+          disabled={!tool.unlocked}
+          className={`
+            aspect-square rounded-2xl shadow-lg flex flex-col items-center justify-center gap-2 p-3
+            relative overflow-hidden active:scale-90 transition-transform
+            ${!tool.unlocked ? 'opacity-50 grayscale' : ''}
+          `}
+          style={{ backgroundColor: tool.color }}
+        >
+          <span className="text-4xl">{tool.icon}</span>
+          <span className="text-sm font-bold text-white drop-shadow-sm text-center">{tool.name}</span>
+
+          {tool.stars > 0 && (
+            <div className="absolute top-1 right-1 bg-yellow-400 rounded-full px-2 py-0.5 flex items-center gap-1">
+              <span className="text-xs">⭐</span>
+              <span className="text-xs font-bold">{tool.stars}</span>
+            </div>
+          )}
+
+          {!tool.unlocked && (
+            <div className="absolute inset-0 bg-black/30 flex items-center justify-center">
+              <span className="text-3xl">🔒</span>
+            </div>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default Toolshed;

--- a/src/lib/toolshed/index.ts
+++ b/src/lib/toolshed/index.ts
@@ -1,0 +1,71 @@
+/**
+ * 8gent Jr Toolshed
+ *
+ * Kid-friendly tool system. Visual grid with categories,
+ * gamified star progress, unlock states.
+ */
+
+export interface Tool {
+  id: string;
+  name: string;
+  icon: string;
+  color: string;
+  category: ToolCategory;
+  route: string;
+  unlocked: boolean;
+  stars: number;
+  description: string;
+}
+
+export type ToolCategory =
+  | 'communicate'
+  | 'create'
+  | 'learn'
+  | 'feel'
+  | 'routine'
+  | 'reward';
+
+export const TOOL_CATEGORIES: Array<{
+  id: ToolCategory;
+  name: string;
+  icon: string;
+  color: string;
+}> = [
+  { id: 'communicate', name: 'Talk', icon: '\uD83D\uDCAC', color: '#8BC34A' },
+  { id: 'create', name: 'Create', icon: '\uD83C\uDFA8', color: '#FF9800' },
+  { id: 'learn', name: 'Learn', icon: '\uD83D\uDCDA', color: '#4ECDC4' },
+  { id: 'feel', name: 'Feel', icon: '\uD83D\uDE0A', color: '#FFEB3B' },
+  { id: 'routine', name: 'My Day', icon: '\uD83D\uDCC5', color: '#607D8B' },
+  { id: 'reward', name: 'Prizes', icon: '\uD83C\uDFC6', color: '#FFC107' },
+];
+
+export const TOOLS: Tool[] = [
+  // Communicate
+  { id: 'aac-home', name: 'Talk', icon: '\uD83D\uDCAC', color: '#8BC34A', category: 'communicate', route: '/talk/core', unlocked: true, stars: 0, description: 'AAC communication board' },
+  { id: 'stories', name: 'Stories', icon: '\uD83D\uDCD6', color: '#9C27B0', category: 'communicate', route: '/stories', unlocked: true, stars: 0, description: 'Social stories' },
+  // Create
+  { id: 'draw', name: 'Draw', icon: '\uD83C\uDFA8', color: '#FF9800', category: 'create', route: '/draw', unlocked: true, stars: 0, description: 'Drawing canvas' },
+  { id: 'music', name: 'Music', icon: '\uD83C\uDFB5', color: '#E91E63', category: 'create', route: '/music', unlocked: true, stars: 0, description: 'Music & beats' },
+  // Learn
+  { id: 'speech', name: 'Speech', icon: '\uD83D\uDC44', color: '#FF5722', category: 'learn', route: '/speech', unlocked: true, stars: 0, description: 'Speech therapy' },
+  { id: 'intuition', name: 'Game', icon: '\uD83C\uDFAE', color: '#9C27B0', category: 'learn', route: '/intuition', unlocked: true, stars: 0, description: 'Intuition game' },
+  { id: 'vsd', name: 'Scenes', icon: '\uD83D\uDDBC\uFE0F', color: '#2196F3', category: 'learn', route: '/vsd', unlocked: true, stars: 0, description: 'Visual scene displays' },
+  { id: 'science', name: 'Science', icon: '\uD83E\uDDEA', color: '#4ECDC4', category: 'learn', route: '/science', unlocked: true, stars: 0, description: 'Science experiments' },
+  // Feel
+  { id: 'games', name: 'Games', icon: '\uD83C\uDFB2', color: '#FFEB3B', category: 'feel', route: '/games', unlocked: true, stars: 0, description: 'Fun games' },
+  // Routine
+  { id: 'timer', name: 'Timer', icon: '\u23F0', color: '#00BCD4', category: 'routine', route: '/timer', unlocked: true, stars: 0, description: 'Visual countdown timer' },
+  { id: 'schedule', name: 'My Day', icon: '\uD83D\uDCC5', color: '#607D8B', category: 'routine', route: '/schedule', unlocked: true, stars: 0, description: 'Visual schedule' },
+  // Reward
+  { id: 'add', name: 'Add Card', icon: '\u2795', color: '#4CAF50', category: 'reward', route: '/add', unlocked: true, stars: 0, description: 'Create new cards' },
+];
+
+export function getToolsByCategory(category: ToolCategory): Tool[] {
+  return TOOLS.filter((t) => t.category === category);
+}
+
+export function getTotalStars(): number {
+  return TOOLS.reduce((sum, t) => sum + t.stars, 0);
+}
+
+export const TOOLSHED_NAME = '8gent Jr';

--- a/src/lib/vsd/scenes.ts
+++ b/src/lib/vsd/scenes.ts
@@ -1,0 +1,76 @@
+/**
+ * Default Visual Scene Displays
+ *
+ * 5 seed scenes for GLP Stage 1-2 learners.
+ * Gradient placeholders until real photos are uploaded.
+ */
+
+import type { VisualScene } from './types';
+
+export const DEFAULT_SCENES: VisualScene[] = [
+  {
+    id: 'kitchen',
+    title: 'Kitchen',
+    imageUrl: '/vsd/kitchen.jpg',
+    glpStage: 1,
+    category: 'home',
+    hotspots: [
+      { id: 'kitchen-juice', x: 10, y: 30, width: 20, height: 25, phrase: 'I want juice' },
+      { id: 'kitchen-more', x: 40, y: 50, width: 20, height: 20, phrase: 'More please' },
+      { id: 'kitchen-done', x: 70, y: 40, width: 20, height: 20, phrase: 'All done' },
+      { id: 'kitchen-help', x: 35, y: 10, width: 25, height: 20, phrase: 'Help me' },
+    ],
+  },
+  {
+    id: 'playground',
+    title: 'Playground',
+    imageUrl: '/vsd/playground.jpg',
+    glpStage: 1,
+    category: 'park',
+    hotspots: [
+      { id: 'playground-go', x: 5, y: 60, width: 22, height: 20, phrase: "Let's go" },
+      { id: 'playground-turn', x: 30, y: 30, width: 20, height: 25, phrase: 'My turn' },
+      { id: 'playground-push', x: 55, y: 25, width: 22, height: 25, phrase: 'Push me' },
+      { id: 'playground-swing', x: 70, y: 60, width: 25, height: 25, phrase: 'I want to swing' },
+    ],
+  },
+  {
+    id: 'bedroom',
+    title: 'Bedroom',
+    imageUrl: '/vsd/bedroom.jpg',
+    glpStage: 1,
+    category: 'home',
+    hotspots: [
+      { id: 'bedroom-book', x: 10, y: 20, width: 22, height: 25, phrase: 'Read a book' },
+      { id: 'bedroom-night', x: 40, y: 40, width: 25, height: 25, phrase: 'Night night' },
+      { id: 'bedroom-tired', x: 65, y: 20, width: 22, height: 25, phrase: "I'm tired" },
+      { id: 'bedroom-light', x: 70, y: 60, width: 25, height: 20, phrase: 'Turn off light' },
+    ],
+  },
+  {
+    id: 'school',
+    title: 'School',
+    imageUrl: '/vsd/school.jpg',
+    glpStage: 2,
+    category: 'school',
+    hotspots: [
+      { id: 'school-hello', x: 5, y: 15, width: 22, height: 22, phrase: 'Hello teacher' },
+      { id: 'school-help', x: 35, y: 35, width: 25, height: 25, phrase: 'I need help' },
+      { id: 'school-go', x: 65, y: 15, width: 22, height: 22, phrase: 'Can I go' },
+      { id: 'school-done', x: 35, y: 65, width: 28, height: 22, phrase: 'Finished work' },
+    ],
+  },
+  {
+    id: 'park',
+    title: 'Park',
+    imageUrl: '/vsd/park.jpg',
+    glpStage: 1,
+    category: 'park',
+    hotspots: [
+      { id: 'park-look', x: 10, y: 15, width: 22, height: 22, phrase: 'Look at that' },
+      { id: 'park-play', x: 40, y: 40, width: 22, height: 25, phrase: "Let's play" },
+      { id: 'park-icecream', x: 68, y: 50, width: 25, height: 22, phrase: 'I want ice cream' },
+      { id: 'park-home', x: 10, y: 65, width: 22, height: 22, phrase: 'Go home' },
+    ],
+  },
+];

--- a/src/lib/vsd/types.ts
+++ b/src/lib/vsd/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Visual Scene Display (VSD) Types
+ *
+ * Photo-based AAC where real photos have interactive hotspots
+ * that speak whole language chunks. For GLP Stage 1-2 learners.
+ */
+
+export interface VisualScene {
+  id: string;
+  title: string;
+  imageUrl: string;
+  hotspots: Hotspot[];
+  glpStage: 1 | 2;
+  category: string;
+}
+
+export interface Hotspot {
+  id: string;
+  x: number;      // percentage 0-100
+  y: number;      // percentage 0-100
+  width: number;   // percentage of scene width
+  height: number;  // percentage of scene height
+  phrase: string;
+  symbolId?: number;
+  audioUrl?: string;
+}


### PR DESCRIPTION
## Summary
- Port 6 system features from NickOS to 8gent Jr (CSS-only, no Framer Motion dependency)
- **Lock Screen**: tap-to-unlock overlay on session start with time display and CSS animations
- **Toolshed**: categorized tool grid with star counts and unlock states at `/toolshed`
- **Timer**: bubble timer with 1/2/5/10 min presets, SVG progress circle at `/timer`
- **Intuition**: color card pattern recognition game with score/streak/accuracy at `/intuition`
- **VSD**: visual scene display with 5 scenes and hotspot-based TTS phrases at `/vsd`
- **Add Card**: ARASAAC symbol search + image upload, localStorage persistence at `/add`
- Updated Dock "More" overlay with all new routes

## Test plan
- [ ] Lock screen appears on fresh session, tap/click dismisses it
- [ ] Toolshed grid renders categories and drills into tools
- [ ] Timer presets work, countdown completes with "Done!" celebration
- [ ] Intuition game tracks score, streak, and accuracy across guesses
- [ ] VSD scenes navigate with picker, hotspots speak phrases via TTS
- [ ] Add Card searches ARASAAC, saves to localStorage
- [ ] All new routes appear in Dock "More" overlay
- [ ] `next build` succeeds with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)