### PR TITLE
feat: PWA install prompt + fullscreen standalone

### DIFF
--- a/src/app/api/pwa-icon/route.tsx
+++ b/src/app/api/pwa-icon/route.tsx
@@ -1,0 +1,42 @@
+import { ImageResponse } from "next/og";
+import { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+export async function GET(req: NextRequest) {
+  const size = Number(req.nextUrl.searchParams.get("size") || "512");
+  const maskable = req.nextUrl.searchParams.get("maskable") === "1";
+
+  // Maskable icons need extra padding (safe zone is inner 80%)
+  const padding = maskable ? size * 0.1 : 0;
+  const fontSize = Math.round((maskable ? size * 0.32 : size * 0.4));
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: size,
+          height: size,
+          background: "linear-gradient(135deg, #0E0F0F 0%, #1a1a2e 100%)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding,
+          borderRadius: maskable ? 0 : size * 0.22,
+        }}
+      >
+        <span
+          style={{
+            fontSize,
+            fontWeight: 800,
+            color: "#C9A84C",
+            letterSpacing: `${-fontSize * 0.025}px`,
+          }}
+        >
+          8.
+        </span>
+      </div>
+    ),
+    { width: size, height: size },
+  );
+}

--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,34 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: 180,
+          height: 180,
+          background: "linear-gradient(135deg, #0E0F0F 0%, #1a1a2e 100%)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          borderRadius: 40,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 80,
+            fontWeight: 800,
+            color: "#C9A84C",
+            letterSpacing: "-2px",
+          }}
+        >
+          8.
+        </span>
+      </div>
+    ),
+    { width: 180, height: 180 },
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Providers } from './providers';
 import { OfflineBanner } from '../components/OfflineBanner';
 import Dock from '../components/Dock';
 import { LockScreenGate } from '../components/LockScreenGate';
+import { InstallPrompt } from '../components/InstallPrompt';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -24,7 +25,6 @@ export const metadata: Metadata = {
   },
   description:
     'Personalised AI OS for neurodivergent children. AAC communication, AI-generated symbols, personalized voice. Free forever.',
