### PR TITLE
feat: unified SharedSentenceBar across all Talk screens

### DIFF
--- a/src/app/category/[id]/page.tsx
+++ b/src/app/category/[id]/page.tsx
@@ -13,6 +13,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useState, useCallback, useMemo } from "react";
 import { AAC_CATEGORIES, getPhrasesByCategory } from "@/lib/vocabulary";
 import { speak } from "@/lib/tts";
+import { SharedSentenceBar } from "@/components/SharedSentenceBar";
 
 export default function CategoryDetailPage() {
   const params = useParams();
@@ -36,6 +37,10 @@ export default function CategoryDetailPage() {
 
   const handleClear = () => setSelectedWords([]);
 
+  const handleRemoveWord = useCallback((index: number) => {
+    setSelectedWords((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
   if (!category) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
@@ -56,13 +61,12 @@ export default function CategoryDetailPage() {
     <div className="min-h-screen flex flex-col" style={{ background: `linear-gradient(135deg, ${category.color}22, ${category.color}08)` }}>
       {/* Header */}
       <div
-        className="flex items-center gap-3 px-4 pt-4 pb-3 border-b-2"
-        style={{ borderColor: category.color + "30", backgroundColor: category.color + "18" }}
+        className="flex items-center gap-3 px-4 pt-4 pb-3 border-b-2 bg-gray-800"
+        style={{ borderColor: category.color + "60" }}
       >
         <button
           onClick={() => router.back()}
-          className="flex items-center gap-1 font-semibold"
-          style={{ color: category.color }}
+          className="flex items-center gap-1 font-semibold text-white/70 hover:text-white transition-colors"
         >
           <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
             <polyline points="15 18 9 12 15 6" />
@@ -71,43 +75,26 @@ export default function CategoryDetailPage() {
         </button>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src={category.imageUrl} alt={category.name} className="w-10 h-10 object-contain" />
-        <h1 className="text-xl font-bold" style={{ color: category.color }}>{category.name}</h1>
+        <h1 className="text-xl font-bold text-white">{category.name}</h1>
       </div>
 
-      {/* Sentence strip */}
-      <div className="mx-4 mt-3 mb-2">
-        <div
-          className="flex items-center gap-2 min-h-[48px] px-3 py-2 rounded-xl text-lg flex-wrap border-2 bg-white"
-          style={{ borderColor: category.color + "40" }}
-        >
-          {selectedWords.length === 0 ? (
-            <span className="text-gray-400 italic text-base">Tap words to build a sentence...</span>
-          ) : (
-            selectedWords.map((word, i) => (
-              <span
-                key={`${word}-${i}`}
-                className="inline-block px-2.5 py-1 rounded-lg font-semibold text-sm"
-                style={{ backgroundColor: category.color + "22", border: `2px solid ${category.color}`, color: category.color }}
-              >
-                {word}
-              </span>
-            ))
-          )}
-        </div>
-        {selectedWords.length > 0 && (
-          <div className="flex gap-2 mt-2">
-            <button onClick={handleClear} className="flex-1 py-2 rounded-xl bg-red-500 text-white font-semibold text-sm">
-              Clear
-            </button>
-            <button onClick={handleSpeak} className="flex-[2] py-2 rounded-xl bg-green-500 text-white font-bold text-base">
-              ▶ Speak
-            </button>
-          </div>
-        )}
-      </div>
+      {/* Sentence strip — shared design */}
+      <SharedSentenceBar
+        words={selectedWords.map((word) => ({
+          label: word,
+          style: {
+            backgroundColor: category.color + "33",
+            borderColor: category.color,
+            color: category.color,
+          },
+        }))}
+        onSpeak={handleSpeak}
+        onClear={handleClear}
+        onRemoveWord={handleRemoveWord}
+      />
 
       {/* Word grid */}
-      <div className="flex-1 px-4 pb-6 overflow-y-auto">
+      <div className="flex-1 px-4 pb-6 pt-3 overflow-y-auto">
         {phrases.length === 0 ? (
           <div className="text-center py-12 text-gray-400">
             <p className="text-4xl mb-3">🔧</p>

--- a/src/components/AACBoard.tsx
+++ b/src/components/AACBoard.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { GENERAL_PHRASES, FEELINGS_PHRASES, ACTIONS_PHRASES } from "@/lib/vocabulary";
 import { speak } from "@/lib/tts";
+import { SharedSentenceBar } from "@/components/SharedSentenceBar";
 
 // ---------------------------------------------------------------------------
 // Grid density presets — progressive from accessible to advanced
@@ -58,34 +59,22 @@ export default function AACBoard({
 
   const handleClear = () => setSelectedSymbols([]);
 
+  const handleRemoveWord = (index: number) =>
+    setSelectedSymbols((prev) => prev.filter((_, i) => i !== index));
+
   return (
     <div className="w-full max-w-[900px] mx-auto">
-      {/* Sentence strip */}
-      <div className="flex items-center gap-2 min-h-12 px-3 py-2 mb-3 bg-[--warm-bg-subtle] rounded-xl text-lg flex-wrap">
-        <span className={`flex-1 ${selectedSymbols.length ? "text-[--brand-text]" : "text-[--brand-text-muted]"}`}>
-          {selectedSymbols.length ? selectedSymbols.join(" ") : "Tap symbols to build a sentence..."}
-        </span>
-        {selectedSymbols.length > 0 && (
-          <>
-            <button
-              onClick={handleSpeakSentence}
-              className="bg-green-500 hover:bg-green-600 text-white border-none rounded-lg px-3.5 py-1.5 cursor-pointer font-semibold text-sm transition-colors"
-            >
-              ▶ Speak
-            </button>
-            <button
-              onClick={handleClear}
-              className="bg-[--brand-accent] hover:bg-[--brand-accent-hover] text-white border-none rounded-lg px-3.5 py-1.5 cursor-pointer font-semibold text-sm transition-colors"
-            >
-              Clear
-            </button>
-          </>
-        )}
-      </div>
+      {/* Sentence strip — shared design */}
+      <SharedSentenceBar
+        words={selectedSymbols.map((label) => ({ label }))}
+        onSpeak={handleSpeakSentence}
+        onClear={handleClear}
+        onRemoveWord={handleRemoveWord}
+      />
 
       {/* Density selector */}
       {showDensitySelector && (
-        <div className="flex items-center gap-2 mb-3 text-sm text-[--brand-text-soft]">
+        <div className="flex items-center gap-2 my-3 text-sm text-[--brand-text-soft]">
           <span>Grid size:</span>
           {GRID_DENSITY_OPTIONS.map((opt) => (
             <button

--- a/src/components/SharedSentenceBar.tsx
+++ b/src/components/SharedSentenceBar.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+/**
+ * SharedSentenceBar — consistent sentence display bar used across all Talk screens.
+ *
+ * Matches the SupercoreGrid design language:
+ * - bg-gray-800 bar
+ * - ▶ speak (emerald), ✨ magic (purple, optional), ✕ clear (red)
+ * - Scrollable chips area; chips accept optional custom className/style for
+ *   Fitzgerald Key colours (SupercoreGrid) or category colours (category pages).
+ */
+
+import { useRef, useEffect } from 'react';
+
+export interface SentenceChip {
+  label: string;
+  /** Optional Tailwind classes for chip background/text/border (Fitzgerald Key) */
+  className?: string;
+  /** Optional inline styles for chip (category colour overrides) */
+  style?: React.CSSProperties;
+}
+
+export interface SharedSentenceBarProps {
+  words: SentenceChip[];
+  onSpeak: () => void;
+  onClear: () => void;
+  /** Tap a chip to remove it */
+  onRemoveWord?: (index: number) => void;
+  /** Optional magic ✨ button */
+  onMagic?: () => void;
+  isMagicLoading?: boolean;
+  placeholder?: string;
+}
+
+export function SharedSentenceBar({
+  words,
+  onSpeak,
+  onClear,
+  onRemoveWord,
+  onMagic,
+  isMagicLoading = false,
+  placeholder = 'Tap words to build a sentence...',
+}: SharedSentenceBarProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
+    }
+  }, [words.length]);
+
+  const hasWords = words.length > 0;
+
+  return (
+    <div className="flex items-center gap-1.5 px-2 py-1.5 min-h-[56px] bg-gray-800 rounded-xl mx-2 mt-2 shrink-0">
+      {/* ▶ Speak */}
+      <button
+        onClick={onSpeak}
+        disabled={!hasWords}
+        className={`shrink-0 w-10 h-10 rounded-xl text-white flex items-center justify-center text-lg font-bold transition-colors ${
+          hasWords ? 'bg-emerald-500 hover:bg-emerald-400 cursor-pointer' : 'bg-gray-600 cursor-not-allowed'
+        }`}
+        aria-label="Speak sentence"
+      >
+        &#9654;
+      </button>
+
+      {/* ✨ Magic — only rendered when onMagic is provided */}
+      {onMagic && (
+        <button
+          onClick={onMagic}
+          disabled={words.length < 2 || isMagicLoading}
+          className={`shrink-0 w-10 h-10 rounded-xl text-white flex items-center justify-center text-base font-bold transition-all ${
+            words.length >= 2 && !isMagicLoading
+              ? 'bg-purple-500 hover:bg-purple-400 cursor-pointer active:scale-90'
+              : 'bg-gray-600 cursor-not-allowed'
+          } ${isMagicLoading ? 'animate-pulse' : ''}`}
+          aria-label="Improve and speak sentence"
+          title="Magic: improve my sentence"
+        >
+          &#10024;
+        </button>
+      )}
+
+      {/* Chips / placeholder */}
+      <div
+        ref={scrollRef}
+        className="flex-1 flex items-center gap-1.5 overflow-x-auto scroll-smooth no-scrollbar"
+      >
+        {!hasWords ? (
+          <span className="text-gray-400 text-base font-medium select-none px-2">
+            {placeholder}
+          </span>
+        ) : (
+          words.map((chip, index) => (
+            <button
+              key={`${chip.label}-${index}`}
+              onClick={() => onRemoveWord?.(index)}
+              disabled={!onRemoveWord}
+              className={`shrink-0 px-3 py-1.5 rounded-lg font-bold text-sm border-2 transition-transform active:scale-95 ${
+                onRemoveWord ? 'cursor-pointer' : 'cursor-default'
+              } ${chip.className ?? 'bg-gray-600 text-white border-gray-500'}`}
+              style={chip.style}
+              aria-label={onRemoveWord ? `Remove ${chip.label}` : chip.label}
+            >
+              {chip.label}
+            </button>
+          ))
+        )}
+      </div>
+
+      {/* ✕ Clear */}
+      {hasWords && (
+        <button
+          onClick={onClear}
+          className="shrink-0 w-10 h-10 rounded-xl bg-red-500 hover:bg-red-400 text-white cursor-pointer flex items-center justify-center text-lg font-bold transition-colors"
+          aria-label="Clear sentence"
+        >
+          &#10005;
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -24,10 +24,11 @@
  * - Red:     Negation (no, don't, stop)
  */
 
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { FITZGERALD_COLORS, type WordCategory } from '@/lib/fitzgerald-key';
 import { logWord } from '@/lib/session-logger';
 import { speak as elevenLabsSpeak } from '@/lib/tts';
+import { SharedSentenceBar } from '@/components/SharedSentenceBar';
 
 // =============================================================================
 // Fitzgerald Key Color Definitions (mapped from shared vocabulary system)
@@ -166,94 +167,8 @@ function speak(text: string) {
 }
 
 // =============================================================================
-// Sentence Strip
+// Sentence Strip — now uses SharedSentenceBar
 // =============================================================================
-
-interface SentenceStripProps {
-  words: CoreWord[];
-  onSpeakAll: () => void;
-  onMagicSpeak: () => void;
-  isMagicLoading: boolean;
-  onClear: () => void;
-  onRemoveWord: (index: number) => void;
-}
-
-function SentenceStrip({ words, onSpeakAll, onMagicSpeak, isMagicLoading, onClear, onRemoveWord }: SentenceStripProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
-    }
-  }, [words.length]);
-
-  return (
-    <div className="flex items-center gap-1.5 px-2 py-1.5 min-h-[56px] bg-gray-700 rounded-xl mx-2 mt-2">
-      {/* Speak All (exact words) */}
-      <button
-        onClick={onSpeakAll}
-        disabled={words.length === 0}
-        className={`shrink-0 w-10 h-10 rounded-xl border-none text-white flex items-center justify-center text-lg font-bold ${
-          words.length > 0
-            ? 'bg-emerald-500 cursor-pointer'
-            : 'bg-gray-500 cursor-not-allowed'
-        }`}
-        aria-label="Speak sentence"
-      >
-        &#9654;
-      </button>
-
-      {/* Magic sparkle button */}
-      <button
-        onClick={onMagicSpeak}
-        disabled={words.length < 2 || isMagicLoading}
-        className={`shrink-0 w-10 h-10 rounded-xl border-none text-white flex items-center justify-center text-base font-bold transition-all ${
-          words.length >= 2 && !isMagicLoading
-            ? 'bg-purple-500 cursor-pointer hover:bg-purple-400 active:scale-90'
-            : 'bg-gray-500 cursor-not-allowed'
-        } ${isMagicLoading ? 'animate-pulse' : ''}`}
-        aria-label="Improve and speak sentence"
-        title="Magic: improve my sentence"
-      >
-        &#10024;
-      </button>
-
-      {/* Word chips */}
-      <div ref={scrollRef} className="flex-1 flex items-center gap-1.5 overflow-x-auto scroll-smooth">
-        {words.length === 0 ? (
-          <span className="text-gray-400 text-base font-medium select-none px-2">
-            Tap words to build a sentence...
-          </span>
-        ) : (
-          words.map((word, index) => {
-            const cls = FITZGERALD_CLASSES[word.category];
-            return (
-              <button
-                key={`${word.id}-${index}`}
-                onClick={() => onRemoveWord(index)}
-                className={`shrink-0 px-3 py-1.5 rounded-lg font-bold text-sm border-2 cursor-pointer ${cls.bg} ${cls.text} ${cls.border}`}
-                aria-label={`Remove ${word.label}`}
-              >
-                {word.label}
-              </button>
-            );
-          })
-        )}
-      </div>
-
-      {/* Clear */}
-      {words.length > 0 && (
-        <button
-          onClick={onClear}
-          className="shrink-0 w-10 h-10 rounded-xl border-none bg-red-500 text-white cursor-pointer flex items-center justify-center text-lg font-bold"
-          aria-label="Clear sentence"
-        >
-          &#10005;
-        </button>
-      )}
-    </div>
-  );
-}
 
 // =============================================================================
 // Single Core Word Button
@@ -380,10 +295,13 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   return (
     <div className="flex flex-col h-screen min-h-[100dvh] bg-gray-50 font-sans">
       {/* Sentence Strip */}
-      <SentenceStrip
-        words={sentence}
-        onSpeakAll={handleSpeakAll}
-        onMagicSpeak={handleMagicSpeak}
+      <SharedSentenceBar
+        words={sentence.map(w => ({
+          label: w.label,
+          className: `${FITZGERALD_CLASSES[w.category].bg} ${FITZGERALD_CLASSES[w.category].text} ${FITZGERALD_CLASSES[w.category].border}`,
+        }))}
+        onSpeak={handleSpeakAll}
+        onMagic={handleMagicSpeak}
         isMagicLoading={isMagicLoading}
         onClear={handleClear}
         onRemoveWord={handleRemoveWord}


### PR DESCRIPTION
## Summary
- Extracts a shared `SharedSentenceBar` component (`src/components/SharedSentenceBar.tsx`)
- All three talk views now use identical layout: `bg-gray-800` bar, emerald ▶, purple ✨ (optional), red ✕
- Chip colours remain contextual: Fitzgerald Key in SupercoreGrid, category colour in category pages, neutral in AACBoard
- Category page header updated to `bg-gray-800` to match the Talk page header
- Word chips are tappable to remove (consistent across all screens)
- Zero design regressions — SupercoreGrid still shows Fitzgerald Key colours per word

## Test plan
- [ ] /talk — SupercoreGrid sentence bar looks correct
- [ ] /talk → Browse → tap a category — bar visually matches SupercoreGrid bar
- [ ] AACBoard (if accessible) — same bar style
- [ ] All three: ▶ speak, ✨ magic (SupercoreGrid only), ✕ clear work correctly
- [ ] Chips are tappable to remove on all screens