### PR TITLE
fix: enforce 14px minimum font size on all AAC card labels

### DIFF
--- a/src/app/category/[id]/page.tsx
+++ b/src/app/category/[id]/page.tsx
@@ -133,7 +133,7 @@ export default function CategoryDetailPage() {
                     {phrase.text.charAt(0).toUpperCase()}
                   </div>
                 )}
-                <span className="text-xs font-semibold text-gray-700 text-center leading-tight line-clamp-2">
+                <span className="text-sm font-semibold text-gray-700 text-center leading-tight line-clamp-2">
                   {phrase.text}
                 </span>
               </button>

--- a/src/components/AACBoard.tsx
+++ b/src/components/AACBoard.tsx
@@ -129,7 +129,7 @@ export default function AACBoard({
               alt={sym.label}
               className="w-[60px] h-[60px] object-contain"
             />
-            <span className="text-xs font-semibold text-[--brand-text-soft]">
+            <span className="text-sm font-semibold text-[--brand-text-soft]">
               {sym.label}
             </span>
           </button>

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -284,7 +284,7 @@ function CoreWordButton({ word, onTap }: { word: CoreWord; onTap: (w: CoreWord) 
           loading="lazy"
         />
       )}
-      <span className="font-bold text-[11px] mt-0.5 w-full truncate px-0.5">{word.label}</span>
+      <span className="font-bold text-[14px] mt-0.5 w-full truncate px-0.5 leading-none">{word.label}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Fixes issue #73 requirement: all interactive AAC card labels must be ≥ 14px
- `SupercoreGrid`: `text-[11px]` → `text-[14px]` on word labels
- `AACBoard`: `text-xs` (12px) → `text-sm` (14px) on symbol labels
- `category/[id]/page.tsx`: `text-xs` (12px) → `text-sm` (14px) on word card labels

## Test plan
- [ ] Open /talk — SupercoreGrid word labels readable at 14px
- [ ] Tap a symbol in AACBoard — label renders at 14px
- [ ] Open a category → word card labels render at 14px
- [ ] Run accessibility audit — no text-xs violations on interactive AAC elements