-  manifest: '/manifest.json',
   appleWebApp: {
     capable: true,
     statusBarStyle: 'default',
@@ -36,6 +36,9 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
+  minimumScale: 1,
+  maximumScale: 1,
+  userScalable: false,
   viewportFit: 'cover',
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: '#FFFDF9' },
@@ -54,6 +57,7 @@ export default function RootLayout({
         <Providers>
           <LockScreenGate>
             <OfflineBanner />
+            <InstallPrompt />
             <main className="pb-safe-dock">{children}</main>
             <Dock />
           </LockScreenGate>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "8gent Jr - A Voice for Every Kid",
+    short_name: "8gent Jr",
+    description:
+      "Personalised AI OS for neurodivergent children. AAC communication, AI-generated symbols, personalized voice.",
+    start_url: "/",
+    display: "standalone",
+    orientation: "portrait",
+    background_color: "#FFF8F0",
+    theme_color: "#FFFDF9",
+    categories: ["education", "health", "kids"],
+    icons: [
+      {
+        src: "/api/pwa-icon?size=192",
+        sizes: "192x192",
+        type: "image/png",
+      },
+      {
+        src: "/api/pwa-icon?size=512",
+        sizes: "512x512",
+        type: "image/png",
+      },
+      {
+        src: "/api/pwa-icon?size=512&maskable=1",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "maskable",
+      },
+    ],
+  };
+}

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+
+/**
+ * PWA install prompt with platform-specific handling.
+ *
+ * Android/Chrome: captures `beforeinstallprompt` → one-tap native install.
+ * iOS/Safari: shows manual instructions (Share → Add to Home Screen).
+ * Hides itself if already running in standalone mode or user dismissed.
+ */
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+type Platform = "ios" | "android" | "other" | null;
+
+const DISMISS_KEY = "8gentjr_install_dismissed";
+
+export function InstallPrompt() {
+  const [platform, setPlatform] = useState<Platform>(null);
+  const [show, setShow] = useState(false);
+  const deferredPrompt = useRef<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    // Already installed as standalone — hide prompt
+    if (window.matchMedia("(display-mode: standalone)").matches) return;
+
+    // User previously dismissed
+    if (localStorage.getItem(DISMISS_KEY)) return;
+
+    // Detect platform
+    const ua = navigator.userAgent.toLowerCase();
+    const isIOS = /ipad|iphone|ipod/.test(ua);
+    const isAndroid = /android/.test(ua);
+
+    if (isIOS) {
+      setPlatform("ios");
+      // Small delay so it doesn't flash on page load
+      const t = setTimeout(() => setShow(true), 2000);
+      return () => clearTimeout(t);
+    }
+
+    setPlatform(isAndroid ? "android" : "other");
+
+    // Chrome/Edge/Samsung: listen for native install prompt
+    const handler = (e: Event) => {
+      e.preventDefault();
+      deferredPrompt.current = e as BeforeInstallPromptEvent;
+      setShow(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  }, []);
+
+  const handleInstall = useCallback(async () => {
+    if (!deferredPrompt.current) return;
+    await deferredPrompt.current.prompt();
+    const { outcome } = await deferredPrompt.current.userChoice;
+    if (outcome === "accepted") {
+      setShow(false);
+    }
+    deferredPrompt.current = null;
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    setShow(false);
+    localStorage.setItem(DISMISS_KEY, "1");
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Install app"
+      className="fixed bottom-20 inset-x-0 z-[9990] flex justify-center px-4 animate-slide-up"
+    >
+      <div className="w-full max-w-sm bg-white rounded-2xl shadow-2xl border border-[#f0e6d6] p-4">
+        {/* Header */}
+        <div className="flex items-start gap-3">
+          <div className="w-11 h-11 shrink-0 rounded-xl bg-[#0E0F0F] flex items-center justify-center">
+            <span className="text-[#C9A84C] font-extrabold text-lg">8.</span>
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="font-bold text-[#1a1a2e] text-[15px] leading-tight">
+              Add 8gent Jr to Home Screen
+            </p>
+            <p className="text-[#8a7e70] text-xs mt-0.5 leading-snug">
+              {platform === "ios"
+                ? "Opens full screen — just like a real app"
+                : "One tap to install — opens full screen"}
+            </p>
+          </div>
+          <button
+            onClick={handleDismiss}
+            className="w-7 h-7 shrink-0 rounded-full bg-[#f0e6d6] text-[#8a7e70] flex items-center justify-center text-xs border-none cursor-pointer hover:bg-[#e0d6c6] transition-colors"
+            aria-label="Dismiss"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Action */}
+        <div className="mt-3">
+          {platform === "ios" ? (
+            /* iOS: manual instructions */
+            <div className="flex items-center gap-2 bg-[#FFF8F0] rounded-xl px-3 py-2.5">
+              <span className="text-lg">
+                {/* Share icon approximation */}
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#E8610A" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8" />
+                  <polyline points="16 6 12 2 8 6" />
+                  <line x1="12" y1="2" x2="12" y2="15" />
+                </svg>
+              </span>
+              <p className="text-[#1a1a2e] text-xs leading-snug">
+                Tap{" "}
+                <span className="font-bold text-[#E8610A]">Share</span>
+                {" "}then{" "}
+                <span className="font-bold text-[#E8610A]">Add to Home Screen</span>
+              </p>
+            </div>
+          ) : (
+            /* Android/Chrome/Other: one-tap install */
+            <button
+              onClick={handleInstall}
+              className="w-full py-3 rounded-xl bg-gradient-to-r from-[#FF6B35] to-[#E8610A] text-white font-bold text-sm border-none cursor-pointer active:scale-95 transition-transform shadow-md"
+            >
+              Install App
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Slide-up animation */}
+      <style jsx>{`
+        @keyframes slide-up {
+          from {
+            opacity: 0;
+            transform: translateY(20px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+        .animate-slide-up {
+          animation: slide-up 0.3s ease-out;
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- One-tap "Add to Home Screen" install prompt with platform-specific handling (Android native install dialog, iOS manual Share instructions)
- Fullscreen standalone mode via web manifest (`display: "standalone"`) — no browser chrome when launched from homescreen
- Viewport locked (no zoom) for app-like feel
- PWA icons: 180x180 apple-touch-icon, 192/512 android chrome icons, 512 maskable icon
- Install prompt auto-hides if already installed or previously dismissed

## Test plan
- [ ] Open on Android Chrome — verify native install prompt appears after `beforeinstallprompt` fires
- [ ] Open on iOS Safari — verify Share instructions appear after 2s delay
- [ ] Dismiss prompt — verify it doesn't reappear (localStorage persistence)
- [ ] Install to homescreen — verify app opens fullscreen without browser chrome
- [ ] Verify manifest at `/manifest.webmanifest` returns correct JSON
- [ ] Verify icons render at `/api/pwa-icon?size=192` and `/api/pwa-icon?size=512`
- [ ] Verify apple-touch-icon renders at `/apple-icon`