### PR TITLE
fix: iOS PWA meta tag + song error messages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,9 @@ export const metadata: Metadata = {
     statusBarStyle: 'default',
     title: '8gent Jr',
   },
+  other: {
+    'apple-mobile-web-app-capable': 'yes',
+  },
   category: 'Education',
 };
 

--- a/src/components/SongCreator.tsx
+++ b/src/components/SongCreator.tsx
@@ -124,7 +124,7 @@ export default function SongCreator() {
 
       if (data.error) {
         setPhase('error');
-        setErrorMsg('Could not create song. Try again!');
+        setErrorMsg(data.error || 'Could not create song. Try again!');
         return;
       }
 


### PR DESCRIPTION
## Summary
- Adds explicit `apple-mobile-web-app-capable` meta tag — Next.js 15 omits it when a manifest link exists, but iOS Safari needs it for standalone PWA behavior
- Song creator now surfaces the actual API error (e.g. "Music generation unavailable") instead of the generic "Could not create song. Try again!"

## Root cause of song creation failure
Missing `SUNO_API_KEY` and `ELEVENLABS_API_KEY` env vars in Vercel. Groq generates lyrics fine but no audio provider is configured. Need to add at least one audio API key in Vercel env vars.