### PR TITLE
feat: parent chat, fix home redirect, fix symbols, resources db

### DIFF
--- a/data/resources/index.json
+++ b/data/resources/index.json
@@ -1,0 +1,46 @@
+{
+  "meta": {
+    "description": "Research datasets, tools, and publications relevant to 8gent Jr and neurodivergent AAC development",
+    "last_updated": "2026-04-06",
+    "schema_version": "1.0"
+  },
+  "resources": [
+    {
+      "id": "pgc-psychiatric-genetics-2026",
+      "name": "Psychiatric Genomics Consortium — Full GWAS Dataset",
+      "type": "dataset",
+      "host": "Hugging Face (OpenMed)",
+      "hf_org": "OpenMed",
+      "hf_datasets": [
+        "OpenMed/pgc-schizophrenia",
+        "OpenMed/pgc-adhd",
+        "OpenMed/pgc-autism",
+        "OpenMed/pgc-depression",
+        "OpenMed/pgc-bipolar",
+        "OpenMed/pgc-ptsd",
+        "OpenMed/pgc-ocd"
+      ],
+      "load_example": "from datasets import load_dataset\nds = load_dataset('OpenMed/pgc-schizophrenia', 'scz2022')",
+      "format": "Apache Parquet",
+      "size": "~1 billion rows",
+      "disorders": [
+        "ADHD",
+        "Depression",
+        "Schizophrenia",
+        "Bipolar",
+        "PTSD",
+        "OCD",
+        "Autism"
+      ],
+      "disorder_groups": 12,
+      "publications": 52,
+      "source_org": "Psychiatric Genomics Consortium (PGC)",
+      "original_sources": ["Figshare", "university servers"],
+      "license": "CC BY 4.0",
+      "relevance_to_8gentjr": "ADHD and Autism are primary user populations for AAC tools. GWAS data may inform feature prioritization, symptom clustering, and evidence-based vocabulary selection.",
+      "tags": ["genetics", "gwas", "adhd", "autism", "psychiatry", "neurodivergent", "research"],
+      "added": "2026-04-06",
+      "notes": "Convert from Figshare/university servers to clean Parquet. Full attribution required per CC BY 4.0."
+    }
+  ]
+}

