### PR TITLE
feat: local-first AI inference — Ollama first, Groq fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.37.4",
-    "groq-sdk": "^1.1.2",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
+  },
+  "optionalDependencies": {
+    "groq-sdk": "^1.1.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/app/api/autocomplete/route.ts
+++ b/src/app/api/autocomplete/route.ts
@@ -1,16 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import Groq from 'groq-sdk';
+import { createAIProviderWithFallback } from '@/lib/ai-provider';
 
 /**
  * 8gent Jr — Autocomplete API
  *
- * Uses Groq (fast, free) for AI-powered word suggestions.
+ * Uses local Ollama (free) with Groq (free tier) as cloud fallback for AI-powered word suggestions.
  * Ported from NickOS autocomplete endpoint, adapted for 8gent Jr AAC.
  *
  * Issue: #53
  */
-
-export const runtime = 'edge';
 
 interface AutocompleteRequest {
   input: string;
@@ -19,14 +17,6 @@ interface AutocompleteRequest {
 
 export async function POST(request: NextRequest) {
   try {
-    const groqKey = process.env.GROQ_API_KEY;
-    if (!groqKey) {
-      return NextResponse.json(
-        { error: 'GROQ_API_KEY not configured', suggestions: [] },
-        { status: 500 }
-      );
-    }
-
     const body: AutocompleteRequest = await request.json();
     const { input, existingWords = [] } = body;
 
@@ -34,7 +24,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ suggestions: [] });
     }
 
-    const groq = new Groq({ apiKey: groqKey });
+    const provider = await createAIProviderWithFallback('llama-3.1-8b-instant');
+
+    if (!provider) {
+      return NextResponse.json({ suggestions: [], offline: true });
+    }
 
     const prompt = `You are an AAC (Augmentative and Alternative Communication) word suggestion assistant for a 7-year-old child.
 
@@ -50,13 +44,7 @@ Suggest 5 words that:
 
 Return ONLY a JSON array of 5 words, no explanation. Example: ["hello", "help", "happy", "home", "hungry"]`;
 
-    const completion = await groq.chat.completions.create({
-      model: 'llama-3.1-8b-instant',
-      messages: [{ role: 'user', content: prompt }],
-      max_tokens: 128,
-    });
-
-    const text = completion.choices?.[0]?.message?.content ?? '';
+    const text = await provider.chat([{ role: 'user', content: prompt }], { max_tokens: 128 });
 
     // Parse the response — expecting a JSON array
     let suggestions: string[] = [];

--- a/src/app/api/improve-sentence/route.ts
+++ b/src/app/api/improve-sentence/route.ts
@@ -1,17 +1,15 @@
 import { NextRequest } from 'next/server';
-import Groq from 'groq-sdk';
+import { createAIProviderWithFallback } from '@/lib/ai-provider';
 
 /**
  * 8gent Jr — Sentence Improvement API (Magic Button)
  *
  * Takes raw AAC card words and returns a grammatically improved sentence.
- * Uses Groq (free, fast) for LLM-powered grammar correction.
+ * Uses local Ollama (free) with Groq (free tier) as cloud fallback.
  * Ported from NickOS improve-sentence endpoint.
  *
  * Issue: #53
  */
-
-export const runtime = 'edge';
 
 const SYSTEM_PROMPT = `You are an AAC sentence improver for children. Your job is to take words from communication cards and form natural sentences.
 
@@ -62,29 +60,30 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const groqKey = process.env.GROQ_API_KEY;
-
-    if (!groqKey) {
-      return new Response(JSON.stringify({ error: 'GROQ_API_KEY not configured' }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
+    const provider = await createAIProviderWithFallback('llama-3.1-8b-instant');
 
     const rawSentence = body.cards.join(' ');
 
-    const groq = new Groq({ apiKey: groqKey });
+    if (!provider) {
+      // Graceful degradation: return the raw sentence unchanged
+      return new Response(
+        JSON.stringify({
+          original: rawSentence,
+          improved: rawSentence,
+          explanation: 'AI unavailable — sentence returned as-is',
+          missing: [],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
 
-    const completion = await groq.chat.completions.create({
-      model: 'llama-3.1-8b-instant',
-      max_tokens: 512,
-      messages: [
+    const content = await provider.chat(
+      [
         { role: 'system', content: SYSTEM_PROMPT },
         { role: 'user', content: `Improve this AAC sentence: "${rawSentence}"` },
       ],
-    });
-
-    const content = completion.choices?.[0]?.message?.content;
+      { max_tokens: 512 }
+    );
 
     if (content) {
       return parseAndRespond(content, rawSentence);

--- a/src/app/api/parent-chat/route.ts
+++ b/src/app/api/parent-chat/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import Groq from 'groq-sdk';
+import { createAIProviderWithFallback } from '@/lib/ai-provider';
 
 /**
  * 8gent Jr — Parent Chat API
@@ -8,10 +8,8 @@ import Groq from 'groq-sdk';
  * their child's communication, vocabulary, and AAC strategy using
  * specialist knowledge. Not generalised — grounded in AAC research.
  *
- * Stack: Groq / llama-3.3-70b-versatile (more capable than 8b for nuanced Q&A)
+ * Stack: Ollama (local) → Groq / llama-3.3-70b-versatile (cloud fallback)
  */
-
-export const runtime = 'edge';
 
 const SYSTEM_PROMPT = `You are an expert AAC (Augmentative and Alternative Communication) specialist and speech-language pathologist advisor embedded in 8gent Jr, a communication app for children.
 
@@ -54,14 +52,6 @@ interface ChatRequest {
 
 export async function POST(request: NextRequest) {
   try {
-    const groqKey = process.env.GROQ_API_KEY;
-    if (!groqKey) {
-      return new Response(JSON.stringify({ error: 'GROQ_API_KEY not configured' }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-
     const body: ChatRequest = await request.json();
     const { messages } = body;
 
@@ -72,18 +62,22 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const groq = new Groq({ apiKey: groqKey });
+    const provider = await createAIProviderWithFallback('llama-3.3-70b-versatile');
 
-    const completion = await groq.chat.completions.create({
-      model: 'llama-3.3-70b-versatile',
-      max_tokens: 1024,
-      messages: [
-        { role: 'system', content: SYSTEM_PROMPT },
-        ...messages,
-      ],
-    });
+    if (!provider) {
+      return new Response(
+        JSON.stringify({
+          reply:
+            'AI unavailable offline — check AAC resources at aac.8gentjr.com',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
 
-    const content = completion.choices?.[0]?.message?.content ?? '';
+    const content = await provider.chat(
+      [{ role: 'system', content: SYSTEM_PROMPT }, ...messages],
+      { max_tokens: 1024 }
+    );
 
     return new Response(JSON.stringify({ reply: content }), {
       status: 200,

--- a/src/app/api/voice-card-create/route.ts
+++ b/src/app/api/voice-card-create/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import Groq from 'groq-sdk';
+import { createAIProviderWithFallback } from '@/lib/ai-provider';
 
 /**
  * POST /api/voice-card-create
@@ -7,14 +7,12 @@ import Groq from 'groq-sdk';
  * Takes a parent's spoken request and returns a ready-to-render AAC card.
  *
  * Flow:
- *   1. Groq (llama-3.3-70b) extracts: label, ARASAAC search term, Fitzgerald category
+ *   1. Ollama (local) or Groq (llama-3.3-70b) extracts: label, ARASAAC search term, Fitzgerald category
  *   2. ARASAAC public API finds the best matching pictogram
  *   3. Returns structured card data — client animates the card into view
  *
- * Stack: Groq / llama-3.3-70b-versatile + ARASAAC public API (no key needed)
+ * Stack: Ollama (local, free) → Groq / llama-3.3-70b-versatile (cloud fallback) + ARASAAC public API (no key needed)
  */
-
-export const runtime = 'edge';
 
 const SYSTEM_PROMPT = `You are an AAC (Augmentative and Alternative Communication) vocabulary specialist.
 
@@ -74,14 +72,6 @@ async function findArasaacPictogram(searchTerm: string): Promise<{ id: number; i
 
 export async function POST(request: NextRequest) {
   try {
-    const groqKey = process.env.GROQ_API_KEY;
-    if (!groqKey) {
-      return new Response(JSON.stringify({ error: 'GROQ_API_KEY not configured' }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-
     const body: CardRequest = await request.json();
     const { speech } = body;
 
@@ -92,19 +82,22 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const groq = new Groq({ apiKey: groqKey });
+    const provider = await createAIProviderWithFallback('llama-3.3-70b-versatile');
 
-    const completion = await groq.chat.completions.create({
-      model: 'llama-3.3-70b-versatile',
-      max_tokens: 200,
-      temperature: 0.1, // deterministic — same request should return same card
-      messages: [
+    if (!provider) {
+      return new Response(
+        JSON.stringify({ error: 'AI unavailable — no local or cloud provider configured' }),
+        { status: 503, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const raw = await provider.chat(
+      [
         { role: 'system', content: SYSTEM_PROMPT },
         { role: 'user', content: speech.trim() },
       ],
-    });
-
-    const raw = completion.choices?.[0]?.message?.content ?? '';
+      { max_tokens: 200, temperature: 0.1 }
+    );
 
     // Parse JSON from response — model is instructed to return only JSON
     let parsed: { label: string; searchTerm: string; category: string; rationale?: string };

--- a/src/lib/ai-provider.ts
+++ b/src/lib/ai-provider.ts
@@ -1,0 +1,145 @@
+/**
+ * 8gent Jr — AI Provider Abstraction
+ *
+ * Priority: Ollama (local, free) → Groq (cloud, free tier) → null (graceful degradation)
+ *
+ * No new dependencies. Ollama is reached via raw fetch.
+ */
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatOptions {
+  max_tokens?: number;
+  temperature?: number;
+}
+
+export type ChatFn = (messages: ChatMessage[], options?: ChatOptions) => Promise<string>;
+
+interface OllamaResponse {
+  message: { content: string };
+}
+
+interface GroqResponse {
+  choices: Array<{ message: { content: string | null } }>;
+}
+
+function ollamaProvider(host: string, model: string): ChatFn {
+  return async (messages, options = {}) => {
+    const res = await fetch(`${host}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: false,
+        ...(options.max_tokens !== undefined && { num_predict: options.max_tokens }),
+        ...(options.temperature !== undefined && { options: { temperature: options.temperature } }),
+      }),
+    });
+    if (!res.ok) throw new Error(`Ollama ${res.status}`);
+    const data = (await res.json()) as OllamaResponse;
+    return data.message.content;
+  };
+}
+
+function groqProvider(apiKey: string, model: string): ChatFn {
+  return async (messages, options = {}) => {
+    const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(options.max_tokens !== undefined && { max_tokens: options.max_tokens }),
+        ...(options.temperature !== undefined && { temperature: options.temperature }),
+      }),
+    });
+    if (!res.ok) throw new Error(`Groq ${res.status}`);
+    const data = (await res.json()) as GroqResponse;
+    return data.choices?.[0]?.message?.content ?? '';
+  };
+}
+
+export interface AIProvider {
+  chat: ChatFn;
+  source: 'ollama' | 'groq';
+  model: string;
+}
+
+/**
+ * Returns the best available AI provider, or null if none configured.
+ *
+ * @param groqModel  Groq model to use when falling back to cloud (default: llama-3.3-70b-versatile)
+ * @param ollamaModel  Ollama model to use locally (default: llama3.2:3b)
+ */
+export function createAIProvider(
+  groqModel = 'llama-3.3-70b-versatile',
+  ollamaModel = 'llama3.2:3b'
+): AIProvider | null {
+  const ollamaHost = process.env.OLLAMA_HOST ?? 'http://localhost:11434';
+  const groqKey = process.env.GROQ_API_KEY;
+
+  // Ollama wins when OLLAMA_HOST is set (or default localhost is acceptable to try).
+  // We always prefer local — callers can set OLLAMA_HOST=disabled to skip.
+  if (ollamaHost && ollamaHost !== 'disabled') {
+    return {
+      chat: ollamaProvider(ollamaHost, ollamaModel),
+      source: 'ollama',
+      model: ollamaModel,
+    };
+  }
+
+  if (groqKey) {
+    return {
+      chat: groqProvider(groqKey, groqModel),
+      source: 'groq',
+      model: groqModel,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Tries Ollama first; if the request fails (e.g. Ollama not running), falls back to Groq.
+ * This is the recommended function for server routes — handles the fallback automatically.
+ */
+export async function createAIProviderWithFallback(
+  groqModel = 'llama-3.3-70b-versatile',
+  ollamaModel = 'llama3.2:3b'
+): Promise<AIProvider | null> {
+  const ollamaHost = process.env.OLLAMA_HOST ?? 'http://localhost:11434';
+  const groqKey = process.env.GROQ_API_KEY;
+
+  if (ollamaHost && ollamaHost !== 'disabled') {
+    // Probe Ollama with a lightweight tags request
+    try {
+      const probe = await fetch(`${ollamaHost}/api/tags`, { signal: AbortSignal.timeout(2000) });
+      if (probe.ok) {
+        return {
+          chat: ollamaProvider(ollamaHost, ollamaModel),
+          source: 'ollama',
+          model: ollamaModel,
+        };
+      }
+    } catch {
+      // Ollama not reachable — fall through to Groq
+    }
+  }
+
+  if (groqKey) {
+    return {
+      chat: groqProvider(groqKey, groqModel),
+      source: 'groq',
+      model: groqModel,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Add `src/lib/ai-provider.ts`: thin provider abstraction (<100 lines, zero new npm packages)
  - `createAIProviderWithFallback()` probes Ollama at `OLLAMA_HOST` (default `http://localhost:11434`) with a 2-second timeout, falls back to Groq if `GROQ_API_KEY` is set, returns `null` if neither available
  - Ollama uses raw `fetch` to `/api/chat` — no library added
  - Groq calls also use raw `fetch` to the OpenAI-compat endpoint (removes direct SDK dependency from routes)
- Update all 4 AI routes to use the abstraction: `parent-chat`, `autocomplete`, `improve-sentence`, `voice-card-create`
  - Removed `import Groq from 'groq-sdk'` from each
  - Removed `export const runtime = 'edge'` (edge runtime cannot reach localhost Ollama)
  - Each route handles `null` provider with a graceful offline response (no crash, no 500)
- `package.json`: move `groq-sdk` from `dependencies` to `optionalDependencies`

## Test plan

- [ ] With Ollama running locally (`ollama serve`, model `llama3.2:3b` pulled): hit any route — should work with no env vars set
- [ ] With Ollama stopped and `GROQ_API_KEY` set: routes fall back to Groq cloud automatically
- [ ] With neither configured: `parent-chat` returns offline message, `autocomplete` returns empty suggestions, `improve-sentence` returns raw sentence unchanged, `voice-card-create` returns 503
- [ ] Set `OLLAMA_HOST=disabled` to force Groq path even when localhost is reachable
- [ ] No system prompts changed — verify response quality unchanged vs previous Groq-only routes