### PR TITLE
feat(signup): age gate before account creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "bun test",
     "prewarm": "node scripts/prewarm-tts.mjs"
   },
   "dependencies": {

--- a/src/app/parent-email-verification/page.tsx
+++ b/src/app/parent-email-verification/page.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+
+/**
+ * Parent email verification placeholder (DPIA 2026-04-21).
+ *
+ * Child-path accounts land here after the age gate. The real
+ * email-plus Verifiable Parental Consent flow is tracked in
+ * issue #117 - this page exists only so the child path has a
+ * destination and users are told what happens next.
+ *
+ * DPIA reference:
+ *   8gi-governance/docs/legal/2026-04-21-8gentjr-dpia-interim.md
+ */
+
+export const metadata = {
+  title: "Parent email confirmation - 8gent Jr",
+};
+
+export default function ParentEmailVerificationPage() {
+  return (
+    <div className="min-h-screen bg-[var(--brand-bg)] flex items-center justify-center p-6">
+      <div className="w-full max-w-md text-center">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-[var(--brand-accent)] text-white text-2xl font-bold mb-6">
+          8
+        </div>
+
+        <h1 className="text-2xl font-bold text-[var(--brand-text)] mb-3">
+          We will email you to confirm
+        </h1>
+
+        <p className="text-sm text-[var(--brand-text-soft)] mb-6 leading-relaxed">
+          Because the account is for a child under 13, we need a parent or
+          legal guardian to confirm by email before the account is activated.
+          You will receive a confirmation link shortly.
+        </p>
+
+        <div className="bg-[var(--brand-bg-warm)] border border-[var(--brand-border)] rounded-2xl p-4 text-left text-sm text-[var(--brand-text-soft)] space-y-2">
+          <p className="font-semibold text-[var(--brand-text)]">
+            What happens next
+          </p>
+          <p>
+            The full Verifiable Parental Consent flow is being finalised
+            (tracked in issue #117). Until then, this page is a placeholder
+            to let you know a confirmation step is required before the
+            account becomes active.
+          </p>
+          <p>
+            Questions: email{" "}
+            <span className="text-[var(--brand-accent)]">privacy@8gi.org</span>.
+          </p>
+        </div>
+
+        <div className="mt-6 text-xs text-[var(--brand-text-muted)] space-x-2">
+          <Link href="/privacy" className="hover:underline">
+            Privacy Policy
+          </Link>
+          <span>|</span>
+          <Link href="/terms" className="hover:underline">
+            Terms
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -14,7 +14,7 @@ import { LockScreenGate } from './LockScreenGate';
 import { InstallPrompt } from './InstallPrompt';
 import { ParentalGate } from './ParentalGate';
 
-const CHROMELESS_ROUTES = ['/onboarding'];
+const CHROMELESS_ROUTES = ['/onboarding', '/parent-email-verification'];
 const UNGATED_ROUTES = ['/privacy', '/terms', '/help'];
 
 export function AppChrome({ children }: { children: ReactNode }) {

--- a/src/components/ParentalGate.tsx
+++ b/src/components/ParentalGate.tsx
@@ -1,318 +1,368 @@
 "use client";
 
+/**
+ * ParentalGate - DPIA age gate before account creation (issue #116).
+ *
+ * Three paths:
+ *   child_under_13: parent/guardian path. Collects birth year +
+ *                   legal-guardian confirmation, then routes to a
+ *                   VPC placeholder (#117 implements email-plus flow).
+ *   self_13_plus:   the account subject is 13+ and using it for themselves.
+ *   carer_13_plus:  the account subject is 13+ and a carer is setting it up.
+ *
+ * Persists accountType + birthYear (band only) + isChild to AppContext.
+ * This runs BEFORE onboarding / AAC board access.
+ *
+ * DPIA reference:
+ *   8gi-governance/docs/legal/2026-04-21-8gentjr-dpia-interim.md
+ */
+
 import { useState, useEffect, type ReactNode } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useApp } from "@/context/AppContext";
+import {
+  type AccountType,
+  ageFromBirthYear,
+  buildAccountRecord,
+  nextRouteForAccount,
+  validateAccountInput,
+} from "@/lib/account";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+type Step = "who" | "birth_year" | "guardian" | "done";
 
-interface ConsentRecord {
-  parentEmail: string;
-  childAge: number;
-  consentedAt: string;
-  privacyPolicyVersion: string;
-}
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const CONSENT_KEY = "8gentjr_parental_consent";
-const PRIVACY_POLICY_VERSION = "2026-04-10";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function getConsent(): ConsentRecord | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const raw = localStorage.getItem(CONSENT_KEY);
-    return raw ? (JSON.parse(raw) as ConsentRecord) : null;
-  } catch {
-    return null;
-  }
-}
-
-function saveConsent(record: ConsentRecord): void {
-  localStorage.setItem(CONSENT_KEY, JSON.stringify(record));
-}
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
-
-type Step = "role" | "age" | "consent" | "done";
+const CURRENT_YEAR = new Date().getUTCFullYear();
+// Offer roughly the last 100 years as birth-year options.
+const BIRTH_YEAR_OPTIONS: number[] = Array.from(
+  { length: 100 },
+  (_, i) => CURRENT_YEAR - i,
+);
 
 export function ParentalGate({ children }: { children: ReactNode }) {
+  const { settings, updateSettings, isLoaded } = useApp();
+  const router = useRouter();
+
   const [step, setStep] = useState<Step>("done");
   const [mounted, setMounted] = useState(false);
 
-  // Form state
-  const [childAge, setChildAge] = useState<number | null>(null);
-  const [parentEmail, setParentEmail] = useState("");
-  const [readPolicy, setReadPolicy] = useState(false);
-  const [consentGiven, setConsentGiven] = useState(false);
+  // Form state - local to the gate flow, only committed to AppContext on submit.
+  const [accountType, setAccountType] = useState<AccountType | null>(null);
+  const [birthYear, setBirthYear] = useState<number | null>(null);
+  const [carerRelationship, setCarerRelationship] = useState("");
+  const [guardianConfirmed, setGuardianConfirmed] = useState(false);
   const [error, setError] = useState("");
 
   useEffect(() => {
     setMounted(true);
-    const existing = getConsent();
-    if (existing && existing.privacyPolicyVersion === PRIVACY_POLICY_VERSION) {
-      setStep("done");
-    } else {
-      setStep("role");
-    }
   }, []);
 
-  // Don't flash gate on SSR
-  if (!mounted) return null;
+  useEffect(() => {
+    if (!isLoaded) return;
+    // Gate is "done" once we have an accountType + birthYear committed.
+    if (settings.accountType !== null && settings.birthYear !== null) {
+      setStep("done");
+    } else {
+      setStep("who");
+    }
+  }, [isLoaded, settings.accountType, settings.birthYear]);
+
+  if (!mounted || !isLoaded) return null;
   if (step === "done") return <>{children}</>;
 
-  // -------------------------------------------------------------------------
-  // Step 1: Who is using this?
-  // -------------------------------------------------------------------------
+  function commitAndRoute() {
+    if (!accountType || birthYear === null) return;
+    const record = buildAccountRecord({
+      accountType,
+      birthYear,
+      guardianConfirmed,
+      carerRelationship:
+        accountType === "carer_13_plus"
+          ? carerRelationship.trim() || undefined
+          : undefined,
+    });
+    updateSettings({
+      accountType: record.accountType,
+      birthYear: record.birthYear,
+      isChild: record.isChild,
+      carerRelationship: record.carerRelationship ?? null,
+      guardianConfirmed: record.guardianConfirmed,
+      parentEmailConfirmed: record.parentEmailConfirmed,
+      gatedAt: record.gatedAt,
+    });
+    setStep("done");
+    router.replace(nextRouteForAccount(record.accountType));
+  }
 
-  if (step === "role") {
+  // ---- Step 1: who is this account for? --------------------------------
+
+  if (step === "who") {
     return (
       <GateShell>
         <h1 className="text-2xl font-bold text-[var(--brand-text)] mb-2">
-          Welcome to 8gent Jr
+          Who is this account for?
         </h1>
         <p className="text-sm text-[var(--brand-text-soft)] mb-8">
-          Before we start, we need to know who is setting up the app.
+          We ask so we can give the right experience and follow
+          children&apos;s privacy law. We store a birth year only, never a full
+          date of birth.
         </p>
 
         <div className="space-y-3">
-          <button
-            onClick={() => setStep("age")}
-            className="w-full py-4 px-6 rounded-2xl bg-[var(--brand-accent)] text-white font-semibold text-base hover:opacity-90 transition-opacity"
-          >
-            I am a parent or guardian
-          </button>
-          <button
-            onClick={() => setStep("age")}
-            className="w-full py-4 px-6 rounded-2xl bg-[var(--brand-bg-warm)] text-[var(--brand-text)] font-semibold text-base border border-[var(--brand-border)] hover:bg-[var(--brand-bg-accent)] transition-colors"
-          >
-            I am a teacher or therapist
-          </button>
-          <div className="pt-2">
-            <p className="text-xs text-[var(--brand-text-muted)] text-center">
-              If you are a child, please ask your parent or guardian to set up
-              8gent Jr for you.
-            </p>
-          </div>
+          <GateChoiceButton
+            label="A child under 13"
+            sub="I am a parent or legal guardian setting this up for a child under 13."
+            onClick={() => {
+              setAccountType("child_under_13");
+              setError("");
+              setStep("birth_year");
+            }}
+          />
+          <GateChoiceButton
+            label="Myself, 13 or older"
+            sub="I am 13 or older and this account is for me."
+            onClick={() => {
+              setAccountType("self_13_plus");
+              setError("");
+              setStep("birth_year");
+            }}
+          />
+          <GateChoiceButton
+            label="A person I care for, 13 or older"
+            sub="I am a carer, teacher, therapist or family member setting this up for someone 13 or older."
+            onClick={() => {
+              setAccountType("carer_13_plus");
+              setError("");
+              setStep("birth_year");
+            }}
+          />
         </div>
       </GateShell>
     );
   }
 
-  // -------------------------------------------------------------------------
-  // Step 2: Child's age
-  // -------------------------------------------------------------------------
+  // ---- Step 2: birth year (band only) ----------------------------------
 
-  if (step === "age") {
+  if (step === "birth_year") {
+    const headline =
+      accountType === "child_under_13"
+        ? "What year was the child born?"
+        : accountType === "carer_13_plus"
+          ? "What year was the person born?"
+          : "What year were you born?";
+
+    const age = birthYear !== null ? ageFromBirthYear(birthYear) : null;
+
+    const mismatchWarning = (() => {
+      if (age === null || accountType === null) return null;
+      if (accountType === "child_under_13" && age >= 13) {
+        return "That birth year is 13 or older. Please pick the 13+ option on the previous screen.";
+      }
+      if (accountType !== "child_under_13" && age < 13) {
+        return "That birth year is under 13. Please pick the child-under-13 option on the previous screen.";
+      }
+      return null;
+    })();
+
+    const canContinue =
+      birthYear !== null &&
+      mismatchWarning === null &&
+      (accountType !== "carer_13_plus" || carerRelationship.trim().length > 0);
+
     return (
       <GateShell>
         <h1 className="text-2xl font-bold text-[var(--brand-text)] mb-2">
-          How old is the child?
+          {headline}
         </h1>
         <p className="text-sm text-[var(--brand-text-soft)] mb-6">
-          We ask this to provide the right experience and comply with
-          children&apos;s privacy law.
+          Birth year only. We never ask for a full date of birth.
         </p>
 
-        <div className="grid grid-cols-4 gap-2 mb-6">
-          {[3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18].map(
-            (age) => (
-              <button
-                key={age}
-                onClick={() => setChildAge(age)}
-                className={`py-3 rounded-xl text-base font-semibold transition-all ${
-                  childAge === age
-                    ? "bg-[var(--brand-accent)] text-white scale-105"
-                    : "bg-[var(--brand-bg-warm)] text-[var(--brand-text)] border border-[var(--brand-border)] hover:border-[var(--brand-accent)]"
-                }`}
-              >
-                {age === 18 ? "18+" : age}
-              </button>
-            ),
-          )}
-        </div>
+        <label
+          htmlFor="birth-year"
+          className="text-sm font-medium text-[var(--brand-text)] mb-1 block"
+        >
+          Birth year
+        </label>
+        <select
+          id="birth-year"
+          value={birthYear ?? ""}
+          onChange={(e) => {
+            const value = e.target.value;
+            setBirthYear(value === "" ? null : Number(value));
+            setError("");
+          }}
+          className="w-full px-4 py-3 rounded-xl border border-[var(--brand-border)] bg-white text-[var(--brand-text)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:border-transparent"
+        >
+          <option value="">Select a year</option>
+          {BIRTH_YEAR_OPTIONS.map((year) => (
+            <option key={year} value={year}>
+              {year}
+            </option>
+          ))}
+        </select>
 
-        {childAge !== null && (
+        {accountType === "carer_13_plus" && (
+          <div className="mt-4">
+            <label
+              htmlFor="carer-relationship"
+              className="text-sm font-medium text-[var(--brand-text)] mb-1 block"
+            >
+              Your relationship to this person
+            </label>
+            <input
+              id="carer-relationship"
+              type="text"
+              value={carerRelationship}
+              onChange={(e) => setCarerRelationship(e.target.value)}
+              placeholder="e.g. therapist, teacher, family carer"
+              className="w-full px-4 py-3 rounded-xl border border-[var(--brand-border)] bg-white text-[var(--brand-text)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:border-transparent"
+              maxLength={60}
+            />
+          </div>
+        )}
+
+        {mismatchWarning && (
+          <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-xl p-3 mt-4">
+            {mismatchWarning}
+          </p>
+        )}
+
+        {error && <p className="text-sm text-red-500 font-medium mt-4">{error}</p>}
+
+        <div className="mt-6 flex gap-3">
           <button
             onClick={() => {
-              if (childAge < 13) {
-                setStep("consent");
-              } else {
-                // 13+ can use with simplified consent
-                saveConsent({
-                  parentEmail: "self-verified-13-plus",
-                  childAge,
-                  consentedAt: new Date().toISOString(),
-                  privacyPolicyVersion: PRIVACY_POLICY_VERSION,
-                });
-                setStep("done");
-              }
+              setStep("who");
+              setError("");
             }}
-            className="w-full py-4 rounded-2xl bg-[var(--brand-accent)] text-white font-semibold text-base hover:opacity-90 transition-opacity"
+            className="px-5 py-3 rounded-2xl border border-[var(--brand-border)] text-[var(--brand-text-soft)] font-semibold text-sm hover:bg-[var(--brand-bg-warm)] transition-colors"
+          >
+            Back
+          </button>
+          <button
+            onClick={() => {
+              if (!accountType) {
+                setStep("who");
+                return;
+              }
+              if (accountType === "child_under_13") {
+                setStep("guardian");
+                return;
+              }
+              const validation = validateAccountInput({
+                accountType,
+                birthYear,
+                guardianConfirmed: true,
+              });
+              if (validation) {
+                setError(validation);
+                return;
+              }
+              commitAndRoute();
+            }}
+            disabled={!canContinue}
+            className={`flex-1 py-3 rounded-2xl font-semibold text-base transition-all ${
+              canContinue
+                ? "bg-[var(--brand-accent)] text-white hover:opacity-90"
+                : "bg-[var(--brand-border)] text-[var(--brand-text-muted)] cursor-not-allowed"
+            }`}
           >
             Continue
           </button>
-        )}
-
-        <button
-          onClick={() => setStep("role")}
-          className="mt-3 text-sm text-[var(--brand-text-muted)] hover:underline"
-        >
-          Back
-        </button>
+        </div>
       </GateShell>
     );
   }
 
-  // -------------------------------------------------------------------------
-  // Step 3: Parental consent (under 13)
-  // -------------------------------------------------------------------------
+  // ---- Step 3: guardian confirmation (child path only) -----------------
 
-  if (step === "consent") {
-    const canSubmit =
-      parentEmail.includes("@") &&
-      parentEmail.includes(".") &&
-      readPolicy &&
-      consentGiven;
+  if (step === "guardian") {
+    const canSubmit = guardianConfirmed && birthYear !== null;
 
     return (
       <GateShell>
         <h1 className="text-2xl font-bold text-[var(--brand-text)] mb-2">
-          Parental Consent Required
+          Guardian confirmation
         </h1>
         <p className="text-sm text-[var(--brand-text-soft)] mb-6">
-          Because your child is under 13, we need your consent before they can
-          use 8gent Jr. This is required by the Children&apos;s Online Privacy
-          Protection Act (COPPA).
+          Because the account subject is under 13, we need a parent or legal
+          guardian to confirm before we go any further. After this, we will
+          ask for a parent email to send a confirmation link.
         </p>
 
-        <div className="space-y-4">
-          {/* Parent email */}
-          <div>
-            <label className="text-sm font-medium text-[var(--brand-text)] mb-1 block">
-              Your email address (parent/guardian)
-            </label>
-            <input
-              type="email"
-              value={parentEmail}
-              onChange={(e) => {
-                setParentEmail(e.target.value);
-                setError("");
-              }}
-              placeholder="parent@example.com"
-              className="w-full px-4 py-3 rounded-xl border border-[var(--brand-border)] bg-white text-[var(--brand-text)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:border-transparent"
-            />
-            <p className="text-xs text-[var(--brand-text-muted)] mt-1">
-              We will send a confirmation to this address. We will never share
-              it.
-            </p>
-          </div>
+        <label className="flex items-start gap-3 cursor-pointer p-3 rounded-xl border border-[var(--brand-border)] hover:bg-[var(--brand-bg-warm)] transition-colors">
+          <input
+            type="checkbox"
+            checked={guardianConfirmed}
+            onChange={(e) => setGuardianConfirmed(e.target.checked)}
+            className="mt-1 w-5 h-5 rounded border-[var(--brand-border)] accent-[var(--brand-accent)]"
+          />
+          <span className="text-sm text-[var(--brand-text-soft)] leading-relaxed">
+            I am the parent or legal guardian of this child and I am authorised
+            to set up this communication tool for them. I understand I will be
+            asked to confirm by email before the account is activated, and that
+            I can withdraw consent at any time by contacting{" "}
+            <span className="text-[var(--brand-accent)]">privacy@8gi.org</span>.
+          </span>
+        </label>
 
-          {/* Privacy policy acknowledgment */}
-          <label className="flex items-start gap-3 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={readPolicy}
-              onChange={(e) => setReadPolicy(e.target.checked)}
-              className="mt-1 w-5 h-5 rounded border-[var(--brand-border)] accent-[var(--brand-accent)]"
-            />
-            <span className="text-sm text-[var(--brand-text-soft)]">
-              I have read and understand the{" "}
-              <Link
-                href="/privacy"
-                target="_blank"
-                className="text-[var(--brand-accent)] underline"
-              >
-                Privacy Policy
-              </Link>
-              , including how my child&apos;s data is collected and used.
-            </span>
-          </label>
+        <div className="mt-6 bg-[var(--brand-bg-warm)] rounded-xl p-4 text-xs text-[var(--brand-text-soft)] space-y-1">
+          <p className="font-semibold text-[var(--brand-text)]">
+            Your rights under COPPA and GDPR
+          </p>
+          <p>
+            Review the{" "}
+            <Link
+              href="/privacy"
+              target="_blank"
+              className="text-[var(--brand-accent)] underline"
+            >
+              Privacy Policy
+            </Link>{" "}
+            for what we collect and how we use it. No ads. No tracking. No data
+            sales.
+          </p>
+        </div>
 
-          {/* Consent checkbox */}
-          <label className="flex items-start gap-3 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={consentGiven}
-              onChange={(e) => setConsentGiven(e.target.checked)}
-              className="mt-1 w-5 h-5 rounded border-[var(--brand-border)] accent-[var(--brand-accent)]"
-            />
-            <span className="text-sm text-[var(--brand-text-soft)]">
-              I am the parent or legal guardian of this child and I consent to
-              the collection and use of data as described in the Privacy Policy.
-              I understand I can withdraw consent at any time by contacting{" "}
-              <span className="text-[var(--brand-accent)]">
-                privacy@8gi.org
-              </span>
-              .
-            </span>
-          </label>
+        {error && <p className="text-sm text-red-500 font-medium mt-4">{error}</p>}
 
-          {/* Data summary */}
-          <div className="bg-[var(--brand-bg-warm)] rounded-xl p-4 text-xs text-[var(--brand-text-soft)] space-y-1">
-            <p className="font-semibold text-[var(--brand-text)]">
-              What we collect:
-            </p>
-            <p>
-              Your email (for consent verification). Your child&apos;s age (for
-              compliance). On-device usage data (never sent to us). Text sent to
-              AI for autocomplete and speech features (not stored).
-            </p>
-            <p className="font-semibold text-[var(--brand-text)] mt-2">
-              What we never do:
-            </p>
-            <p>
-              No ads. No tracking. No data sales. No third-party sharing. No
-              cookies beyond authentication.
-            </p>
-          </div>
-
-          {error && (
-            <p className="text-sm text-red-500 font-medium">{error}</p>
-          )}
-
+        <div className="mt-6 flex gap-3">
           <button
             onClick={() => {
-              if (!canSubmit) {
-                setError(
-                  "Please fill in your email and check both boxes to continue.",
-                );
+              setStep("birth_year");
+              setError("");
+            }}
+            className="px-5 py-3 rounded-2xl border border-[var(--brand-border)] text-[var(--brand-text-soft)] font-semibold text-sm hover:bg-[var(--brand-bg-warm)] transition-colors"
+          >
+            Back
+          </button>
+          <button
+            onClick={() => {
+              if (!accountType || birthYear === null) {
+                setStep("who");
                 return;
               }
-              saveConsent({
-                parentEmail,
-                childAge: childAge!,
-                consentedAt: new Date().toISOString(),
-                privacyPolicyVersion: PRIVACY_POLICY_VERSION,
+              const validation = validateAccountInput({
+                accountType,
+                birthYear,
+                guardianConfirmed,
               });
-              setStep("done");
+              if (validation) {
+                setError(validation);
+                return;
+              }
+              commitAndRoute();
             }}
             disabled={!canSubmit}
-            className={`w-full py-4 rounded-2xl font-semibold text-base transition-all ${
+            className={`flex-1 py-3 rounded-2xl font-semibold text-base transition-all ${
               canSubmit
                 ? "bg-[var(--brand-accent)] text-white hover:opacity-90"
                 : "bg-[var(--brand-border)] text-[var(--brand-text-muted)] cursor-not-allowed"
             }`}
           >
-            I Consent — Set Up 8gent Jr
+            Continue to email confirmation
           </button>
         </div>
-
-        <button
-          onClick={() => setStep("age")}
-          className="mt-3 text-sm text-[var(--brand-text-muted)] hover:underline"
-        >
-          Back
-        </button>
       </GateShell>
     );
   }
@@ -321,14 +371,13 @@ export function ParentalGate({ children }: { children: ReactNode }) {
 }
 
 // ---------------------------------------------------------------------------
-// Shell
+// Shell + primitives
 // ---------------------------------------------------------------------------
 
 function GateShell({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen bg-[var(--brand-bg)] flex items-center justify-center p-6">
       <div className="w-full max-w-md">
-        {/* Logo */}
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-[var(--brand-accent)] text-white text-2xl font-bold mb-3">
             8
@@ -340,7 +389,6 @@ function GateShell({ children }: { children: ReactNode }) {
 
         {children}
 
-        {/* Footer */}
         <div className="mt-8 text-center">
           <p className="text-[10px] text-[var(--brand-text-muted)]">
             <Link href="/privacy" className="hover:underline">
@@ -356,5 +404,29 @@ function GateShell({ children }: { children: ReactNode }) {
         </div>
       </div>
     </div>
+  );
+}
+
+function GateChoiceButton({
+  label,
+  sub,
+  onClick,
+}: {
+  label: string;
+  sub: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full text-left py-4 px-5 rounded-2xl bg-[var(--brand-bg-warm)] border border-[var(--brand-border)] hover:border-[var(--brand-accent)] transition-colors"
+    >
+      <div className="font-semibold text-[var(--brand-text)] text-base">
+        {label}
+      </div>
+      <div className="text-sm text-[var(--brand-text-soft)] mt-1 leading-snug">
+        {sub}
+      </div>
+    </button>
   );
 }

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import type { AccountType } from '@/lib/account';
 
 /**
  * 8gent Jr App Context
@@ -18,6 +19,19 @@ export interface AppSettings {
   gridColumns: number;
   hasCompletedOnboarding: boolean;
   glpStage: number;
+  /**
+   * DPIA age gate (issue #116).
+   * accountType + birthYear are captured BEFORE account creation.
+   * Birth YEAR only (never full DOB) - band captured for compliance.
+   */
+  accountType: AccountType | null;
+  birthYear: number | null;
+  isChild: boolean;
+  carerRelationship: string | null;
+  guardianConfirmed: boolean;
+  /** Filled in by VPC flow (#117). */
+  parentEmailConfirmed: boolean;
+  gatedAt: string | null;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -29,6 +43,13 @@ const DEFAULT_SETTINGS: AppSettings = {
   gridColumns: 3,
   hasCompletedOnboarding: false,
   glpStage: 3,
+  accountType: null,
+  birthYear: null,
+  isChild: false,
+  carerRelationship: null,
+  guardianConfirmed: false,
+  parentEmailConfirmed: false,
+  gatedAt: null,
 };
 
 const STORAGE_KEY = '8gentjr-app-settings';

--- a/src/lib/account.test.ts
+++ b/src/lib/account.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the age gate logic (issue #116).
+ *
+ * Covers the three signup paths forking correctly:
+ *   - child_under_13 (birth year makes age < 13, guardian confirmation required)
+ *   - self_13_plus   (birth year makes age >= 13)
+ *   - carer_13_plus  (birth year makes age >= 13, relationship captured)
+ *
+ * Run with: bun test src/lib/account.test.ts
+ */
+
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+
+import {
+  ageFromBirthYear,
+  buildAccountRecord,
+  isUnder13,
+  nextRouteForAccount,
+  validateAccountInput,
+} from './account';
+
+const NOW = new Date('2026-04-21T00:00:00.000Z');
+
+test('ageFromBirthYear computes age from current UTC year', () => {
+  assert.equal(ageFromBirthYear(2020, NOW), 6);
+  assert.equal(ageFromBirthYear(2013, NOW), 13);
+  assert.equal(ageFromBirthYear(1990, NOW), 36);
+});
+
+test('ageFromBirthYear rejects invalid years', () => {
+  assert.equal(ageFromBirthYear(Number.NaN, NOW), null);
+  assert.equal(ageFromBirthYear(1800, NOW), null);
+  assert.equal(ageFromBirthYear(2100, NOW), null);
+});
+
+test('isUnder13 is true only for ages strictly below 13', () => {
+  assert.equal(isUnder13(2020, NOW), true);
+  assert.equal(isUnder13(2013, NOW), false);
+  assert.equal(isUnder13(2014, NOW), true);
+  assert.equal(isUnder13(1990, NOW), false);
+});
+
+test('nextRouteForAccount routes child path to the VPC placeholder', () => {
+  assert.equal(
+    nextRouteForAccount('child_under_13'),
+    '/parent-email-verification',
+  );
+  assert.equal(nextRouteForAccount('self_13_plus'), '/onboarding');
+  assert.equal(nextRouteForAccount('carer_13_plus'), '/onboarding');
+});
+
+test('validateAccountInput: child path requires under-13 + guardian confirmation', () => {
+  assert.match(
+    validateAccountInput({
+      accountType: 'child_under_13',
+      birthYear: 1990,
+      guardianConfirmed: true,
+      now: NOW,
+    }) ?? '',
+    /only for children under 13/i,
+  );
+  assert.match(
+    validateAccountInput({
+      accountType: 'child_under_13',
+      birthYear: 2020,
+      guardianConfirmed: false,
+      now: NOW,
+    }) ?? '',
+    /parent or legal guardian/i,
+  );
+  assert.equal(
+    validateAccountInput({
+      accountType: 'child_under_13',
+      birthYear: 2020,
+      guardianConfirmed: true,
+      now: NOW,
+    }),
+    null,
+  );
+});
+
+test('validateAccountInput: 13+ paths reject under-13 birth years', () => {
+  assert.match(
+    validateAccountInput({
+      accountType: 'self_13_plus',
+      birthYear: 2020,
+      guardianConfirmed: true,
+      now: NOW,
+    }) ?? '',
+    /13 or older/i,
+  );
+  assert.match(
+    validateAccountInput({
+      accountType: 'carer_13_plus',
+      birthYear: 2020,
+      guardianConfirmed: true,
+      now: NOW,
+    }) ?? '',
+    /13 or older/i,
+  );
+  assert.equal(
+    validateAccountInput({
+      accountType: 'self_13_plus',
+      birthYear: 1990,
+      guardianConfirmed: false,
+      now: NOW,
+    }),
+    null,
+  );
+});
+
+test('validateAccountInput: missing birth year is rejected', () => {
+  assert.match(
+    validateAccountInput({
+      accountType: 'self_13_plus',
+      birthYear: null,
+      guardianConfirmed: true,
+      now: NOW,
+    }) ?? '',
+    /birth year/i,
+  );
+});
+
+test('buildAccountRecord: child path forks correctly', () => {
+  const record = buildAccountRecord({
+    accountType: 'child_under_13',
+    birthYear: 2020,
+    guardianConfirmed: true,
+    now: NOW,
+  });
+  assert.equal(record.accountType, 'child_under_13');
+  assert.equal(record.birthYear, 2020);
+  assert.equal(record.isChild, true);
+  assert.equal(record.guardianConfirmed, true);
+  assert.equal(record.parentEmailConfirmed, false);
+  assert.equal(record.carerRelationship, undefined);
+  assert.equal(record.gatedAt, NOW.toISOString());
+});
+
+test('buildAccountRecord: self 13+ path forks correctly', () => {
+  const record = buildAccountRecord({
+    accountType: 'self_13_plus',
+    birthYear: 1995,
+    guardianConfirmed: false,
+    now: NOW,
+  });
+  assert.equal(record.accountType, 'self_13_plus');
+  assert.equal(record.isChild, false);
+  assert.equal(record.guardianConfirmed, true, '13+ path has implicit self-consent');
+  assert.equal(record.carerRelationship, undefined);
+});
+
+test('buildAccountRecord: carer 13+ path retains relationship', () => {
+  const record = buildAccountRecord({
+    accountType: 'carer_13_plus',
+    birthYear: 2005,
+    guardianConfirmed: false,
+    carerRelationship: 'speech therapist',
+    now: NOW,
+  });
+  assert.equal(record.accountType, 'carer_13_plus');
+  assert.equal(record.isChild, false);
+  assert.equal(record.carerRelationship, 'speech therapist');
+  assert.equal(record.guardianConfirmed, true);
+});
+
+test('routing: child path goes to VPC placeholder, others to onboarding', () => {
+  const childRecord = buildAccountRecord({
+    accountType: 'child_under_13',
+    birthYear: 2020,
+    guardianConfirmed: true,
+    now: NOW,
+  });
+  const selfRecord = buildAccountRecord({
+    accountType: 'self_13_plus',
+    birthYear: 1995,
+    guardianConfirmed: false,
+    now: NOW,
+  });
+  const carerRecord = buildAccountRecord({
+    accountType: 'carer_13_plus',
+    birthYear: 2000,
+    guardianConfirmed: false,
+    carerRelationship: 'teacher',
+    now: NOW,
+  });
+  assert.equal(
+    nextRouteForAccount(childRecord.accountType),
+    '/parent-email-verification',
+  );
+  assert.equal(nextRouteForAccount(selfRecord.accountType), '/onboarding');
+  assert.equal(nextRouteForAccount(carerRecord.accountType), '/onboarding');
+});

--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -1,0 +1,135 @@
+/**
+ * Account type + age gate logic (DPIA 2026-04-21).
+ *
+ * Three paths per issue #116:
+ *   child_under_13: parent/guardian setting up for a child under 13.
+ *                   Requires guardian confirmation + routes to the
+ *                   email-plus Verifiable Parental Consent flow (#117).
+ *   self_13_plus:   a person 13+ using it for themselves.
+ *   carer_13_plus:  a person 13+ setting up for someone else who is 13+
+ *                   (therapist, teacher, family carer).
+ *
+ * We store birth YEAR only (band) - never full DOB - to minimise
+ * child data collected. See DPIA:
+ *   8gi-governance/docs/legal/2026-04-21-8gentjr-dpia-interim.md
+ */
+
+export type AccountType =
+  | 'child_under_13'
+  | 'self_13_plus'
+  | 'carer_13_plus';
+
+export interface AccountRecord {
+  accountType: AccountType;
+  /** Birth year band only. Never capture full date of birth. */
+  birthYear: number | null;
+  /** True if the account subject is under 13 (derived at gate time). */
+  isChild: boolean;
+  /** Relationship for the carer path (e.g. "therapist", "teacher"). */
+  carerRelationship?: string;
+  /** ISO timestamp of when the gate was completed. */
+  gatedAt: string;
+  /** Parent/guardian confirmation for the child path. */
+  guardianConfirmed: boolean;
+  /** VPC flow completion (filled in by #117, placeholder here). */
+  parentEmailConfirmed: boolean;
+}
+
+/** Minimum plausible birth year for an under-13 user today. */
+export const MIN_BIRTH_YEAR = 1900;
+
+/** Compute age band from a birth year. Returns null for invalid input. */
+export function ageFromBirthYear(
+  birthYear: number,
+  now: Date = new Date(),
+): number | null {
+  if (!Number.isFinite(birthYear)) return null;
+  if (birthYear < MIN_BIRTH_YEAR) return null;
+  const currentYear = now.getUTCFullYear();
+  if (birthYear > currentYear) return null;
+  return currentYear - birthYear;
+}
+
+/** Is the given birth year under 13 relative to `now`? */
+export function isUnder13(
+  birthYear: number,
+  now: Date = new Date(),
+): boolean {
+  const age = ageFromBirthYear(birthYear, now);
+  if (age === null) return false;
+  return age < 13;
+}
+
+/**
+ * Resolve the next route for a given account type.
+ *   child_under_13 -> /parent-email-verification (VPC placeholder, #117)
+ *   self_13_plus   -> /onboarding
+ *   carer_13_plus  -> /onboarding
+ */
+export function nextRouteForAccount(type: AccountType): string {
+  if (type === 'child_under_13') return '/parent-email-verification';
+  return '/onboarding';
+}
+
+/**
+ * Validate the inputs for a given path. Returns null if valid,
+ * or a human-readable error string if not.
+ */
+export function validateAccountInput(input: {
+  accountType: AccountType;
+  birthYear: number | null;
+  guardianConfirmed: boolean;
+  now?: Date;
+}): string | null {
+  const { accountType, birthYear, guardianConfirmed, now } = input;
+  if (birthYear === null || !Number.isFinite(birthYear)) {
+    return 'Please provide a birth year.';
+  }
+  const age = ageFromBirthYear(birthYear, now);
+  if (age === null) {
+    return 'Please provide a valid birth year.';
+  }
+
+  if (accountType === 'child_under_13') {
+    if (age >= 13) {
+      return 'This path is only for children under 13. Please choose a different option.';
+    }
+    if (!guardianConfirmed) {
+      return 'A parent or legal guardian must confirm to continue.';
+    }
+    return null;
+  }
+
+  // Both self_13_plus and carer_13_plus require age >= 13.
+  if (age < 13) {
+    return 'The 13+ paths require the account subject to be 13 or older.';
+  }
+  return null;
+}
+
+/**
+ * Build a persisted account record from validated inputs.
+ * Caller is expected to have called `validateAccountInput` first.
+ */
+export function buildAccountRecord(input: {
+  accountType: AccountType;
+  birthYear: number;
+  guardianConfirmed: boolean;
+  carerRelationship?: string;
+  now?: Date;
+}): AccountRecord {
+  const now = input.now ?? new Date();
+  return {
+    accountType: input.accountType,
+    birthYear: input.birthYear,
+    isChild: isUnder13(input.birthYear, now),
+    carerRelationship:
+      input.accountType === 'carer_13_plus'
+        ? input.carerRelationship
+        : undefined,
+    gatedAt: now.toISOString(),
+    guardianConfirmed:
+      input.accountType === 'child_under_13' ? input.guardianConfirmed : true,
+    parentEmailConfirmed: false,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,8 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
Closes #116.

## Summary
- Three-way signup fork before account creation: `child_under_13`, `self_13_plus`, `carer_13_plus`.
- Child path collects birth YEAR only (band, never full DOB) and requires an explicit parent/legal-guardian confirmation checkbox with disclaimer text.
- Persists `accountType`, `birthYear`, `isChild`, `carerRelationship`, `guardianConfirmed`, `parentEmailConfirmed`, `gatedAt` to the account record via `AppContext` (localStorage).
- Child-path accounts land on a new `/parent-email-verification` placeholder page that sets expectation for the email-plus flow (tracked in #117 - not implemented here).
- Age gate logic extracted into a pure `src/lib/account.ts` module with a `bun:test` unit suite (11 tests) covering all three paths, age-band math, validation, and routing.

## Behaviour by path
- `child_under_13`: who -> birth year -> guardian confirmation -> `/parent-email-verification`.
- `self_13_plus`: who -> birth year -> `/onboarding`.
- `carer_13_plus`: who -> birth year (+ relationship field) -> `/onboarding`.

If the birth year contradicts the chosen path (e.g. 13+ year selected for the child path), an inline warning blocks continuation and points the user back to the who step.

## DPIA reference
- `8gi-governance/docs/legal/2026-04-21-8gentjr-dpia-interim.md`

## Scope OUT (tracked elsewhere)
- Email-plus VPC flow: #117
- Parental withdrawal: #118

## Test plan
- [ ] `bun test src/lib/account.test.ts` green (11 tests).
- [ ] `bunx tsc --noEmit` produces no new errors against touched files.
- [ ] Manual walk-through of all three paths on dev, confirming localStorage record after each.
- [ ] Confirm child path lands on `/parent-email-verification` and stays there (does not auto-advance to AAC board).
- [ ] Confirm returning user (with `accountType` already set in localStorage) skips the gate.

## Files touched
- `src/lib/account.ts` (new) - pure types + logic
- `src/lib/account.test.ts` (new) - 11 bun:test cases
- `src/components/ParentalGate.tsx` - replaced with 3-path gate
- `src/context/AppContext.tsx` - new DPIA fields
- `src/components/AppChrome.tsx` - ungate `/parent-email-verification` chrome
- `src/app/parent-email-verification/page.tsx` (new) - VPC placeholder
- `package.json` - `test` script
- `tsconfig.json` - exclude `*.test.ts` from build typecheck