### PR TITLE
feat: Chladni cymatics Sound Art tab

### DIFF
--- a/src/app/api/voice-card-create/route.ts
+++ b/src/app/api/voice-card-create/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest } from 'next/server';
+import Groq from 'groq-sdk';
+
+/**
+ * POST /api/voice-card-create
+ *
+ * Takes a parent's spoken request and returns a ready-to-render AAC card.
+ *
+ * Flow:
+ *   1. Groq (llama-3.3-70b) extracts: label, ARASAAC search term, Fitzgerald category
+ *   2. ARASAAC public API finds the best matching pictogram
+ *   3. Returns structured card data — client animates the card into view
+ *
+ * Stack: Groq / llama-3.3-70b-versatile + ARASAAC public API (no key needed)
+ */
+
+export const runtime = 'edge';
+
+const SYSTEM_PROMPT = `You are an AAC (Augmentative and Alternative Communication) vocabulary specialist.
+
+A parent has spoken a request to create a custom symbol card for their child's communication board.
+
+Your job: extract the core concept and classify it for the board.
+
+Return ONLY a JSON object — no markdown, no explanation:
+{
+  "label": "swimming",
+  "searchTerm": "swim",
+  "category": "verb",
+  "rationale": "swimming is an action/activity"
+}
+
+Rules:
+- label: 1-3 words, child-friendly, title case for nouns, lowercase for verbs/adjectives
+- searchTerm: single simple English word for pictogram search (the most concrete noun or verb)
+- category: MUST be one of exactly: pronoun | verb | noun | adjective | preposition | question | negation | social
+  - verb: actions, activities (eat, swim, play, run, help)
+  - noun: people, places, objects, animals (dog, toilet, park, doctor)
+  - adjective: feelings, descriptions (happy, hot, tired, big)
+  - pronoun: people words (I, you, we) — only if explicitly requested
+  - social: greetings, manners (hello, please, sorry)
+  - negation: stop, no, don't — only if explicitly requested
+  - question: what, where, why — only if explicitly requested
+  - preposition: in, on, under — only if explicitly requested
+- rationale: one brief sentence explaining the category choice`;
+
+interface CardRequest {
+  speech: string;
+}
+
+interface ArasaacResult {
+  _id: number;
+  [key: string]: unknown;
+}
+
+async function findArasaacPictogram(searchTerm: string): Promise<{ id: number; imageUrl: string } | null> {
+  try {
+    const res = await fetch(
+      `https://api.arasaac.org/v1/pictograms/en/search/${encodeURIComponent(searchTerm)}`,
+      { headers: { 'Accept': 'application/json' } }
+    );
+    if (!res.ok) return null;
+    const results: ArasaacResult[] = await res.json();
+    if (!results || results.length === 0) return null;
+    const id = results[0]._id;
+    return {
+      id,
+      imageUrl: `https://static.arasaac.org/pictograms/${id}/${id}_500.png`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const groqKey = process.env.GROQ_API_KEY;
+    if (!groqKey) {
+      return new Response(JSON.stringify({ error: 'GROQ_API_KEY not configured' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const body: CardRequest = await request.json();
+    const { speech } = body;
+
+    if (!speech?.trim()) {
+      return new Response(JSON.stringify({ error: 'speech required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const groq = new Groq({ apiKey: groqKey });
+
+    const completion = await groq.chat.completions.create({
+      model: 'llama-3.3-70b-versatile',
+      max_tokens: 200,
+      temperature: 0.1, // deterministic — same request should return same card
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: speech.trim() },
+      ],
+    });
+
+    const raw = completion.choices?.[0]?.message?.content ?? '';
+
+    // Parse JSON from response — model is instructed to return only JSON
+    let parsed: { label: string; searchTerm: string; category: string; rationale?: string };
+    try {
+      // Strip any accidental markdown fences
+      const cleaned = raw.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+      parsed = JSON.parse(cleaned);
+    } catch {
+      // Fallback: use the speech as the label
+      const fallbackLabel = speech.trim().slice(0, 30);
+      parsed = { label: fallbackLabel, searchTerm: fallbackLabel.split(' ')[0], category: 'noun' };
+    }
+
+    // Validate category
+    const validCategories = ['pronoun', 'verb', 'noun', 'adjective', 'preposition', 'question', 'negation', 'social'];
+    const category = validCategories.includes(parsed.category) ? parsed.category : 'noun';
+
+    // Find ARASAAC pictogram — try searchTerm first, fall back to first word of label
+    let pictogram = await findArasaacPictogram(parsed.searchTerm);
+    if (!pictogram) {
+      pictogram = await findArasaacPictogram(parsed.label.split(' ')[0]);
+    }
+
+    return new Response(
+      JSON.stringify({
+        label: parsed.label,
+        category,
+        arasaacId: pictogram?.id ?? null,
+        imageUrl: pictogram?.imageUrl ?? null,
+        rationale: parsed.rationale ?? null,
+        transcript: speech.trim(),
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  } catch (error) {
+    console.error('[VoiceCardCreate] Error:', error);
+    return new Response(JSON.stringify({ error: 'Failed to create card' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -3,11 +3,13 @@
 import Link from 'next/link';
 import { useState, useEffect, useRef } from 'react';
 import SongCreator from '@/components/SongCreator';
+import { ChladniVisualizer } from '@/components/ChladniVisualizer';
 
 const TABS = [
   { id: 'songs',       label: 'My Songs',   icon: '🎵' },
   { id: 'create',      label: 'Create',     icon: '✨' },
   { id: 'instruments', label: 'Instruments', icon: '🎹' },
+  { id: 'soundart',    label: 'Sound Art',  icon: '✦' },
 ] as const;
 
 type TabId = (typeof TABS)[number]['id'];
@@ -160,6 +162,7 @@ export default function MusicHubPage() {
           </Link>
         </div>
       )}
+      {tab === 'soundart' && <ChladniVisualizer />}
     </div>
   );
 }

--- a/src/app/talk/page.tsx
+++ b/src/app/talk/page.tsx
@@ -12,6 +12,7 @@
 import { useState } from "react";
 import { SupercoreGrid } from "@/components/SupercoreGrid";
 import AACHome from "@/components/AACHome";
+import { VoiceCardCreator } from "@/components/VoiceCardCreator";
 
 type ViewMode = "core" | "browse";
 
@@ -49,6 +50,9 @@ export default function TalkPage() {
         {viewMode === "core" && <SupercoreGrid />}
         {viewMode === "browse" && <AACHome />}
       </div>
+
+      {/* Parent voice card creator — floating mic, bottom-left */}
+      <VoiceCardCreator />
     </div>
   );
 }

--- a/src/components/ChladniVisualizer.tsx
+++ b/src/components/ChladniVisualizer.tsx
@@ -1,0 +1,482 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+
+/* ── Chladni modes — note colors map to visible light spectrum ── */
+
+const MODES = [
+  { n: 1, m: 2, note: "C", freq: 130.81, label: "Cross",   color: "#FF3333" },
+  { n: 2, m: 3, note: "D", freq: 146.83, label: "Diamond", color: "#FF8C00" },
+  { n: 3, m: 5, note: "E", freq: 164.81, label: "Star",    color: "#FFD700" },
+  { n: 1, m: 4, note: "F", freq: 174.61, label: "Lines",   color: "#00CC66" },
+  { n: 4, m: 5, note: "G", freq: 196.0,  label: "Web",     color: "#00BFFF" },
+  { n: 2, m: 5, note: "A", freq: 220.0,  label: "Flower",  color: "#8B5CF6" },
+] as const;
+
+/* ── Ambient noise presets ──────────────────────────────────── */
+
+const AMBIENT = [
+  { id: "rain",  label: "Rain",  filterType: "highpass" as BiquadFilterType, freq: 3000, q: 1.0,  vol: 0.04 },
+  { id: "river", label: "River", filterType: "bandpass" as BiquadFilterType, freq: 800,  q: 0.5,  vol: 0.04 },
+  { id: "ocean", label: "Ocean", filterType: "lowpass"  as BiquadFilterType, freq: 400,  q: 0.7,  vol: 0.06 },
+  { id: "pink",  label: "Pink",  filterType: "lowpass"  as BiquadFilterType, freq: 4000, q: 0.1,  vol: 0.03 },
+  { id: "white", label: "White", filterType: "allpass"  as BiquadFilterType, freq: 1000, q: 0.1,  vol: 0.025 },
+] as const;
+
+const PARTICLE_COUNT = 3000;
+const FORCE = 0.00002;
+const DAMPING = 0.95;
+const NOISE_PHYSICS = 0.00005;
+
+/* ── Particle type ──────────────────────────────────────── */
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  a: number;
+}
+
+/* ── Chladni equation for a vibrating square plate ─────── */
+
+function chladni(x: number, y: number, n: number, m: number): number {
+  return (
+    Math.cos(n * Math.PI * x) * Math.cos(m * Math.PI * y) -
+    Math.cos(m * Math.PI * x) * Math.cos(n * Math.PI * y)
+  );
+}
+
+function chladniGrad(
+  x: number,
+  y: number,
+  n: number,
+  m: number,
+): [number, number] {
+  const np = n * Math.PI;
+  const mp = m * Math.PI;
+  return [
+    -np * Math.sin(np * x) * Math.cos(mp * y) +
+      mp * Math.sin(mp * x) * Math.cos(np * y),
+    -mp * Math.cos(np * x) * Math.sin(mp * y) +
+      np * Math.cos(mp * x) * Math.sin(np * y),
+  ];
+}
+
+/* ── Helpers ────────────────────────────────────────────── */
+
+function makeParticles(): Particle[] {
+  return Array.from({ length: PARTICLE_COUNT }, () => ({
+    x: Math.random(),
+    y: Math.random(),
+    vx: 0,
+    vy: 0,
+    r: 0.6 + Math.random() * 1.0,
+    a: 0.35 + Math.random() * 0.55,
+  }));
+}
+
+function scatter(particles: Particle[]) {
+  for (const p of particles) {
+    p.x = Math.random();
+    p.y = Math.random();
+    p.vx = (Math.random() - 0.5) * 0.002;
+    p.vy = (Math.random() - 0.5) * 0.002;
+  }
+}
+
+function createNoiseBuffer(ctx: AudioContext): AudioBuffer {
+  const len = ctx.sampleRate * 2;
+  const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+  const data = buf.getChannelData(0);
+  for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1;
+  return buf;
+}
+
+/* ── Component ──────────────────────────────────────────── */
+
+export function ChladniVisualizer() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const particles = useRef(makeParticles());
+  const animId = useRef(0);
+  const hueRef = useRef(280);
+  const volRef = useRef(0.5);
+
+  /* Audio refs */
+  const audioCtx = useRef<AudioContext | null>(null);
+  const masterGain = useRef<GainNode | null>(null);
+  const oscNodes = useRef<OscillatorNode[]>([]);
+  const noiseNodes = useRef<{ source: AudioBufferSourceNode; gain: GainNode } | null>(null);
+  const noiseBuf = useRef<AudioBuffer | null>(null);
+  const mode = useRef<{ n: number; m: number } | null>(null);
+
+  /* UI state */
+  const [activeIdx, setActiveIdx] = useState<number | null>(null);
+  const [activeAmbient, setActiveAmbient] = useState<string | null>(null);
+  const [hue, setHue] = useState(280);
+  const [volume, setVolume] = useState(50);
+
+  useEffect(() => { hueRef.current = hue; }, [hue]);
+  useEffect(() => {
+    const v = volume / 100;
+    volRef.current = v;
+    if (masterGain.current) masterGain.current.gain.value = v;
+  }, [volume]);
+
+  /* ── Audio setup ─────────────────────────────────────── */
+
+  const getAudio = useCallback(() => {
+    if (!audioCtx.current || audioCtx.current.state === "closed") {
+      audioCtx.current = new AudioContext();
+      masterGain.current = audioCtx.current.createGain();
+      masterGain.current.gain.value = volRef.current;
+      masterGain.current.connect(audioCtx.current.destination);
+    }
+    if (audioCtx.current.state === "suspended") audioCtx.current.resume();
+    return audioCtx.current;
+  }, []);
+
+  const getMaster = useCallback(() => {
+    getAudio();
+    return masterGain.current!;
+  }, [getAudio]);
+
+  /* ── Tone controls ───────────────────────────────────── */
+
+  const stopTone = useCallback(() => {
+    const ctx = audioCtx.current;
+    if (!ctx) return;
+    const now = ctx.currentTime;
+    for (const o of oscNodes.current) {
+      try { o.stop(now + 1.2); } catch { /* already stopped */ }
+    }
+    oscNodes.current = [];
+  }, []);
+
+  const playTone = useCallback(
+    (freq: number) => {
+      stopTone();
+      const ctx = getAudio();
+      const master = getMaster();
+      const now = ctx.currentTime;
+      const nodes: OscillatorNode[] = [];
+
+      const layer = (f: number, vol: number, attack: number, release: number) => {
+        const osc = ctx.createOscillator();
+        const g = ctx.createGain();
+        osc.type = "sine";
+        osc.frequency.setValueAtTime(f, now);
+        osc.connect(g);
+        g.connect(master);
+        g.gain.setValueAtTime(0.001, now);
+        g.gain.exponentialRampToValueAtTime(vol, now + attack);
+        g.gain.setTargetAtTime(vol, now + attack, 0.5);
+        g.gain.setTargetAtTime(0.001, now + release, 0.9);
+        osc.start(now);
+        osc.stop(now + release + 3);
+        nodes.push(osc);
+      };
+
+      layer(freq, 0.12, 2, 10);
+      layer(freq / 2, 0.05, 2.5, 10);
+      layer(freq * 1.5, 0.018, 3, 9);
+
+      oscNodes.current = nodes;
+    },
+    [getAudio, getMaster, stopTone],
+  );
+
+  /* ── Ambient noise controls ──────────────────────────── */
+
+  const stopNoise = useCallback(() => {
+    if (noiseNodes.current) {
+      const { source, gain } = noiseNodes.current;
+      const ctx = audioCtx.current;
+      if (ctx) {
+        const now = ctx.currentTime;
+        gain.gain.setValueAtTime(gain.gain.value, now);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.5);
+        try { source.stop(now + 0.6); } catch { /* noop */ }
+      }
+      noiseNodes.current = null;
+    }
+  }, []);
+
+  const startNoise = useCallback(
+    (preset: (typeof AMBIENT)[number]) => {
+      stopNoise();
+      const ctx = getAudio();
+      const master = getMaster();
+
+      if (!noiseBuf.current) noiseBuf.current = createNoiseBuffer(ctx);
+
+      const source = ctx.createBufferSource();
+      source.buffer = noiseBuf.current;
+      source.loop = true;
+
+      const filter = ctx.createBiquadFilter();
+      filter.type = preset.filterType;
+      filter.frequency.value = preset.freq;
+      filter.Q.value = preset.q;
+
+      const gain = ctx.createGain();
+      gain.gain.setValueAtTime(0.001, ctx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(preset.vol, ctx.currentTime + 1);
+
+      source.connect(filter);
+      filter.connect(gain);
+      gain.connect(master);
+      source.start();
+
+      noiseNodes.current = { source, gain };
+    },
+    [getAudio, getMaster, stopNoise],
+  );
+
+  const toggleAmbient = useCallback(
+    (id: string) => {
+      if (activeAmbient === id) {
+        stopNoise();
+        setActiveAmbient(null);
+      } else {
+        const preset = AMBIENT.find((a) => a.id === id)!;
+        startNoise(preset);
+        setActiveAmbient(id);
+      }
+    },
+    [activeAmbient, startNoise, stopNoise],
+  );
+
+  /* ── Mode selection ──────────────────────────────────── */
+
+  const selectMode = useCallback(
+    (i: number) => {
+      const m = MODES[i];
+      mode.current = { n: m.n, m: m.m };
+      setActiveIdx(i);
+      playTone(m.freq);
+      scatter(particles.current);
+      if (typeof navigator !== "undefined" && navigator.vibrate)
+        navigator.vibrate(25);
+    },
+    [playTone],
+  );
+
+  /* ── Canvas animation loop ───────────────────────────── */
+
+  useEffect(() => {
+    const cvs = canvasRef.current;
+    if (!cvs) return;
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = cvs.getBoundingClientRect();
+      cvs.width = rect.width * dpr;
+      cvs.height = rect.height * dpr;
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    const ctx = cvs.getContext("2d")!;
+
+    const tick = () => {
+      const w = cvs.width;
+      const h = cvs.height;
+      const sz = Math.min(w, h);
+      const ox = (w - sz) / 2;
+      const oy = (h - sz) / 2;
+      const dpr = window.devicePixelRatio || 1;
+      const pad = 8 * dpr;
+      const inner = sz - pad * 2;
+
+      ctx.fillStyle = "#080810";
+      ctx.fillRect(0, 0, w, h);
+
+      ctx.strokeStyle = `hsla(${hueRef.current}, 30%, 35%, 0.2)`;
+      ctx.lineWidth = 1.5 * dpr;
+      ctx.strokeRect(ox + pad, oy + pad, inner, inner);
+
+      const pts = particles.current;
+      const m = mode.current;
+
+      for (let i = 0; i < pts.length; i++) {
+        const p = pts[i];
+        if (m) {
+          const z = chladni(p.x, p.y, m.n, m.m);
+          const [gx, gy] = chladniGrad(p.x, p.y, m.n, m.m);
+          p.vx += -z * gx * FORCE;
+          p.vy += -z * gy * FORCE;
+        }
+        p.vx += (Math.random() - 0.5) * NOISE_PHYSICS;
+        p.vy += (Math.random() - 0.5) * NOISE_PHYSICS;
+        p.vx *= DAMPING;
+        p.vy *= DAMPING;
+        p.x += p.vx;
+        p.y += p.vy;
+        if (p.x < 0) { p.x = 0; p.vx = Math.abs(p.vx) * 0.3; }
+        if (p.x > 1) { p.x = 1; p.vx = -Math.abs(p.vx) * 0.3; }
+        if (p.y < 0) { p.y = 0; p.vy = Math.abs(p.vy) * 0.3; }
+        if (p.y > 1) { p.y = 1; p.vy = -Math.abs(p.vy) * 0.3; }
+      }
+
+      const ch = hueRef.current;
+      for (let i = 0; i < pts.length; i++) {
+        const p = pts[i];
+        ctx.fillStyle = `hsla(${ch}, 72%, 66%, ${p.a})`;
+        ctx.fillRect(
+          ox + pad + p.x * inner - p.r * dpr * 0.5,
+          oy + pad + p.y * inner - p.r * dpr * 0.5,
+          p.r * dpr,
+          p.r * dpr,
+        );
+      }
+
+      animId.current = requestAnimationFrame(tick);
+    };
+
+    animId.current = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(animId.current);
+      window.removeEventListener("resize", resize);
+    };
+  }, []);
+
+  /* ── Cleanup audio on unmount ────────────────────────── */
+
+  useEffect(() => {
+    return () => {
+      stopTone();
+      stopNoise();
+      if (audioCtx.current && audioCtx.current.state !== "closed")
+        audioCtx.current.close();
+    };
+  }, [stopTone, stopNoise]);
+
+  /* ── Render ──────────────────────────────────────────── */
+
+  return (
+    <div className="flex flex-col items-center gap-3 w-full max-w-md px-3">
+      {/* Chladni plate canvas */}
+      <div className="relative w-full aspect-square rounded-2xl overflow-hidden shadow-xl">
+        <canvas
+          ref={canvasRef}
+          className="w-full h-full block"
+          style={{ touchAction: "none" }}
+        />
+        {activeIdx === null && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none gap-2">
+            <span className="text-3xl opacity-40">✦</span>
+            <p className="text-white/30 text-sm font-medium text-center px-8 leading-relaxed">
+              Tap a note to see
+              <br />
+              sound become art
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Sliders row: Color + Volume */}
+      <div className="flex flex-col gap-2 w-full">
+        {/* Color slider */}
+        <div className="flex items-center gap-2.5 w-full px-1">
+          <span className="text-xs text-[#8a7e70] font-semibold shrink-0 w-10">
+            Color
+          </span>
+          <input
+            type="range"
+            min={0}
+            max={360}
+            value={hue}
+            onChange={(e) => setHue(Number(e.target.value))}
+            className="flex-1 h-2.5 rounded-full appearance-none cursor-pointer outline-none"
+            style={{
+              background:
+                "linear-gradient(to right, hsl(0,80%,60%), hsl(60,80%,60%), hsl(120,80%,60%), hsl(180,80%,60%), hsl(240,80%,60%), hsl(300,80%,60%), hsl(360,80%,60%))",
+            }}
+          />
+          <div
+            className="w-5 h-5 rounded-full border-2 border-white/20 shadow-sm shrink-0"
+            style={{ backgroundColor: `hsl(${hue}, 80%, 60%)` }}
+          />
+        </div>
+
+        {/* Volume slider */}
+        <div className="flex items-center gap-2.5 w-full px-1">
+          <span className="text-xs text-[#8a7e70] font-semibold shrink-0 w-10">
+            Vol
+          </span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={volume}
+            onChange={(e) => setVolume(Number(e.target.value))}
+            className="flex-1 h-2.5 rounded-full appearance-none cursor-pointer outline-none"
+            style={{
+              background: `linear-gradient(to right, #1a1a2e ${volume}%, #f0e6d6 ${volume}%)`,
+            }}
+          />
+          <span className="text-xs text-[#8a7e70] font-semibold shrink-0 w-7 text-right tabular-nums">
+            {volume}%
+          </span>
+        </div>
+      </div>
+
+      {/* Note buttons — colored by frequency-to-light mapping */}
+      <div className="grid grid-cols-6 gap-1.5 w-full">
+        {MODES.map((m, i) => {
+          const active = activeIdx === i;
+          return (
+            <button
+              key={i}
+              onClick={() => selectMode(i)}
+              className={`flex flex-col items-center py-2.5 rounded-xl border-2 font-bold cursor-pointer transition-all duration-200 select-none active:scale-90 ${
+                active ? "scale-[1.06]" : ""
+              }`}
+              style={{
+                backgroundColor: active ? m.color : `${m.color}18`,
+                borderColor: active ? m.color : `${m.color}40`,
+                color: active ? "#fff" : m.color,
+                boxShadow: active
+                  ? `0 0 18px ${m.color}50`
+                  : "none",
+                textShadow: active ? "0 1px 2px rgba(0,0,0,0.4)" : "none",
+              }}
+            >
+              <span className="text-base leading-none">{m.note}</span>
+              <span className="text-[9px] mt-0.5 opacity-70 leading-none">
+                {m.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Ambient noise tracks */}
+      <div className="w-full">
+        <p className="text-[10px] text-[#8a7e70] font-semibold uppercase tracking-wider mb-1.5 px-1">
+          Ambient
+        </p>
+        <div className="grid grid-cols-5 gap-1.5 w-full">
+          {AMBIENT.map((a) => {
+            const active = activeAmbient === a.id;
+            return (
+              <button
+                key={a.id}
+                onClick={() => toggleAmbient(a.id)}
+                className={`py-2 rounded-xl border font-semibold text-xs cursor-pointer transition-all duration-200 select-none active:scale-90 ${
+                  active
+                    ? "bg-[#1a1a2e] text-white border-[#1a1a2e] shadow-md"
+                    : "bg-white/80 text-[#8a7e70] border-[#f0e6d6] hover:border-[#d0c6b6]"
+                }`}
+              >
+                {a.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/VoiceCardCreator.tsx
+++ b/src/components/VoiceCardCreator.tsx
@@ -1,0 +1,516 @@
+'use client';
+
+/**
+ * VoiceCardCreator — parent voice-to-AAC-card builder.
+ *
+ * Parent taps mic → speaks → card materialises in front of their eyes.
+ * Sequence: idle → listening → processing → preview → saved
+ *
+ * Soft, careful, magical — deterministic output, animated reveal.
+ */
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { FITZGERALD_COLORS, type WordCategory } from '@/lib/fitzgerald-key';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Phase = 'idle' | 'listening' | 'processing' | 'preview' | 'saved' | 'error';
+
+interface GeneratedCard {
+  label: string;
+  category: WordCategory;
+  arasaacId: number | null;
+  imageUrl: string | null;
+  transcript: string;
+}
+
+interface VoiceCardCreatorProps {
+  /** Called after the card is saved to localStorage */
+  onSaved?: (card: GeneratedCard) => void;
+  /** Render the floating trigger button inline (default true) */
+  showTrigger?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function saveToLocalStorage(card: GeneratedCard) {
+  try {
+    const stored = JSON.parse(localStorage.getItem('8gentjr_custom_cards') || '[]');
+    stored.unshift({ ...card, id: `custom-${Date.now()}`, createdAt: Date.now() });
+    localStorage.setItem('8gentjr_custom_cards', JSON.stringify(stored.slice(0, 100)));
+  } catch { /* noop — localStorage not available */ }
+}
+
+// ---------------------------------------------------------------------------
+// Listening Ring — pulsing red circle during speech recognition
+// ---------------------------------------------------------------------------
+
+function ListeningRing({ transcript }: { transcript: string }) {
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <div className="relative flex items-center justify-center">
+        {/* Outer pulse rings */}
+        <div className="absolute w-32 h-32 rounded-full bg-red-500/20 animate-ping" style={{ animationDuration: '1.5s' }} />
+        <div className="absolute w-24 h-24 rounded-full bg-red-500/30 animate-ping" style={{ animationDuration: '1.5s', animationDelay: '0.3s' }} />
+        {/* Core mic circle */}
+        <div className="relative w-20 h-20 rounded-full bg-red-500 shadow-[0_0_32px_8px_rgba(239,68,68,0.4)] flex items-center justify-center">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="white" className="drop-shadow">
+            <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/>
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2" stroke="white" strokeWidth="2" fill="none" strokeLinecap="round"/>
+            <line x1="12" y1="19" x2="12" y2="23" stroke="white" strokeWidth="2" strokeLinecap="round"/>
+            <line x1="8" y1="23" x2="16" y2="23" stroke="white" strokeWidth="2" strokeLinecap="round"/>
+          </svg>
+        </div>
+      </div>
+
+      <div className="text-center">
+        <p className="text-white/50 text-sm font-medium tracking-widest uppercase mb-2">Listening</p>
+        <p className="text-white text-lg font-semibold min-h-[28px] transition-all duration-200 max-w-[260px] text-center leading-snug">
+          {transcript || <span className="text-white/30">Say a word or phrase...</span>}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Processing Skeleton — card shape building itself
+// ---------------------------------------------------------------------------
+
+function ProcessingSkeleton() {
+  return (
+    <div className="flex flex-col items-center gap-6">
+      {/* Card skeleton */}
+      <div className="w-44 h-52 rounded-3xl bg-white/8 border border-white/15 overflow-hidden relative flex flex-col items-center justify-end pb-4">
+        {/* Shimmer sweep */}
+        <div className="absolute inset-0 overflow-hidden rounded-3xl">
+          <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent animate-shimmer" />
+        </div>
+        {/* Image placeholder */}
+        <div className="absolute top-6 left-1/2 -translate-x-1/2 w-24 h-24 rounded-2xl bg-white/10 animate-pulse" />
+        {/* Label placeholder */}
+        <div className="w-24 h-4 rounded-full bg-white/15 animate-pulse" />
+      </div>
+
+      <p className="text-white/50 text-sm font-medium tracking-widest uppercase animate-pulse">
+        Creating card...
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card Preview — the magical reveal
+// ---------------------------------------------------------------------------
+
+function CardPreview({
+  card,
+  onSave,
+  onRetry,
+}: {
+  card: GeneratedCard;
+  onSave: () => void;
+  onRetry: () => void;
+}) {
+  const [imgVisible, setImgVisible] = useState(false);
+  const [labelVisible, setLabelVisible] = useState(false);
+  const [buttonsVisible, setButtonsVisible] = useState(false);
+  const colors = FITZGERALD_COLORS[card.category] ?? FITZGERALD_COLORS.noun;
+
+  useEffect(() => {
+    // Staggered reveal — image first, then label, then buttons
+    const t1 = setTimeout(() => setImgVisible(true), 80);
+    const t2 = setTimeout(() => setLabelVisible(true), 280);
+    const t3 = setTimeout(() => setButtonsVisible(true), 480);
+    return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); };
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      {/* The card */}
+      <div
+        className="w-44 h-52 rounded-3xl shadow-2xl flex flex-col items-center justify-between py-5 px-3 border-4 relative overflow-hidden animate-card-appear"
+        style={{ backgroundColor: colors.bg, borderColor: colors.border }}
+      >
+        {/* Category label — top-right chip */}
+        <div
+          className="absolute top-3 right-3 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide opacity-70"
+          style={{ backgroundColor: colors.border, color: colors.bg === '#FFEB3B' ? '#000' : '#fff' }}
+        >
+          {colors.label}
+        </div>
+
+        {/* Pictogram */}
+        <div
+          className="flex-1 flex items-center justify-center transition-all duration-400 ease-out"
+          style={{
+            opacity: imgVisible ? 1 : 0,
+            transform: imgVisible ? 'scale(1)' : 'scale(0.82)',
+          }}
+        >
+          {card.imageUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={card.imageUrl}
+              alt={card.label}
+              className="w-28 h-28 object-contain drop-shadow-sm"
+            />
+          ) : (
+            <div className="w-24 h-24 rounded-2xl flex items-center justify-center text-5xl opacity-60">
+              📋
+            </div>
+          )}
+        </div>
+
+        {/* Label */}
+        <p
+          className="font-extrabold text-base text-center leading-tight transition-all duration-300 ease-out px-1"
+          style={{
+            color: colors.text,
+            opacity: labelVisible ? 1 : 0,
+            transform: labelVisible ? 'translateY(0)' : 'translateY(8px)',
+          }}
+        >
+          {card.label}
+        </p>
+      </div>
+
+      {/* Transcript echo */}
+      {card.transcript && (
+        <p
+          className="text-white/40 text-xs text-center italic transition-opacity duration-500"
+          style={{ opacity: labelVisible ? 1 : 0 }}
+        >
+          &ldquo;{card.transcript}&rdquo;
+        </p>
+      )}
+
+      {/* Actions */}
+      <div
+        className="flex gap-3 transition-all duration-300 ease-out"
+        style={{ opacity: buttonsVisible ? 1 : 0, transform: buttonsVisible ? 'translateY(0)' : 'translateY(6px)' }}
+      >
+        <button
+          onClick={onRetry}
+          className="px-5 py-3 rounded-2xl bg-white/10 text-white font-semibold text-sm hover:bg-white/20 active:scale-95 transition-all border border-white/20"
+        >
+          Try again
+        </button>
+        <button
+          onClick={onSave}
+          className="px-6 py-3 rounded-2xl bg-emerald-500 hover:bg-emerald-400 text-white font-bold text-sm shadow-lg shadow-emerald-500/30 active:scale-95 transition-all"
+        >
+          Add to My Words
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Saved confirmation
+// ---------------------------------------------------------------------------
+
+function SavedConfirmation({ card }: { card: GeneratedCard }) {
+  const colors = FITZGERALD_COLORS[card.category] ?? FITZGERALD_COLORS.noun;
+  return (
+    <div className="flex flex-col items-center gap-4 animate-fade-in">
+      <div
+        className="w-20 h-20 rounded-2xl flex items-center justify-center border-4 shadow-xl"
+        style={{ backgroundColor: colors.bg, borderColor: colors.border }}
+      >
+        {card.imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={card.imageUrl} alt={card.label} className="w-14 h-14 object-contain" />
+        ) : (
+          <span className="text-3xl">📋</span>
+        )}
+      </div>
+      <div className="text-center">
+        <p className="text-emerald-400 font-bold text-lg">Added!</p>
+        <p className="text-white/60 text-sm">{card.label} is now in My Words</p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-5 text-center">
+      <div className="w-16 h-16 rounded-full bg-red-500/20 flex items-center justify-center">
+        <span className="text-2xl">🎤</span>
+      </div>
+      <div>
+        <p className="text-white font-semibold">{message}</p>
+        <p className="text-white/40 text-sm mt-1">Voice recognition needs microphone permission</p>
+      </div>
+      <button
+        onClick={onRetry}
+        className="px-6 py-3 rounded-2xl bg-white/10 text-white font-semibold border border-white/20 hover:bg-white/20 active:scale-95 transition-all"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function VoiceCardCreator({ onSaved, showTrigger = true }: VoiceCardCreatorProps) {
+  const [open, setOpen] = useState(false);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [transcript, setTranscript] = useState('');
+  const [card, setCard] = useState<GeneratedCard | null>(null);
+  const [errorMsg, setErrorMsg] = useState('');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recognitionRef = useRef<any>(null);
+
+  // Clean up recognition on unmount
+  useEffect(() => {
+    return () => { recognitionRef.current?.abort(); };
+  }, []);
+
+  const closeOverlay = useCallback(() => {
+    recognitionRef.current?.abort();
+    setOpen(false);
+    // Reset phase after fade-out
+    setTimeout(() => {
+      setPhase('idle');
+      setTranscript('');
+      setCard(null);
+      setErrorMsg('');
+    }, 400);
+  }, []);
+
+  const generateCard = useCallback(async (text: string) => {
+    setPhase('processing');
+    try {
+      const res = await fetch('/api/voice-card-create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ speech: text }),
+      });
+      if (!res.ok) throw new Error('API error');
+      const data = await res.json();
+      if (data.error) throw new Error(data.error);
+      setCard(data as GeneratedCard);
+      setPhase('preview');
+    } catch {
+      setErrorMsg("Couldn't create the card. Try again.");
+      setPhase('error');
+    }
+  }, []);
+
+  const startListening = useCallback(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = typeof window !== 'undefined' ? (window as any) : null;
+    const SR = w?.SpeechRecognition ?? w?.webkitSpeechRecognition ?? null;
+
+    if (!SR) {
+      setErrorMsg("Voice recognition isn't supported on this browser.");
+      setPhase('error');
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const recognition: any = new SR();
+    recognition.lang = 'en-GB';
+    recognition.continuous = false;
+    recognition.interimResults = true;
+    recognition.maxAlternatives = 1;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    recognition.onresult = (e: any) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const t = Array.from(e.results as any[]).map((r: any) => r[0].transcript).join('');
+      setTranscript(t);
+
+      if (e.results[e.results.length - 1].isFinal) {
+        recognition.stop();
+        generateCard(t);
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    recognition.onerror = (e: any) => {
+      if (e.error === 'no-speech') {
+        setErrorMsg("I didn't catch that. Tap to try again.");
+      } else if (e.error === 'not-allowed') {
+        setErrorMsg('Microphone permission denied. Please allow access.');
+      } else {
+        setErrorMsg("Couldn't hear you. Try again.");
+      }
+      setPhase('error');
+    };
+
+    recognition.onend = () => {
+      // If still listening (no result) → transition to processing with current transcript
+      setPhase((current) => {
+        if (current === 'listening' && transcript) {
+          generateCard(transcript);
+          return 'processing';
+        }
+        return current;
+      });
+    };
+
+    recognitionRef.current = recognition;
+    recognition.start();
+    setTranscript('');
+    setPhase('listening');
+  }, [generateCard, transcript]);
+
+  const handleSave = useCallback(() => {
+    if (!card) return;
+    saveToLocalStorage(card);
+    onSaved?.(card);
+    setPhase('saved');
+    setTimeout(() => closeOverlay(), 1800);
+  }, [card, onSaved, closeOverlay]);
+
+  const handleOpen = useCallback(() => {
+    setOpen(true);
+    setPhase('idle');
+    // Auto-start listening immediately
+    requestAnimationFrame(() => startListening());
+  }, [startListening]);
+
+  return (
+    <>
+      {/* Floating trigger */}
+      {showTrigger && (
+        <button
+          onClick={handleOpen}
+          className="fixed bottom-28 left-4 z-30 w-12 h-12 rounded-full bg-gray-800/80 backdrop-blur-md border border-white/10 text-white/60 hover:text-white hover:bg-gray-700/90 hover:border-white/20 active:scale-90 transition-all shadow-lg flex items-center justify-center"
+          aria-label="Create a new word card by voice"
+          title="Create card by voice"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/>
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+            <line x1="12" y1="19" x2="12" y2="23"/>
+            <line x1="8" y1="23" x2="16" y2="23"/>
+          </svg>
+        </button>
+      )}
+
+      {/* Overlay */}
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          style={{
+            background: 'rgba(10, 10, 20, 0.82)',
+            backdropFilter: 'blur(12px)',
+            WebkitBackdropFilter: 'blur(12px)',
+            animation: 'overlayIn 0.35s ease-out',
+          }}
+        >
+          {/* Close button */}
+          <button
+            onClick={closeOverlay}
+            className="absolute top-6 right-6 w-10 h-10 rounded-full bg-white/10 text-white/60 hover:text-white hover:bg-white/20 flex items-center justify-center transition-all active:scale-90"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <line x1="18" y1="6" x2="6" y2="18"/>
+              <line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+          </button>
+
+          {/* Header */}
+          <div className="absolute top-6 left-0 right-0 flex justify-center">
+            <div className="text-center">
+              <p className="text-white/40 text-xs font-semibold uppercase tracking-widest">
+                {phase === 'listening' ? 'Parent voice mode' :
+                 phase === 'processing' ? 'Building your card' :
+                 phase === 'preview' ? 'Here\'s your card' :
+                 phase === 'saved' ? 'Word added' :
+                 'Create a word card'}
+              </p>
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="flex flex-col items-center px-8 w-full max-w-sm">
+            {phase === 'idle' && (
+              <div className="flex flex-col items-center gap-6">
+                <button
+                  onClick={startListening}
+                  className="w-20 h-20 rounded-full bg-red-500 hover:bg-red-400 shadow-[0_0_32px_8px_rgba(239,68,68,0.35)] flex items-center justify-center active:scale-90 transition-all"
+                >
+                  <svg width="32" height="32" viewBox="0 0 24 24" fill="white">
+                    <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/>
+                    <path d="M19 10v2a7 7 0 0 1-14 0v-2" stroke="white" strokeWidth="2" fill="none" strokeLinecap="round"/>
+                    <line x1="12" y1="19" x2="12" y2="23" stroke="white" strokeWidth="2" strokeLinecap="round"/>
+                    <line x1="8" y1="23" x2="16" y2="23" stroke="white" strokeWidth="2" strokeLinecap="round"/>
+                  </svg>
+                </button>
+                <p className="text-white/50 text-sm text-center leading-relaxed max-w-[240px]">
+                  Say something like:<br/>
+                  <span className="text-white/80 italic">&ldquo;make a card for swimming&rdquo;</span><br/>
+                  <span className="text-white/80 italic">&ldquo;add dinosaur&rdquo;</span>
+                </p>
+              </div>
+            )}
+
+            {phase === 'listening' && <ListeningRing transcript={transcript} />}
+            {phase === 'processing' && <ProcessingSkeleton />}
+            {phase === 'preview' && card && (
+              <CardPreview
+                card={card}
+                onSave={handleSave}
+                onRetry={() => { setCard(null); startListening(); }}
+              />
+            )}
+            {phase === 'saved' && card && <SavedConfirmation card={card} />}
+            {phase === 'error' && (
+              <ErrorState
+                message={errorMsg}
+                onRetry={() => { setErrorMsg(''); startListening(); }}
+              />
+            )}
+          </div>
+        </div>
+      )}
+
+      <style>{`
+        @keyframes overlayIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @keyframes cardAppear {
+          0%  { opacity: 0; transform: scale(0.88) translateY(12px); }
+          60% { transform: scale(1.03) translateY(-2px); }
+          100% { opacity: 1; transform: scale(1) translateY(0); }
+        }
+        @keyframes shimmer {
+          0%   { transform: translateX(-200%); }
+          100% { transform: translateX(200%); }
+        }
+        @keyframes fadeIn {
+          from { opacity: 0; transform: translateY(8px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .animate-card-appear {
+          animation: cardAppear 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+        }
+        .animate-shimmer {
+          animation: shimmer 1.6s ease-in-out infinite;
+        }
+        .animate-fade-in {
+          animation: fadeIn 0.4s ease-out forwards;
+        }
+      `}</style>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds "Sound Art" tab to /music with interactive Chladni pattern visualizer
- 3000 sand particles settle into geometric nodal patterns driven by sound frequency math
- 6 note modes (C-A), each with spectral color mapping, meditative sine tones with slow attack
- Color slider, volume control (50% default), and 5 ambient noise tracks (Rain, River, Ocean, Pink, White)

## Test plan
- [ ] Open /music, tap Sound Art tab
- [ ] Tap each note button — verify pattern forms and tone plays
- [ ] Slide color slider — particles change color in real-time
- [ ] Adjust volume slider — audio level changes
- [ ] Tap ambient buttons (Rain, Ocean, etc.) — verify layered noise plays alongside tone
- [ ] Toggle ambient off by tapping active ambient button
- [ ] Test on mobile viewport