### PR TITLE
fix: restore TTS fallback with amber glow signal

### DIFF
--- a/src/app/category/[id]/page.tsx
+++ b/src/app/category/[id]/page.tsx
@@ -24,15 +24,18 @@ export default function CategoryDetailPage() {
   const phrases = useMemo(() => getPhrasesByCategory(categoryId), [categoryId]);
 
   const [selectedWords, setSelectedWords] = useState<string[]>([]);
+  const [engineFallback, setEngineFallback] = useState(false);
 
-  const handleTap = useCallback((text: string) => {
+  const handleTap = useCallback(async (text: string) => {
     setSelectedWords((prev) => [...prev, text]);
-    speak({ text });
+    const engine = await speak({ text });
+    setEngineFallback(engine === 'browser');
   }, []);
 
-  const handleSpeak = useCallback(() => {
+  const handleSpeak = useCallback(async () => {
     if (selectedWords.length === 0) return;
-    speak({ text: selectedWords.join(" ") });
+    const engine = await speak({ text: selectedWords.join(" ") });
+    setEngineFallback(engine === 'browser');
   }, [selectedWords]);
 
   const handleClear = () => setSelectedWords([]);
@@ -91,6 +94,7 @@ export default function CategoryDetailPage() {
         onSpeak={handleSpeak}
         onClear={handleClear}
         onRemoveWord={handleRemoveWord}
+        engineFallback={engineFallback}
       />
 
       {/* Word grid */}

--- a/src/components/SharedSentenceBar.tsx
+++ b/src/components/SharedSentenceBar.tsx
@@ -8,9 +8,10 @@
  * - ▶ speak (emerald), ✨ magic (purple, optional), ✕ clear (red)
  * - Scrollable chips area; chips accept optional custom className/style for
  *   Fitzgerald Key colours (SupercoreGrid) or category colours (category pages).
+ * - engineFallback: shows a subtle amber glow when browser TTS fallback is active
  */
 
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 
 export interface SentenceChip {
   label: string;
@@ -30,6 +31,11 @@ export interface SharedSentenceBarProps {
   onMagic?: () => void;
   isMagicLoading?: boolean;
   placeholder?: string;
+  /**
+   * Set to true briefly when browser TTS fallback fired (ElevenLabs was unavailable).
+   * Shows a subtle amber glow on the bar for 3 seconds.
+   */
+  engineFallback?: boolean;
 }
 
 export function SharedSentenceBar({
@@ -40,8 +46,10 @@ export function SharedSentenceBar({
   onMagic,
   isMagicLoading = false,
   placeholder = 'Tap words to build a sentence...',
+  engineFallback = false,
 }: SharedSentenceBarProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [showFallbackGlow, setShowFallbackGlow] = useState(false);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -49,10 +57,23 @@ export function SharedSentenceBar({
     }
   }, [words.length]);
 
+  // Pulse the amber glow for 3s whenever engineFallback fires
+  useEffect(() => {
+    if (!engineFallback) return;
+    setShowFallbackGlow(true);
+    const t = setTimeout(() => setShowFallbackGlow(false), 3000);
+    return () => clearTimeout(t);
+  }, [engineFallback]);
+
   const hasWords = words.length > 0;
 
   return (
-    <div className="flex items-center gap-1.5 px-2 py-1.5 min-h-[56px] bg-gray-800 rounded-xl mx-2 mt-2 shrink-0">
+    <div
+      className={`flex items-center gap-1.5 px-2 py-1.5 min-h-[56px] bg-gray-800 rounded-xl mx-2 mt-2 shrink-0 transition-shadow duration-500 ${
+        showFallbackGlow ? 'ring-2 ring-amber-400/70 shadow-[0_0_12px_2px_rgba(251,191,36,0.35)]' : ''
+      }`}
+      title={showFallbackGlow ? 'Using backup voice — ElevenLabs unavailable' : undefined}
+    >
       {/* ▶ Speak */}
       <button
         onClick={onSpeak}
@@ -108,6 +129,15 @@ export function SharedSentenceBar({
           ))
         )}
       </div>
+
+      {/* Fallback indicator dot */}
+      {showFallbackGlow && (
+        <div
+          className="shrink-0 w-2 h-2 rounded-full bg-amber-400 animate-pulse"
+          aria-hidden="true"
+          title="Backup voice active"
+        />
+      )}
 
       {/* ✕ Clear */}
       {hasWords && (

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -162,10 +162,6 @@ const SUPERCORE_50: CoreWord[] = [
 // TTS Helper — ElevenLabs via tts.ts
 // =============================================================================
 
-function speak(text: string) {
-  elevenLabsSpeak({ text });
-}
-
 // =============================================================================
 // Sentence Strip — now uses SharedSentenceBar
 // =============================================================================
@@ -217,6 +213,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   const [sentence, setSentence] = useState<CoreWord[]>([]);
   const [cols, setCols] = useState(10);
   const [isMagicLoading, setIsMagicLoading] = useState(false);
+  const [engineFallback, setEngineFallback] = useState(false);
 
   // Responsive column count: 4 on phone, 5 on small tablet, 10 on desktop
   useEffect(() => {
@@ -231,9 +228,10 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
     return () => window.removeEventListener('resize', check);
   }, []);
 
-  const speakText = useCallback((text: string) => {
+  const speakText = useCallback(async (text: string) => {
     if (onSpeak) { onSpeak(text); return; }
-    speak(text);
+    const engine = await elevenLabsSpeak({ text });
+    setEngineFallback(engine === 'browser');
   }, [onSpeak]);
 
   const handleWordTap = useCallback((word: CoreWord) => {
@@ -305,6 +303,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
         isMagicLoading={isMagicLoading}
         onClear={handleClear}
         onRemoveWord={handleRemoveWord}
+        engineFallback={engineFallback}
       />
 
       {/* Color Legend — single scrollable row */}

--- a/src/lib/tts.ts
+++ b/src/lib/tts.ts
@@ -91,13 +91,16 @@ export async function speak(options: TTSOptions): Promise<TTSEngine> {
   // Stop anything currently playing
   stopSpeaking();
 
-  // ElevenLabs only — no browser TTS fallback (avoid double-voice issue)
+  // Try ElevenLabs first
   try {
     const engine = await speakElevenLabs(text, { voiceId, stability, similarityBoost, volume });
-    return engine;
+    if (engine === 'elevenlabs') return 'elevenlabs';
   } catch {
-    return 'none';
+    // Fall through to browser TTS
   }
+
+  // Fallback: Web Speech API (caller should signal this to the user)
+  return speakBrowser(text, { rate, volume });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Restores browser TTS fallback when ElevenLabs is unavailable. Adds a subtle amber ring + pulsing dot on the SharedSentenceBar for 3s to signal the fallback fired. No UI change when ElevenLabs works normally.