### PR TITLE
fix: music player + games visual regressions

### DIFF
--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -11,11 +11,11 @@ import ReelsFeed from "@/components/schooltube/ReelsFeed";
 
 export default function GamesPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-cyan-400 via-cyan-500 to-teal-600">
+    <div className="min-h-screen bg-gradient-to-b from-cyan-400 via-purple-400 to-pink-400">
       {/* Header */}
       <div className="px-4 pt-6 pb-2">
         <h1 className="text-3xl font-extrabold text-white text-center drop-shadow-md">
-          SchoolTube
+          Games
         </h1>
         <p className="text-center text-white/80 text-sm mt-1">
           Learn through play!

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -1,38 +1,141 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import SongCreator from '@/components/SongCreator';
 
-/* ── Music Hub Tabs ──────────────────────────────────────── */
-
 const TABS = [
+  { id: 'songs',       label: 'My Songs',   icon: '🎵' },
+  { id: 'create',      label: 'Create',     icon: '✨' },
   { id: 'instruments', label: 'Instruments', icon: '🎹' },
-  { id: 'moods',       label: 'Moods',       icon: '🎭' },
-  { id: 'create',      label: 'Create Song',  icon: '🎤' },
 ] as const;
 
 type TabId = (typeof TABS)[number]['id'];
 
