### PR TITLE
docs: align README and site copy with 8GI canon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # 8gent Jr
 
-Personalised AI OS for neurodivergent children (Autism, ADHD). Free forever.
+Personalised AI OS for neurodivergent children (autism, ADHD). Free forever.
 
 - **Domain:** 8gentjr.com
-- **Parent:** 8GI Foundation
+- **Parent:** [8GI Foundation](https://8gi.org)
 - **License:** Apache 2.0
 
 ## What it is
@@ -12,9 +12,12 @@ Not a generic kids' app. A personalised system that learns YOUR child's patterns
 
 ## Architecture
 
-- Next.js on Vercel (8gentjr.com)
+- Next.js 15.1 / React 19 on Vercel (8gentjr.com)
 - Auth via 8gent.app (Clerk)
 - AI via 8gent-code kernel (local-first, privacy-first)
+- ARASAAC symbol library (46,000+ CC BY 4.0 pictograms)
+- Web Audio API for music synthesis and sound feedback
+- PWA with offline support
 - Nick's instance at nick.8gentjr.com
 
 ## Neurodiversity & AAC Glossary
@@ -23,14 +26,14 @@ Terminology used in this codebase and why it matters. Using the wrong term confu
 
 | Term | What it means | What NOT to confuse it with |
 |------|--------------|----------------------------|
-| **AAC** (Augmentative & Alternative Communication) | Any method that supplements or replaces spoken language — picture cards, symbol boards, speech-generating devices. Umbrella term. | "Special needs app" — too vague, avoid |
+| **AAC** (Augmentative & Alternative Communication) | Any method that supplements or replaces spoken language: picture cards, symbol boards, speech-generating devices. Umbrella term. | "Special needs app" (too vague, avoid) |
 | **Core vocabulary** | ~400 high-frequency words (I, want, more, go, stop) that make up ~80% of what people say daily. Contrast with fringe vocabulary (specific nouns). | Topic vocabulary / fringe vocabulary |
 | **Fringe vocabulary** | Context-specific words (banana, swimming, teacher). Important but secondary to core. | Core vocabulary |
-| **Visual Scene Display (VSD)** | A scene-based AAC format: a contextually rich image with hotspot buttons overlaid. Tapping a hotspot produces a phrase. Developed by Beukelman & Janice Light. This is what the `/vsd` ("Scenes") route implements. | **Social Stories™** — completely different |
-| **Social Stories™** | Short, first-person narratives written *about* a child to explain social situations and expected behaviour ("When I arrive at school, I hang my bag up first…"). Created by Carol Gray (1991). Evidence-based for autism. | Visual Scene Displays |
+| **Visual Scene Display (VSD)** | A scene-based AAC format: a contextually rich image with hotspot buttons overlaid. Tapping a hotspot produces a phrase. Developed by Beukelman & Janice Light. This is what the `/vsd` ("Scenes") route implements. | Social Stories (completely different) |
+| **Social Stories** | Short, first-person narratives written *about* a child to explain social situations and expected behaviour ("When I arrive at school, I hang my bag up first…"). Created by Carol Gray (1991). Evidence-based for autism. | Visual Scene Displays |
 | **GLP (Gestalt Language Processing)** | A language acquisition style where children learn language in chunks/phrases ("ready-set-go", "do you want to?") before breaking them into parts. Contrast with analytic language processing. Many autistic children are gestalt processors. | Echolalia (overlapping but distinct) |
 | **Fitzgerald Key** | A colour-coding system for AAC symbol categorisation: Yellow = pronouns, Green = verbs, Orange = nouns, Pink = adjectives/adverbs, Blue = prepositions, Red = negation/interjections, White = small words. Industry standard (used by Grid 3, Supercore, Snap Core). | Arbitrary colour choices |
-| **Motor planning** | The muscle-memory principle that AAC words should NEVER move position on a board. A child builds motor memory for where "I" lives — moving it breaks that memory. Critical for SupercoreGrid. | Layout flexibility / drag-and-drop |
+| **Motor planning** | The muscle-memory principle that AAC words should NEVER move position on a board. A child builds motor memory for where "I" lives, and moving it breaks that memory. Critical for SupercoreGrid. | Layout flexibility / drag-and-drop |
 | **Supercore / Core Word Board** | A fixed-position 50-word grid following Modified Fitzgerald Key. The `/talk` route. Based on Smartbox Supercore design principles. | General symbol board |
 | **ARASAAC** | Aragonese Centre of Augmentative and Alternative Communication. Provides 46,000+ free CC BY 4.0 pictographic symbols used throughout the app. | Any paid symbol library |
 | **Neurodivergent** | Umbrella term for people whose neurological development differs from the statistical norm: autism, ADHD, dyslexia, dyspraxia, etc. Preferred by the community over "special needs". | "Special needs", "disabled" (context-dependent) |
@@ -45,10 +48,10 @@ Terminology used in this codebase and why it matters. Using the wrong term confu
 | Feature | Route | Description |
 |---------|-------|-------------|
 | **Talk (Supercore)** | `/talk` | 50-word core vocabulary grid following Modified Fitzgerald Key colour coding. Fixed motor-planned positions. Three views: Core grid, Browse categories, Quick Phrases |
-| **Browse Categories** | `/talk` (browse tab) | Category-based AAC board - tap a category to see symbols, tap a symbol to speak |
+| **Browse Categories** | `/talk` (browse tab) | Category-based AAC board. Tap a category to see symbols, tap a symbol to speak |
 | **Quick Phrases** | `/talk` (phrases tab) | Saved sentences with 4 input methods for rapid communication |
 | **Voice Card Creator** | via Talk | Create custom AAC cards with symbol search and voice recording |
-| **Visual Scenes (VSD)** | `/vsd` | Scene-based AAC - contextual images (kitchen, playground, bedroom, school, park) with tappable hotspots that speak gestalt phrases |
+| **Visual Scenes (VSD)** | `/vsd` | Scene-based AAC. Contextual images (kitchen, playground, bedroom, school, park) with tappable hotspots that speak gestalt phrases |
 | **Sentence Builder** | via AAC | Build sentences from symbols with shared sentence bar and TTS output |
 | **Symbol Search** | `/symbols` | Search 46,000+ ARASAAC pictographic symbols |
 
@@ -63,7 +66,7 @@ Games are presented in a TikTok-style reels feed with topic filters and daily ac
 | **Bubble Pop Numbers** | Pop numbered bubbles in sequence |
 | **Color Mix** | Mix primary colours to discover new ones |
 | **Color Sort** | Sort objects by colour into matching bins |
-| **Counting Balls** | Count falling balls - number recognition |
+| **Counting Balls** | Count falling balls for number recognition |
 | **Letter Trace** | Trace letter shapes with touch |
 | **Number Bonds** | Find pairs that add up to a target number |
 | **Number Order** | Arrange numbers in ascending/descending order |
@@ -78,20 +81,20 @@ Games are presented in a TikTok-style reels feed with topic filters and daily ac
 | **Animal Sounds** | Listen to and identify animal sounds |
 | **Copy Move** | Watch and copy movement sequences |
 | **Feelings Explorer** | Identify and learn about emotions |
-| **Jump Count** | Jump and count - physical movement + numbers |
+| **Jump Count** | Jump and count: physical movement + numbers |
 | **Nature Explore** | Explore nature scenes with vocabulary |
 | **Rhyme Time** | Find words that rhyme together |
 | **Sentence Builder** | Build sentences from word cards |
-| **Word Repeat** | Listen and repeat words - articulation practice |
+| **Word Repeat** | Listen and repeat words for articulation practice |
 
 **Sensory**
 
 | Game | Description |
 |------|-------------|
-| **Ball Rain** | Colourful balls raining down - tap to pop |
+| **Ball Rain** | Colourful balls raining down, tap to pop |
 | **Bottle Fill** | Pour virtual liquid into bottles |
 | **Breathing Sphere** | Guided breathing with expanding/contracting sphere |
-| **Bubble Wrap** | Pop virtual bubble wrap - tactile satisfaction |
+| **Bubble Wrap** | Pop virtual bubble wrap for tactile satisfaction |
 | **Ice Cream Builder** | Stack scoops to build ice cream cones |
 | **Marble Run** | Watch marbles roll through tracks |
 | **Rainbow Paint** | Free paint with rainbow colours |
@@ -128,17 +131,17 @@ Games are presented in a TikTok-style reels feed with topic filters and daily ac
 | **Song Creator** | `/music` (create tab) | AI-generated songs from text prompts, saved to local library |
 | **My Songs** | `/music` (songs tab) | Personal song library with playback and management |
 | **Drum Pads** | `/music` (instruments tab) | Touch-responsive drum pad grid with real drum samples |
-| **Xylophone Keys** | `/music` (instruments tab) | Coloured xylophone keys - play melodies by tapping |
-| **Sound Detective** | `/music` (listen tab) | Ear training game - 8 notes, cymatics shapes, visual-first |
-| **Sound Art (Chladni)** | `/music` (sound art tab) | Cymatics visualiser - see sound wave patterns as Chladni figures |
+| **Xylophone Keys** | `/music` (instruments tab) | Coloured xylophone keys, play melodies by tapping |
+| **Sound Detective** | `/music` (listen tab) | Ear training game: 8 notes, cymatics shapes, visual-first |
+| **Sound Art (Chladni)** | `/music` (sound art tab) | Cymatics visualiser: see sound wave patterns as Chladni figures |
 | **Mood Music** | `/music/moods` | Music playlists organised by mood/emotion |
 
 ### Science
 
 | Feature | Route | Description |
 |---------|-------|-------------|
-| **Shape World** | `/science/shapes` | Isometric world builder - paint 3D terrain with colours mapped to musical tones. Synesthetic learning: every colour plays a note (C4 to C5). Procedural terrain generation, "Play Song" sweeps painted colours as melody |
-| **Physics Lab** | `/science/physics` | Launch particles, swing pendulums, splash colours - interactive physics sandbox |
+| **Shape World** | `/science/shapes` | Isometric world builder: paint 3D terrain with colours mapped to musical tones. Synesthetic learning, every colour plays a note (C4 to C5). Procedural terrain generation, "Play Song" sweeps painted colours as melody |
+| **Physics Lab** | `/science/physics` | Launch particles, swing pendulums, splash colours: interactive physics sandbox |
 
 ### Speech Therapy
 
@@ -151,7 +154,7 @@ Games are presented in a TikTok-style reels feed with topic filters and daily ac
 | Feature | Route | Description |
 |---------|-------|-------------|
 | **Social Stories** | `/stories` | Picture-based first-person narratives explaining everyday social situations (Carol Gray method) |
-| **Intuition Game** | `/intuition` | Colour card pattern recognition - "which colour do you feel?" with scoring, streaks, and accuracy tracking |
+| **Intuition Game** | `/intuition` | Colour card pattern recognition ("which colour do you feel?") with scoring, streaks, and accuracy tracking |
 
 ### Creative
 
@@ -177,41 +180,18 @@ Games are presented in a TikTok-style reels feed with topic filters and daily ac
 | Feature | Route | Description |
 |---------|-------|-------------|
 | **Parent Chat** | `/parent-chat` | Customise your child's AAC board through AI-powered conversation |
-| **Onboarding** | `/onboarding` | Problem-first onboarding flow - learns about your child before configuring the system |
+| **Onboarding** | `/onboarding` | Problem-first onboarding flow: learns about your child before configuring the system |
 | **Settings** | `/settings` | App preferences and child profile configuration |
 | **Parental Gate** | (system) | Consent gate protecting all content (localStorage-based) |
 | **Lock Screen** | (system) | Session-based lock screen to prevent accidental exits |
 
-## Architecture
+## Ecosystem
 
-- Next.js 15.1 / React 19 on Vercel (8gentjr.com)
-- Auth via 8gent.app (Clerk)
-- AI via 8gent-code kernel (local-first, privacy-first)
-- ARASAAC symbol library (46,000+ CC BY 4.0 pictograms)
-- Web Audio API for music synthesis and sound feedback
-- PWA with offline support
-- Nick's instance at nick.8gentjr.com
+8gent Jr is a product of the [8GI Foundation](https://8gi.org), a Dublin-based non-profit building free, local-first AI for people the K-shaped economy is leaving behind.
 
-## Neurodiversity & AAC Glossary
-
-Terminology used in this codebase and why it matters. Using the wrong term confuses SLTs (speech-language therapists) and informed parents.
-
-| Term | What it means | What NOT to confuse it with |
-|------|--------------|----------------------------|
-| **AAC** (Augmentative & Alternative Communication) | Any method that supplements or replaces spoken language - picture cards, symbol boards, speech-generating devices. Umbrella term. | "Special needs app" - too vague, avoid |
-| **Core vocabulary** | ~400 high-frequency words (I, want, more, go, stop) that make up ~80% of what people say daily. Contrast with fringe vocabulary (specific nouns). | Topic vocabulary / fringe vocabulary |
-| **Fringe vocabulary** | Context-specific words (banana, swimming, teacher). Important but secondary to core. | Core vocabulary |
-| **Visual Scene Display (VSD)** | A scene-based AAC format: a contextually rich image with hotspot buttons overlaid. Tapping a hotspot produces a phrase. Developed by Beukelman & Janice Light. This is what the `/vsd` ("Scenes") route implements. | **Social Stories** - completely different |
-| **Social Stories** | Short, first-person narratives written *about* a child to explain social situations and expected behaviour. Created by Carol Gray (1991). Evidence-based for autism. | Visual Scene Displays |
-| **GLP (Gestalt Language Processing)** | A language acquisition style where children learn language in chunks/phrases ("ready-set-go", "do you want to?") before breaking them into parts. Contrast with analytic language processing. Many autistic children are gestalt processors. | Echolalia (overlapping but distinct) |
-| **Fitzgerald Key** | A colour-coding system for AAC symbol categorisation: Yellow = pronouns, Green = verbs, Orange = nouns, Blue = prepositions, Red = negation/interjections, White = small words. Industry standard (used by Grid 3, Supercore, Snap Core). | Arbitrary colour choices |
-| **Motor planning** | The muscle-memory principle that AAC words should NEVER move position on a board. A child builds motor memory for where "I" lives - moving it breaks that memory. Critical for SupercoreGrid. | Layout flexibility / drag-and-drop |
-| **Supercore / Core Word Board** | A fixed-position 50-word grid following Modified Fitzgerald Key. The `/talk` route. Based on Smartbox Supercore design principles. | General symbol board |
-| **ARASAAC** | Aragonese Centre of Augmentative and Alternative Communication. Provides 46,000+ free CC BY 4.0 pictographic symbols used throughout the app. | Any paid symbol library |
-| **Neurodivergent** | Umbrella term for people whose neurological development differs from the statistical norm: autism, ADHD, dyslexia, dyspraxia, etc. Preferred by the community over "special needs". | "Special needs", "disabled" (context-dependent) |
-| **SLT / SLP** | Speech and Language Therapist (UK/IE) / Speech-Language Pathologist (US). The clinical professional who prescribes and trains AAC use. Target professional user of Parent Chat. | OT (Occupational Therapist), different role |
-| **Co-regulation** | An adult helping a child regulate their emotional/sensory state before expecting communication. A key principle: communicate when regulated, regulate before communicating. | Self-regulation (child doing it independently) |
-| **PGC** | Psychiatric Genomics Consortium. Provides large-scale GWAS (genome-wide association study) data for ADHD, autism, and other conditions. Stored in `data/resources/index.json` as a research reference. | Clinical diagnosis tool |
+- [8gi.org](https://8gi.org): foundation site
+- [8gent.dev](https://8gent.dev): open source agent kernel (8gent Code)
+- [8gentjr.com](https://8gentjr.com): this product
 
 ## Development
 

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,7 +1,7 @@
 import Analytics from "@/components/Analytics";
 
 export const metadata = {
-  title: "Progress — 8gent Jr",
+  title: "Progress | 8gent Jr",
   description: "Usage stats and communication progress tracker",
 };
 

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -28,7 +28,7 @@ const VIDEOS: VideoCard[] = [
     durationLabel: '~60 sec',
     steps: [
       'Open the app and tap "Talk" at the bottom.',
-      'Tap any symbol — it appears in the sentence bar at the top.',
+      'Tap any symbol and it appears in the sentence bar at the top.',
       'Keep tapping symbols to build your message.',
       'Tap the speaker icon in the sentence bar to hear it.',
       'Tap the X on any word to remove it, or swipe the bar to clear.',
@@ -44,7 +44,7 @@ const VIDEOS: VideoCard[] = [
     durationLabel: '~60 sec',
     steps: [
       'From the Talk screen, tap "Browse" to see all categories.',
-      'Choose a category — Food, Feelings, Actions, and more.',
+      'Choose a category: Food, Feelings, Actions, and more.',
       'Tap any word inside to add it to your sentence.',
       'Your sentence bar stays the same as you browse. Nothing is lost.',
       'Tap "Talk" in the dock to go back to the main screen.',
@@ -59,9 +59,9 @@ const VIDEOS: VideoCard[] = [
     youtubeId: null,
     durationLabel: '~90 sec',
     steps: [
-      'Open the app and complete the short onboarding — it takes 2 minutes.',
+      'Open the app and complete the short onboarding. It takes 2 minutes.',
       "Enter your child's name and choose a voice that feels right.",
-      'The app remembers everything — no account or login needed.',
+      'The app remembers everything. No account or login needed.',
       'Tap "More" in the dock, then "My Stuff" to change settings any time.',
       'Everything is stored on the device. No data leaves without your permission.',
     ],
@@ -78,7 +78,7 @@ const VIDEOS: VideoCard[] = [
       'Open a browser on the board and go to 8gentjr.com.',
       'If the site is blocked, ask your IT admin to whitelist 8gentjr.com.',
       'Press F11 (or the fullscreen button) for the best classroom view.',
-      'The app works without an account — just open and go.',
+      'The app works without an account. Just open and go.',
       'Tap the symbols with your finger or a stylus, same as a tablet.',
       'To reset between students, tap "More" then "My Stuff" and clear the session.',
     ],
@@ -225,7 +225,7 @@ export default function HelpPage() {
         >
           <strong>For schools:</strong> If 8gentjr.com is blocked by your network, ask your IT admin to whitelist{' '}
           <code className="bg-white/60 px-1 rounded text-xs">8gentjr.com</code>. It&apos;s a free educational tool for
-          neurodivergent children — most content filters approve it immediately.
+          neurodivergent children, and most content filters approve it immediately.
         </div>
       </div>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -89,13 +89,13 @@ const jsonLd = {
     },
     {
       "@type": "Organization",
-      name: "8gent",
-      url: "https://8gent.world",
+      name: "8GI Foundation",
+      url: "https://8gi.org",
       logo: "https://8gentjr.com/logo.png",
       sameAs: [
-        "https://8gent.world",
-        "https://8gentos.com",
+        "https://8gi.org",
         "https://8gent.dev",
+        "https://8gent.world",
       ],
     },
   ],

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -72,7 +72,7 @@ function MySongsTab() {
         <div className="text-5xl">🎤</div>
         <p className="font-bold text-[#1a1a2e] text-lg">No songs yet</p>
         <p className="text-[#8a7e70] text-sm leading-relaxed max-w-[280px]">
-          Head to the Create tab to make your first AI-generated song — it&apos;ll show up here.
+          Head to the Create tab to make your first AI-generated song. It&apos;ll show up here.
         </p>
       </div>
     );

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -104,7 +104,7 @@ export default function SettingsPage() {
                 >
                   <div className="flex items-center justify-between">
                     <span className="font-bold" style={{ color: active ? accent : 'var(--warm-text, #1A1614)' }}>
-                      Stage {stage.id} — {stage.name}
+                      Stage {stage.id}: {stage.name}
                     </span>
                     {active && (
                       <span
@@ -227,7 +227,7 @@ export default function SettingsPage() {
 
         {/* Version footer */}
         <p className="text-center text-xs pb-4" style={{ color: 'var(--warm-text-muted, #9A9088)' }}>
-          8gent Jr v1.0 — Made with care
+          8gent Jr v1.0. Made with care.
         </p>
       </div>
     </div>

--- a/src/app/speech/page.tsx
+++ b/src/app/speech/page.tsx
@@ -1,7 +1,7 @@
 import SpeechTherapy from "@/components/SpeechTherapy";
 
 export const metadata = {
-  title: "Speech Therapy — 8gent Jr",
+  title: "Speech Therapy | 8gent Jr",
   description: "Interactive phoneme practice with mouth visualisation and speech synthesis",
 };
 


### PR DESCRIPTION
Closes #112

## Summary
Aligns 8gentjr README and user-visible homepage/landing copy with the 8GI ecosystem canon (2026-04-18).

## Violations fixed
- README had duplicate Architecture and Glossary sections (drift/corruption from prior edit)
- Em dashes in README glossary rows and user-visible frontend copy replaced with colons, periods, or hyphens
  - README table rows
  - src/app/help/page.tsx (6 visible step descriptions)
  - src/app/settings/page.tsx (stage label + version footer)
  - src/app/music/page.tsx (empty-state message)
  - src/app/analytics/page.tsx (metadata title)
  - src/app/speech/page.tsx (metadata title)
- README missing foundation link; added Ecosystem section linking 8gi.org, 8gent.dev, 8gentjr.com
- src/app/layout.tsx Schema.org Organization pointed to "8gent" at 8gent.world; updated to "8GI Foundation" at 8gi.org and added 8gi.org to sameAs
- Dropped trademark symbol on "Social Stories" in glossary (cleaner, not a legal reference)

## Not touched (out of scope)
- Library/comment em dashes in src/lib/** and JSDoc (non-user-facing)
- Fitzgerald Key clinical colours (industry standard for AAC; not brand)

## Canon checks passed
- No aidhd.dev references
- No Co-Authored-By or vendor attribution
- No podjamz references
- No "diagnosed" claims about James or users
- No banned purple/pink/violet brand hues