--- a/src/app/api/parent-chat/route.ts
+++ b/src/app/api/parent-chat/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest } from 'next/server';
+import Groq from 'groq-sdk';
+
+/**
+ * 8gent Jr — Parent Chat API
+ *
+ * Evidence-informed AAC advisor for parents. Answers questions about
+ * their child's communication, vocabulary, and AAC strategy using
+ * specialist knowledge. Not generalised — grounded in AAC research.
+ *
+ * Stack: Groq / llama-3.3-70b-versatile (more capable than 8b for nuanced Q&A)
+ */
+
+export const runtime = 'edge';
+
+const SYSTEM_PROMPT = `You are an expert AAC (Augmentative and Alternative Communication) specialist and speech-language pathologist advisor embedded in 8gent Jr, a communication app for children.
+
+Your role is to help parents:
+- Understand AAC strategies for their child's specific needs
+- Choose and prioritise vocabulary for their child's board
+- Understand how conditions like ADHD, autism, cerebral palsy, and developmental delays affect communication
+- Implement evidence-based AAC strategies at home
+- Interpret their child's communication behaviours
+
+Your knowledge is grounded in:
+- AAC research (Beukelman & Mirenda, Light & McNaughton, etc.)
+- Core vocabulary research (Banajee, Dicarlo & Stricklin 2003; Cross et al. 2006)
+- Gestalt Language Processing (GLP) theory
+- Modified Fitzgerald Key colour coding system
+- Psychiatric and neurodevelopmental research where relevant
+
+Rules:
+1. Be specific and evidence-informed — not generic wellness advice
+2. When citing research, name the authors and approximate date
+3. Be warm and practical — parents are often overwhelmed
+4. If a question is outside AAC/communication scope, redirect kindly
+5. Keep responses concise but complete — parents are busy
+6. Use plain English, not clinical jargon (explain terms when needed)
+7. When relevant, suggest specific vocabulary words or categories for the app
+
+Format:
+- Use short paragraphs, not bullet walls
+- Bold key terms or recommendations
+- End with a practical next step when appropriate`;
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ChatRequest {
+  messages: Message[];
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const groqKey = process.env.GROQ_API_KEY;
+    if (!groqKey) {
+      return new Response(JSON.stringify({ error: 'GROQ_API_KEY not configured' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const body: ChatRequest = await request.json();
+    const { messages } = body;
+
+    if (!messages || messages.length === 0) {
+      return new Response(JSON.stringify({ error: 'Messages required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const groq = new Groq({ apiKey: groqKey });
+
+    const completion = await groq.chat.completions.create({
+      model: 'llama-3.3-70b-versatile',
+      max_tokens: 1024,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        ...messages,
+      ],
+    });
+
+    const content = completion.choices?.[0]?.message?.content ?? '';
+
+    return new Response(JSON.stringify({ reply: content }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('[Parent Chat] Error:', error);
+    return new Response(JSON.stringify({ error: 'Failed to get response' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,38 +1,5 @@
-"use client";
-
-import PhraseBoard from "../components/PhraseBoard";
-import Dock from "../components/Dock";
-import AACBoard from "@/components/AACBoard";
-import { GENERAL_PHRASES } from "@/lib/vocabulary";
-import { FITZGERALD_COLORS } from "@/lib/fitzgerald-key";
-
-/** PhraseBoard cards built from the vocabulary system's General phrases */
-const PHRASE_CARDS = GENERAL_PHRASES.map((phrase) => ({
-  label: phrase.text,
-  symbolUrl: phrase.imageUrl,
-  bgColor: FITZGERALD_COLORS.verb.bg,
-}));
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return (
-    <>
-      <main className="min-h-screen flex flex-col items-center p-4 pb-24">
-        {/* Hero */}
-        <div className="text-center mt-8 mb-6">
-          <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-extrabold text-[--brand-accent]">
-            8gent Jr
-          </h1>
-          <p className="text-[--brand-text-soft] mt-1">
-            Tap a card to speak
-          </p>
-        </div>
-
-        {/* Main AAC Board */}
-        <div className="w-full max-w-3xl">
-          <AACBoard columns={4} showDensitySelector />
-        </div>
-      </main>
-      <Dock />
-    </>
-  );
+  redirect("/talk");
 }

--- a/src/app/talk/page.tsx
+++ b/src/app/talk/page.tsx
@@ -10,14 +10,12 @@
  */
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { SupercoreGrid } from "@/components/SupercoreGrid";
 import AACHome from "@/components/AACHome";
 
 type ViewMode = "core" | "browse";
 
 export default function TalkPage() {
-  const router = useRouter();
   const [viewMode, setViewMode] = useState<ViewMode>("core");
 
   return (
@@ -25,15 +23,13 @@ export default function TalkPage() {
       {/* Header */}
       <div className="flex items-center justify-between px-4 pt-3 pb-2 bg-gray-800 shrink-0">
         <button
-          onClick={() => viewMode === "browse" ? setViewMode("core") : router.push("/")}
-          className="flex items-center gap-1 text-white/70 hover:text-white transition-colors"
+          onClick={() => setViewMode("core")}
+          className={`flex items-center gap-1 text-white/70 hover:text-white transition-colors ${viewMode === "core" ? "invisible" : ""}`}
         >
           <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
             <polyline points="15 18 9 12 15 6" />
           </svg>
-          <span className="text-base font-medium">
-            {viewMode === "browse" ? "Core" : "Home"}
-          </span>
+          <span className="text-base font-medium">Core</span>
         </button>
 
         <h1 className="text-white text-lg font-bold">

--- a/src/components/Dock.tsx
+++ b/src/components/Dock.tsx
@@ -169,6 +169,15 @@ function IconPlus({ color }: { color: string }) {
   );
 }
 
+function IconParentChat({ color }: { color: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17 8h2a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2h-2v4l-4-4H9a2 2 0 0 1-2-2v-1" />
+      <path d="M15 4H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2v4l4-4h4a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z" />
+    </svg>
+  );
+}
+
 function IconSettings({ color }: { color: string }) {
   return (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -187,6 +196,7 @@ const MORE_ITEMS: MoreItem[] = [
   { id: 'toolshed', label: 'Toolshed', icon: IconToolshed, href: '/toolshed' },
   { id: 'intuition', label: 'Intuition', icon: IconBrain, href: '/intuition' },
   { id: 'vsd', label: 'Scenes', icon: IconImage, href: '/vsd' },
+  { id: 'parent-chat', label: 'Parent Chat', icon: IconParentChat, href: '/parent-chat' },
   { id: 'add', label: 'Add Card', icon: IconPlus, href: '/add' },
   { id: 'settings', label: 'My Stuff', icon: IconSettings, href: '/settings' },
 ];

--- a/src/components/ParentChat.tsx
+++ b/src/components/ParentChat.tsx
@@ -1,11 +1,6 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import ChangePreview, { type ChangeDetail } from "./ChangePreview";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 type MessageRole = "user" | "assistant";
 
@@ -13,219 +8,101 @@ interface ChatMessage {
   id: string;
   role: MessageRole;
   text: string;
-  /** If this message proposes a change, attach the detail here */
-  change?: ChangeDetail & { status: "pending" | "confirmed" | "undone" };
 }
-
-// ---------------------------------------------------------------------------
-// Intent detection — hard-coded regex patterns (v1, no LLM)
-// ---------------------------------------------------------------------------
-
-interface DetectedIntent {
-  type: "add_card" | "remove_card" | "set_columns" | "find_symbol" | "unknown";
-  params: Record<string, string>;
-}
-
-function detectIntent(input: string): DetectedIntent {
-  const lower = input.toLowerCase().trim();
-
-  const addMatch = lower.match(
-    /add\s+(?:card\s+)?["']?(.+?)["']?\s+(?:to\s+)?(?:the\s+)?["']?(.+?)["']?\s*(?:grid|board|page)?$/
-  );
-  if (addMatch) {
-    return { type: "add_card", params: { card: addMatch[1], grid: addMatch[2] } };
-  }
-
-  const removeMatch = lower.match(
-    /(?:remove|delete)\s+(?:card\s+)?["']?(.+?)["']?\s*(?:card)?$/
-  );
-  if (removeMatch) {
-    return { type: "remove_card", params: { card: removeMatch[1] } };
-  }
-
-  const colMatch = lower.match(
-    /(?:make|set|change)?\s*(?:the\s+)?(?:grid\s+)?(?:to\s+)?(\d+)\s*columns?/
-  );
-  if (colMatch) {
-    return { type: "set_columns", params: { columns: colMatch[1] } };
-  }
-
-  const symbolMatch = lower.match(
-    /(?:find|search|look\s+up|get)\s+(?:a\s+)?(?:symbol|icon|image)\s+(?:for\s+)?["']?(.+?)["']?$/
-  );
-  if (symbolMatch) {
-    return { type: "find_symbol", params: { term: symbolMatch[1] } };
-  }
-
-  return { type: "unknown", params: {} };
-}
-
-// ---------------------------------------------------------------------------
-// Response generation
-// ---------------------------------------------------------------------------
-
-function generateResponse(intent: DetectedIntent): {
-  text: string;
-  change?: ChangeDetail;
-} {
-  switch (intent.type) {
-    case "add_card":
-      return {
-        text: `Got it! I'll add "${intent.params.card}" to the ${intent.params.grid} grid.`,
-        change: {
-          description: `Add "${intent.params.card}" card to ${intent.params.grid}`,
-          before: `${intent.params.grid} grid (current cards)`,
-          after: `${intent.params.grid} grid + "${intent.params.card}"`,
-        },
-      };
-
-    case "remove_card":
-      return {
-        text: `Removing the "${intent.params.card}" card.`,
-        change: {
-          description: `Remove "${intent.params.card}" card`,
-          before: `Board with "${intent.params.card}"`,
-          after: `Board without "${intent.params.card}"`,
-        },
-      };
-
-    case "set_columns":
-      return {
-        text: `Changing the grid to ${intent.params.columns} columns.`,
-        change: {
-          description: `Change grid density to ${intent.params.columns} columns`,
-          before: "Current grid layout",
-          after: `${intent.params.columns}-column grid`,
-        },
-      };
-
-    case "find_symbol":
-      return {
-        text: `Searching for a symbol for "${intent.params.term}"... Symbol search isn't wired up yet, but I've noted the request!`,
-      };
-
-    case "unknown":
-    default:
-      return {
-        text: "I can help you customise the board! Try things like:\n- \"Add card Banana to food grid\"\n- \"Make grid 6 columns\"\n- \"Remove card Stop\"\n- \"Find symbol for happy\"",
-      };
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
 
 let msgIdCounter = 0;
 function nextId() {
   return `msg-${++msgIdCounter}-${Date.now()}`;
 }
 
+const SUGGESTIONS = [
+  "My child has ADHD — which words should I prioritise first?",
+  "How do I encourage my child to use their AAC board more?",
+  "What's the difference between core and fringe vocabulary?",
+  "My child is autistic and a gestalt language processor — how does that change things?",
+];
+
 export default function ParentChat() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  const sendMessage = useCallback(
-    (text: string) => {
-      if (!text.trim()) return;
+  const sendMessage = useCallback(async (text: string) => {
+    if (!text.trim() || isLoading) return;
 
-      const userMsg: ChatMessage = {
-        id: nextId(),
-        role: "user",
-        text: text.trim(),
-      };
+    const userMsg: ChatMessage = { id: nextId(), role: "user", text: text.trim() };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
+    setIsLoading(true);
 
-      const intent = detectIntent(text);
-      const response = generateResponse(intent);
+    try {
+      const history = [...messages, userMsg].map((m) => ({
+        role: m.role,
+        content: m.text,
+      }));
 
-      const assistantMsg: ChatMessage = {
-        id: nextId(),
-        role: "assistant",
-        text: response.text,
-        change: response.change
-          ? { ...response.change, status: "pending" }
-          : undefined,
-      };
+      const res = await fetch("/api/parent-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: history }),
+      });
 
-      setMessages((prev) => [...prev, userMsg, assistantMsg]);
-      setInput("");
-    },
-    [],
-  );
+      const data = await res.json();
+      const reply = data.reply || "Sorry, I couldn't get a response. Please try again.";
+
+      setMessages((prev) => [...prev, { id: nextId(), role: "assistant", text: reply }]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { id: nextId(), role: "assistant", text: "Something went wrong. Check your connection and try again." },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [messages, isLoading]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     sendMessage(input);
   };
 
-  const handleConfirmChange = useCallback((msgId: string) => {
-    setMessages((prev) =>
-      prev.map((m) =>
-        m.id === msgId && m.change
-          ? { ...m, change: { ...m.change, status: "confirmed" as const } }
-          : m
-      )
-    );
-  }, []);
-
-  const handleUndoChange = useCallback((msgId: string) => {
-    setMessages((prev) =>
-      prev.map((m) =>
-        m.id === msgId && m.change
-          ? { ...m, change: { ...m.change, status: "undone" as const } }
-          : m
-      )
-    );
-  }, []);
-
-  const suggestions = [
-    "Add card Banana to food grid",
-    "Make grid 6 columns",
-    "Remove card Stop",
-    "Find symbol for happy",
-  ];
-
   return (
     <div className="flex flex-col h-screen min-h-[100dvh] bg-[#FAFAF8] font-sans">
       {/* Header */}
       <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200 bg-white">
-        <a href="/">
+        <a href="/talk">
           <button
             className="w-10 h-10 rounded-[10px] border-2 border-gray-200 bg-white text-lg cursor-pointer flex items-center justify-center"
-            aria-label="Back to home"
+            aria-label="Back"
           >
             &larr;
           </button>
         </a>
         <div>
           <div className="text-[1.1rem] font-bold text-gray-800">Parent Chat</div>
-          <div className="text-xs text-gray-400">
-            Customise your child&apos;s board with words
-          </div>
+          <div className="text-xs text-gray-400">AAC specialist · evidence-informed</div>
         </div>
       </div>
 
-      {/* Messages area */}
+      {/* Messages */}
       <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-3">
         {messages.length === 0 ? (
           <div className="flex-1 flex flex-col items-center justify-center gap-3 p-8 text-gray-400">
             <div className="text-5xl">&#x1F4AC;</div>
-            <div className="text-xl font-bold text-gray-700">Hi there!</div>
+            <div className="text-xl font-bold text-gray-700">Ask anything</div>
             <div className="text-sm text-gray-400 text-center leading-relaxed max-w-[340px]">
-              Tell me what you want to change on your child&apos;s board. I
-              understand things like adding cards, changing grid size, and
-              removing cards.
+              Get evidence-informed answers about your child&apos;s AAC, vocabulary, and communication strategy.
             </div>
-            <div className="flex flex-wrap gap-2 justify-center mt-2">
-              {suggestions.map((s) => (
+            <div className="flex flex-col gap-2 mt-2 w-full max-w-sm">
+              {SUGGESTIONS.map((s) => (
                 <button
                   key={s}
-                  className="inline-block px-3.5 py-1.5 rounded-full border-2 border-orange-300 bg-[#FFF8F0] text-amber-800 text-xs font-semibold cursor-pointer transition-colors hover:bg-orange-100"
+                  className="text-left px-3.5 py-2.5 rounded-xl border-2 border-orange-200 bg-[#FFF8F0] text-amber-900 text-xs font-medium cursor-pointer transition-colors hover:bg-orange-100"
                   onClick={() => sendMessage(s)}
                 >
                   {s}
@@ -235,53 +112,50 @@ export default function ParentChat() {
           </div>
         ) : (
           messages.map((msg) => (
-            <div key={msg.id}>
-              <div
-                className={
-                  msg.role === "user"
-                    ? "max-w-[85%] self-end bg-[#E8610A] text-white rounded-2xl rounded-br-sm px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap"
-                    : "max-w-[85%] self-start bg-white text-gray-800 rounded-2xl rounded-bl-sm px-3.5 py-2.5 text-sm leading-relaxed shadow-sm border border-gray-200 whitespace-pre-wrap"
-                }
-              >
-                {msg.text}
-              </div>
-              {msg.change && msg.change.status === "pending" && (
-                <ChangePreview
-                  change={msg.change}
-                  onConfirm={() => handleConfirmChange(msg.id)}
-                  onUndo={() => handleUndoChange(msg.id)}
-                />
-              )}
-              {msg.change && msg.change.status === "confirmed" && (
-                <div className="text-xs text-emerald-600 font-semibold mt-1.5 px-2.5 py-1 bg-emerald-100 rounded-lg inline-block">
-                  &#10003; Change applied
-                </div>
-              )}
-              {msg.change && msg.change.status === "undone" && (
-                <div className="text-xs text-red-600 font-semibold mt-1.5 px-2.5 py-1 bg-red-100 rounded-lg inline-block">
-                  &#10005; Change reverted
-                </div>
-              )}
+            <div
+              key={msg.id}
+              className={`max-w-[85%] rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap ${
+                msg.role === "user"
+                  ? "self-end bg-[#E8610A] text-white rounded-br-sm"
+                  : "self-start bg-white text-gray-800 rounded-bl-sm shadow-sm border border-gray-200"
+              }`}
+            >
+              {msg.text}
             </div>
           ))
         )}
+
+        {isLoading && (
+          <div className="self-start bg-white border border-gray-200 rounded-2xl rounded-bl-sm px-4 py-3 shadow-sm">
+            <div className="flex gap-1 items-center">
+              <span className="w-2 h-2 bg-gray-300 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+              <span className="w-2 h-2 bg-gray-300 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+              <span className="w-2 h-2 bg-gray-300 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+            </div>
+          </div>
+        )}
+
         <div ref={messagesEndRef} />
       </div>
 
       {/* Input */}
-      <form onSubmit={handleSubmit} className="flex gap-2 px-4 py-3 border-t border-gray-200 bg-white pb-[calc(12px+env(safe-area-inset-bottom))]">
+      <form
+        onSubmit={handleSubmit}
+        className="flex gap-2 px-4 py-3 border-t border-gray-200 bg-white pb-[calc(12px+env(safe-area-inset-bottom))]"
+      >
         <input
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          placeholder="Tell me what to change..."
+          placeholder="Ask about your child's AAC..."
           className="flex-1 text-base px-3.5 py-2.5 rounded-xl border-2 border-gray-200 outline-none font-[inherit] bg-[#FAFAF8] focus:border-[#E8610A] transition-colors"
           aria-label="Chat message input"
+          disabled={isLoading}
         />
         <button
           type="submit"
-          className="w-12 h-12 min-w-[48px] rounded-xl border-none bg-[#E8610A] text-white text-xl font-bold cursor-pointer flex items-center justify-center transition-transform active:scale-95 disabled:opacity-50"
-          disabled={!input.trim()}
+          className="w-12 h-12 min-w-[48px] rounded-xl border-none bg-[#E8610A] text-white text-xl font-bold cursor-pointer flex items-center justify-center transition-transform active:scale-95 disabled:opacity-40"
+          disabled={!input.trim() || isLoading}
           aria-label="Send message"
         >
           &#8593;

--- a/src/lib/vocabulary.ts
+++ b/src/lib/vocabulary.ts
@@ -278,8 +278,8 @@ export const AAC_CATEGORIES: AACCategory[] = [
 // =============================================================================
 
 export const GENERAL_PHRASES: AACPhrase[] = [
-  { id: 'gen-i', text: 'I', imageUrl: ARASAAC(6867), categoryId: 'general' },
-  { id: 'gen-you', text: 'you', imageUrl: ARASAAC(6866), categoryId: 'general' },
+  { id: 'gen-i', text: 'I', imageUrl: ARASAAC(6632), categoryId: 'general' },
+  { id: 'gen-you', text: 'you', imageUrl: ARASAAC(6625), categoryId: 'general' },
   { id: 'gen-yes', text: 'yes', imageUrl: ARASAAC(5584), categoryId: 'general' },
   { id: 'gen-no', text: 'no', imageUrl: ARASAAC(5526), categoryId: 'general' },
   { id: 'gen-help', text: 'help', imageUrl: ARASAAC(7171), categoryId: 'general' },


### PR DESCRIPTION
## Summary

- **Parent Chat** — replaced fake regex engine with real Groq/Llama-3.3-70b chat; AAC specialist system prompt grounded in research (Beukelman, Light, GLP theory); added to More menu in dock
- **Home redirect** — `/` now redirects to `/talk`; orphaned AACBoard landing page removed
- **Symbol fix** — `I` and `you` ARASAAC IDs corrected (`6867→6632`, `6866→6625`) — were showing broken images on home board
- **Resources DB** — `data/resources/index.json` seeded with PGC psychiatric genetics dataset (ADHD + Autism relevant to user base)
- **Talk page cleanup** — back button no longer routes to orphaned `/`; hides when on Core view

## Test plan
- [ ] Visit 8gentjr.com — confirm redirect to /talk
- [ ] Open More menu — confirm Parent Chat appears
- [ ] Open Parent Chat — ask an ADHD question, confirm real AI response (not regex)
- [ ] Confirm I/you cards show pictograms on the home AACBoard