### PR TITLE
fix: remove browser TTS fallback — ElevenLabs only

### DIFF
--- a/src/lib/tts.ts
+++ b/src/lib/tts.ts
@@ -91,18 +91,13 @@ export async function speak(options: TTSOptions): Promise<TTSEngine> {
   // Stop anything currently playing
   stopSpeaking();
 
-  // Try ElevenLabs first (if online)
-  if (navigator.onLine) {
-    try {
-      const engine = await speakElevenLabs(text, { voiceId, stability, similarityBoost, volume });
-      if (engine === 'elevenlabs') return 'elevenlabs';
-    } catch {
-      // Fall through to browser TTS
-    }
+  // ElevenLabs only — no browser TTS fallback (avoid double-voice issue)
+  try {
+    const engine = await speakElevenLabs(text, { voiceId, stability, similarityBoost, volume });
+    return engine;
+  } catch {
+    return 'none';
   }
-
-  // Fallback: Web Speech API
-  return speakBrowser(text, { rate, volume });
 }
 
 // ---------------------------------------------------------------------------
@@ -137,11 +132,13 @@ async function speakElevenLabs(
       resolve('elevenlabs');
     };
     audio.onerror = () => {
+      audio.src = '';
       URL.revokeObjectURL(url);
       currentAudio = null;
       resolve('none');
     };
     audio.play().catch(() => {
+      audio.src = '';
       URL.revokeObjectURL(url);
       currentAudio = null;
       resolve('none');


### PR DESCRIPTION
## Problem
Some cards were playing both the ElevenLabs voice AND the robot browser voice simultaneously.

**Root cause:** `speak()` in `tts.ts` would call `speakBrowser()` (Web Speech API) whenever `speakElevenLabs()` returned `'none'` — which happens on autoplay policy errors, audio decode failures, etc. This means ElevenLabs audio could start playing while browser TTS also fired.

## Fix
- Removed the `speakBrowser()` fallback from `speak()` entirely
- If ElevenLabs fails for any reason → return `'none'` (silence), never browser TTS
- Also added `audio.src = ''` before revoking the object URL on error paths to ensure the audio element is fully stopped

## Impact
- All cards now play ElevenLabs only
- No more double-voice
- If ElevenLabs is unavailable → silence (acceptable, not a regression)