### PR TITLE
fix: prevent double TTS voice + child voice for Talk

### DIFF
--- a/src/app/api/tts/route.ts
+++ b/src/app/api/tts/route.ts
@@ -12,8 +12,8 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
 
-// Jessica — Playful, Bright, Warm (young female, child-friendly)
-const DEFAULT_VOICE_ID = process.env.ELEVENLABS_JR_VOICE_ID ?? 'cgSgspJ2msm6clMCkdW9';
+// Charlie — Young, Natural, Conversational (child voice, ElevenLabs)
+const DEFAULT_VOICE_ID = process.env.ELEVENLABS_JR_VOICE_ID ?? 'IKne3meq5aSn9XLyUdCD';
 
 export async function GET(request: NextRequest) {
   const text = request.nextUrl.searchParams.get('text')?.trim();

--- a/src/lib/tts.ts
+++ b/src/lib/tts.ts
@@ -115,13 +115,15 @@ async function speakElevenLabs(
   if (opts.voiceId) params.set('voice', opts.voiceId);
   const res = await fetch(`/api/tts?${params.toString()}`);
 
-  // 204 = not configured, 4xx/5xx = error — fall back
-  if (!res.ok || res.status === 204) {
-    return 'none';
-  }
+  // 204 = not configured — fall back to browser TTS
+  if (res.status === 204) return 'none';
+
+  // Other error — ElevenLabs is configured but failed; fail silently, no robot fallback
+  if (!res.ok) return 'elevenlabs';
 
   const blob = await res.blob();
-  if (blob.size === 0) return 'none';
+  // Empty blob — configured but silent failure; don't trigger robot voice
+  if (blob.size === 0) return 'elevenlabs';
 
   const url = URL.createObjectURL(blob);
   const audio = new Audio(url);
@@ -138,13 +140,16 @@ async function speakElevenLabs(
       audio.src = '';
       URL.revokeObjectURL(url);
       currentAudio = null;
-      resolve('none');
+      // Don't resolve 'none' — would trigger browser TTS while ElevenLabs may still be audible
+      resolve('elevenlabs');
     };
     audio.play().catch(() => {
+      // iOS Safari can reject play() after user gesture context expires during fetch.
+      // Resolve 'elevenlabs' to prevent robot voice from firing on top.
       audio.src = '';
       URL.revokeObjectURL(url);
       currentAudio = null;
-      resolve('none');
+      resolve('elevenlabs');
     });
   });
 }


### PR DESCRIPTION
## Summary
- Fixed double-voice bug on /talk: ElevenLabs + browser robot voice were firing simultaneously
- Root cause: on iOS Safari, `audio.play()` rejects after ~500ms fetch delay (user gesture context expires); `onerror` / `play().catch()` were resolving `'none'` which triggered browser TTS fallback while ElevenLabs audio was still loaded/playing
- Fix: audio-level failures now resolve `'elevenlabs'` — browser TTS only fires when ElevenLabs is explicitly not configured (204 from server)
- Changed default ElevenLabs voice: Jessica → Charlie (young, natural, child-appropriate voice)

## Test plan
- [ ] Tap AAC cards on /talk — only one voice fires (ElevenLabs Charlie)
- [ ] No robot voice alongside ElevenLabs voice
- [ ] Voice sounds child-appropriate (Charlie voice)
- [ ] Browser TTS fallback still works if ELEVENLABS_API_KEY removed from env