### PR TITLE
fix: lock screen persists unlock state per session

### DIFF
--- a/src/components/LockScreenGate.tsx
+++ b/src/components/LockScreenGate.tsx
@@ -1,18 +1,31 @@
 'use client';
 
-import { useState, type ReactNode } from 'react';
+import { useState, useCallback, type ReactNode } from 'react';
 import { LockScreen } from './LockScreen';
+
+const STORAGE_KEY = '8gentjr-unlocked';
+
+function isSessionUnlocked(): boolean {
+  if (typeof window === 'undefined') return false;
+  return sessionStorage.getItem(STORAGE_KEY) === 'true';
+}
 
 /**
  * Wraps the app in a lock screen overlay on first visit per session.
  * Once unlocked, stays unlocked until the tab is closed.
+ * Uses sessionStorage so route navigations don't re-trigger the lock.
  */
 export function LockScreenGate({ children }: { children: ReactNode }) {
-  const [unlocked, setUnlocked] = useState(false);
+  const [unlocked, setUnlocked] = useState(isSessionUnlocked);
+
+  const handleUnlock = useCallback(() => {
+    sessionStorage.setItem(STORAGE_KEY, 'true');
+    setUnlocked(true);
+  }, []);
 
   return (
     <>
-      {!unlocked && <LockScreen onUnlock={() => setUnlocked(true)} />}
+      {!unlocked && <LockScreen onUnlock={handleUnlock} />}
       {children}
     </>
   );


### PR DESCRIPTION
## Summary
- Fixes #67 — lock screen re-triggering on every route navigation
- Uses `sessionStorage` to persist unlock state for the duration of the browser tab
- First visit per session still shows the lock screen; subsequent navigations skip it

## Changes
- `src/components/LockScreenGate.tsx`: Initialize state from `sessionStorage`, write to it on unlock

## Test plan
- [ ] Open app in new tab — lock screen appears
- [ ] Unlock, navigate to different routes — lock screen does NOT reappear
- [ ] Close tab, open new tab — lock screen appears again (sessionStorage cleared)

Generated with [Claude Code](https://claude.com/claude-code)