-/* ── Page ─────────────────────────────────────────────────── */
+interface SavedSong {
+  id: string;
+  title: string;
+  audioUrl: string;
+  createdAt: number;
+}
+
+function formatDate(ts: number) {
+  return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function MySongsTab() {
+  const [songs, setSongs] = useState<SavedSong[]>([]);
+  const [playingId, setPlayingId] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem('8gentjr_songs') || '[]');
+      setSongs(saved);
+    } catch { /* noop */ }
+  }, []);
+
+  const handlePlay = (song: SavedSong) => {
+    if (playingId === song.id) {
+      audioRef.current?.pause();
+      setPlayingId(null);
+      return;
+    }
+    if (audioRef.current) {
+      audioRef.current.pause();
+    }
+    const audio = new Audio(song.audioUrl);
+    audio.play();
+    audio.onended = () => setPlayingId(null);
+    audioRef.current = audio;
+    setPlayingId(song.id);
+  };
+
+  const handleDelete = (id: string) => {
+    if (playingId === id) {
+      audioRef.current?.pause();
+      setPlayingId(null);
+    }
+    const updated = songs.filter(s => s.id !== id);
+    setSongs(updated);
+    try { localStorage.setItem('8gentjr_songs', JSON.stringify(updated)); } catch { /* noop */ }
+  };
+
+  if (songs.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-16 px-6 text-center">
+        <div className="text-5xl">🎤</div>
+        <p className="font-bold text-[#1a1a2e] text-lg">No songs yet</p>
+        <p className="text-[#8a7e70] text-sm leading-relaxed max-w-[280px]">
+          Head to the Create tab to make your first AI-generated song — it&apos;ll show up here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-md px-4 flex flex-col gap-2">
+      <p className="text-xs text-[#8a7e70] font-medium mb-1">{songs.length} song{songs.length !== 1 ? 's' : ''}</p>
+      {songs.map((song) => {
+        const isPlaying = playingId === song.id;
+        return (
+          <div
+            key={song.id}
+            className={`flex items-center gap-3 p-3 rounded-2xl border-2 transition-all ${
+              isPlaying
+                ? 'border-[#E8610A] bg-[#FFF3EA]'
+                : 'border-[#f0e6d6] bg-white'
+            }`}
+          >
+            {/* Play/pause button */}
+            <button
+              onClick={() => handlePlay(song)}
+              className={`w-11 h-11 shrink-0 rounded-full flex items-center justify-center text-white font-bold text-lg shadow transition-transform active:scale-90 border-none cursor-pointer ${
+                isPlaying
+                  ? 'bg-gradient-to-br from-[#E8610A] to-[#c44f08]'
+                  : 'bg-gradient-to-br from-[#10B981] to-[#059669]'
+              }`}
+              aria-label={isPlaying ? 'Pause' : 'Play'}
+            >
+              {isPlaying ? '⏸' : '▶'}
+            </button>
+
+            {/* Song info */}
+            <div className="flex-1 min-w-0">
+              <p className="font-bold text-[#1a1a2e] text-sm truncate">{song.title}</p>
+              <p className="text-[#8a7e70] text-xs">{formatDate(song.createdAt)}</p>
+            </div>
+
+            {/* Delete */}
+            <button
+              onClick={() => handleDelete(song.id)}
+              className="w-8 h-8 shrink-0 rounded-full bg-[#f0e6d6] text-[#8a7e70] flex items-center justify-center text-xs border-none cursor-pointer hover:bg-red-100 hover:text-red-500 transition-colors"
+              aria-label="Delete song"
+            >
+              ✕
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
 export default function MusicHubPage() {
-  const [tab, setTab] = useState<TabId>('instruments');
+  const [tab, setTab] = useState<TabId>('songs');
 
   return (
     <div className="min-h-dvh flex flex-col items-center bg-[#FFF8F0] pb-24">
       {/* Header */}
-      <h1 className="text-[22px] font-extrabold mt-5 mb-1 text-[#1a1a2e]">
-        Music
-      </h1>
+      <h1 className="text-[22px] font-extrabold mt-5 mb-1 text-[#1a1a2e]">Music</h1>
 
       {/* Tab bar */}
-      <div className="flex gap-2 my-3 mb-5 p-1 rounded-[14px] bg-[#f0e6d6]">
+      <div className="flex gap-1.5 my-3 mb-5 p-1 rounded-[14px] bg-[#f0e6d6]">
         {TABS.map((t) => (
           <button
             key={t.id}
             onClick={() => setTab(t.id)}
-            className={`px-4 py-2 border-none rounded-[10px] font-bold text-[14px] cursor-pointer transition-all duration-150 ${
+            className={`px-3 py-2 border-none rounded-[10px] font-bold text-[13px] cursor-pointer transition-all duration-150 whitespace-nowrap ${
               tab === t.id
                 ? 'bg-white text-[#1a1a2e] shadow-md'
                 : 'bg-transparent text-[#8a7e70]'
@@ -44,11 +147,11 @@ export default function MusicHubPage() {
       </div>
 
       {/* Tab content */}
+      {tab === 'songs' && <MySongsTab />}
+      {tab === 'create' && <SongCreator />}
       {tab === 'instruments' && (
         <div className="flex flex-col items-center gap-4 w-full max-w-md px-4">
-          <p className="text-[#8a7e70] text-center text-[15px]">
-            Play drums, xylophone, and more!
-          </p>
+          <p className="text-[#8a7e70] text-center text-[15px]">Play drums, xylophone, and more!</p>
           <Link
             href="/music/instruments"
             className="w-full flex items-center justify-center gap-3 px-6 py-4 rounded-2xl bg-gradient-to-r from-[#FF6B35] to-[#E8610A] text-white font-bold text-lg shadow-lg active:scale-95 transition-transform no-underline"
@@ -57,22 +160,6 @@ export default function MusicHubPage() {
           </Link>
         </div>
       )}
-
-      {tab === 'moods' && (
-        <div className="flex flex-col items-center gap-4 w-full max-w-md px-4">
-          <p className="text-[#8a7e70] text-center text-[15px]">
-            Pick a mood and listen to matching music!
-          </p>
-          <Link
-            href="/music/moods"
-            className="w-full flex items-center justify-center gap-3 px-6 py-4 rounded-2xl bg-gradient-to-r from-[#8B5CF6] to-[#6D28D9] text-white font-bold text-lg shadow-lg active:scale-95 transition-transform no-underline"
-          >
-            🎭 Browse Moods
-          </Link>
-        </div>
-      )}
-
-      {tab === 'create' && <SongCreator />}
     </div>
   );
 }

--- a/src/components/SongCreator.tsx
+++ b/src/components/SongCreator.tsx
@@ -72,7 +72,14 @@ export default function SongCreator() {
 
         if (data.status === 'complete' && data.audioUrl) {
           setAudioUrl(data.audioUrl);
-          if (data.title) setSongTitle(data.title);
+          const title = data.title || 'My Song';
+          setSongTitle(title);
+          // Persist to localStorage so the player tab can show it
+          try {
+            const saved = JSON.parse(localStorage.getItem('8gentjr_songs') || '[]');
+            saved.unshift({ id: Date.now().toString(), title, audioUrl: data.audioUrl, createdAt: Date.now() });
+            localStorage.setItem('8gentjr_songs', JSON.stringify(saved.slice(0, 50)));
+          } catch { /* localStorage unavailable */ }
           setPhase('ready');
           return;
         }
@@ -133,7 +140,14 @@ export default function SongCreator() {
 
       // Path B: direct audio (ElevenLabs fallback)
       if (data.audioUrl) {
+        const title = data.title || prompt.trim().slice(0, 40) || 'My Song';
         setAudioUrl(data.audioUrl);
+        setSongTitle(title);
+        try {
+          const saved = JSON.parse(localStorage.getItem('8gentjr_songs') || '[]');
+          saved.unshift({ id: Date.now().toString(), title, audioUrl: data.audioUrl, createdAt: Date.now() });
+          localStorage.setItem('8gentjr_songs', JSON.stringify(saved.slice(0, 50)));
+        } catch { /* localStorage unavailable */ }
         setPhase('ready');
         return;
       }

--- a/src/components/schooltube/ReelCard.tsx
+++ b/src/components/schooltube/ReelCard.tsx
@@ -99,22 +99,23 @@ export default function ReelCard({ reel }: { reel: Reel }) {
     <>
       <button
         onClick={handleClick}
-        className="relative overflow-hidden rounded-2xl shadow-md group cursor-pointer transition-all hover:ring-2 hover:ring-cyan-400 active:scale-[0.97] w-full text-left"
+        className="relative overflow-hidden rounded-2xl shadow-lg group cursor-pointer transition-all hover:ring-2 hover:ring-cyan-400 active:scale-[0.93] w-full text-left"
+        style={{ transition: 'transform 0.1s ease, box-shadow 0.15s ease' }}
       >
         <div
-          className="aspect-[3/4] relative"
+          className="aspect-[4/3] relative"
           style={{ background: getGradient(reel.topics) }}
         >
 
           {/* Gradient overlay */}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
 
-          {/* Center play icon */}
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="h-14 w-14 rounded-full bg-white/90 flex items-center justify-center shadow-xl">
+          {/* Center play icon — visible on hover (desktop) always on touch */}
+          <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 sm:group-hover:opacity-100 opacity-100 transition-opacity duration-150">
+            <div className="h-14 w-14 rounded-full bg-white/95 flex items-center justify-center shadow-xl">
               {reel.type === "video" ? (
                 <svg
-                  className="h-7 w-7 text-cyan-500 ml-0.5"
+                  className="h-7 w-7 text-cyan-500 ml-1"
                   fill="currentColor"
                   viewBox="0 0 24 24"
                 >
@@ -122,7 +123,7 @@ export default function ReelCard({ reel }: { reel: Reel }) {
                 </svg>
               ) : (
                 <svg
-                  className="h-7 w-7 text-cyan-500"
+                  className="h-6 w-6 text-cyan-500"
                   fill="none"
                   stroke="currentColor"
                   strokeWidth={2}


### PR DESCRIPTION
## Summary

- **Music — My Songs tab**: replaces the empty Moods playlists with a real player backed by localStorage. Generated songs appear here automatically.
- **Music — persistence**: SongCreator now saves to `localStorage` on both Suno (polling) and ElevenLabs (direct) completion paths. Up to 50 songs stored.
- **Music — tabs**: My Songs / Create / Instruments. Moods removed (empty playlists with no audio).
- **Games — header**: "SchoolTube" → "Games"
- **Games — gradient**: single cyan restored to cyan/purple/pink (matches NickOS original)
- **Games — card aspect ratio**: `[3/4]` → `[4/3]` (landscape, matches NickOS)
- **Games — tap animation**: `active:scale-[0.93]` with smooth shadow transition

## Regression source
Compared against NickOS prototype at `~/Myresumeportfolio/src/app/nick/`