### PR TITLE
feat(accounts): Clerk identity v1 for 13+ path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ VPC_STEP2_DELAY_MS=600000
 VPC_ADMIN_TOKEN=
 # Directory for the JSONL audit log + email outbox stub. Defaults to ./data/consent
 VPC_AUDIT_DIR=
+
+# Clerk accounts v1 (13+ path only; under-13 stays device-bound via VPC)
+# Dashboard: https://dashboard.clerk.com
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter, Fraunces } from 'next/font/google';
+import { ClerkProvider } from '@clerk/nextjs';
 import './globals.css';
 import { Providers } from './providers';
 import { AppChrome } from '../components/AppChrome';
@@ -107,18 +108,20 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={`${inter.variable} ${fraunces.variable}`} data-theme="light">
-      <head>
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-        />
-      </head>
-      <body className="antialiased">
-        <Providers>
-          <AppChrome>{children}</AppChrome>
-        </Providers>
-      </body>
-    </html>
+    <ClerkProvider>
+      <html lang="en" className={`${inter.variable} ${fraunces.variable}`} data-theme="light">
+        <head>
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          />
+        </head>
+        <body className="antialiased">
+          <Providers>
+            <AppChrome>{children}</AppChrome>
+          </Providers>
+        </body>
+      </html>
+    </ClerkProvider>
   );
 }

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,14 @@
+import { SignIn } from '@clerk/nextjs';
+
+export const metadata = {
+  title: 'Sign in',
+  robots: { index: false, follow: false },
+};
+
+export default function SignInPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6">
+      <SignIn path="/sign-in" signUpUrl="/sign-up" />
+    </main>
+  );
+}

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,14 @@
+import { SignUp } from '@clerk/nextjs';
+
+export const metadata = {
+  title: 'Sign up',
+  robots: { index: false, follow: false },
+};
+
+export default function SignUpPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6">
+      <SignUp path="/sign-up" signInUrl="/sign-in" />
+    </main>
+  );
+}

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -13,18 +13,25 @@ import Dock from './Dock';
 import { LockScreenGate } from './LockScreenGate';
 import { InstallPrompt } from './InstallPrompt';
 import { ParentalGate } from './ParentalGate';
+import { AuthBadge } from './AuthBadge';
 
-const CHROMELESS_ROUTES = ['/onboarding', '/parent-email-verification'];
+const CHROMELESS_ROUTES = ['/onboarding', '/parent-email-verification', '/sign-in', '/sign-up'];
 const UNGATED_ROUTES = ['/privacy', '/terms', '/help', '/feedback'];
+const ADULT_AUTH_SURFACES = ['/privacy', '/terms', '/help', '/feedback', '/settings'];
 
 export function AppChrome({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const isChromeless = CHROMELESS_ROUTES.some((r) => pathname?.startsWith(r));
   const isUngated = UNGATED_ROUTES.some((r) => pathname?.startsWith(r));
+  const showAuthBadge = ADULT_AUTH_SURFACES.some((r) => pathname?.startsWith(r));
 
-  // Privacy/terms pages bypass all gates
   if (isUngated) {
-    return <main>{children}</main>;
+    return (
+      <>
+        {showAuthBadge && <AuthBadge />}
+        <main>{children}</main>
+      </>
+    );
   }
 
   if (isChromeless) {
@@ -38,6 +45,7 @@ export function AppChrome({ children }: { children: ReactNode }) {
   return (
     <ParentalGate>
       <LockScreenGate>
+        {showAuthBadge && <AuthBadge />}
         <InstallPrompt />
         <main className="pb-safe-dock">{children}</main>
         <Dock />

--- a/src/components/AuthBadge.tsx
+++ b/src/components/AuthBadge.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+/**
+ * AuthBadge — minimal sign-in indicator for adult (13+) surfaces.
+ *
+ * Shows:
+ *   - SignedIn: Clerk's <UserButton/> (popover w/ sign-out)
+ *   - SignedOut: a "Sign in" link
+ *
+ * Intentionally NOT shown on the child-facing lockscreen + dock flow,
+ * because under-13 accounts stay device-bound per COPPA + the DPIA.
+ */
+import { SignedIn, SignedOut, UserButton } from '@clerk/nextjs';
+import Link from 'next/link';
+
+export function AuthBadge() {
+  return (
+    <div className="fixed top-3 right-3 z-40 flex items-center gap-2">
+      <SignedOut>
+        <Link
+          href="/sign-in"
+          className="text-sm font-medium px-3 py-1.5 rounded-full bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text)] hover:opacity-90"
+        >
+          Sign in
+        </Link>
+      </SignedOut>
+      <SignedIn>
+        <UserButton afterSignOutUrl="/" />
+      </SignedIn>
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,20 @@
+/**
+ * Clerk middleware (accounts v1).
+ *
+ * All routes stay public at the middleware layer. Clerk just attaches auth
+ * state so server components can read it via `auth()` and UI can read it via
+ * `<SignedIn/>` / `<SignedOut/>`. COPPA path for under-13 stays device-bound
+ * (no sign-in required); 13+ path gets persistent identity via Clerk.
+ */
+import { clerkMiddleware } from '@clerk/nextjs/server';
+
+export default clerkMiddleware();
+
+export const config = {
+  matcher: [
+    // Skip Next internals and static files.
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    // Always run on API + trpc routes.
+    '/(api|trpc)(.*)',
+  ],
+};


### PR DESCRIPTION
## Summary

Closes #124. Wires Clerk into 8gentjr so 13+ users get a persistent email+password identity. Under-13 path unchanged (stays device-bound via VPC consent, COPPA-correct).

## Changes

| File | What |
|---|---|
| `src/middleware.ts` | Clerk middleware; attaches auth, does NOT auto-protect |
| `src/app/layout.tsx` | `<ClerkProvider>` wraps the tree |
| `src/app/sign-in/[[...sign-in]]/page.tsx` | Hosted Clerk sign-in |
| `src/app/sign-up/[[...sign-up]]/page.tsx` | Hosted Clerk sign-up |
| `src/components/AuthBadge.tsx` | UserButton / Sign-in link, top-right |
| `src/components/AppChrome.tsx` | Mounts AuthBadge on adult surfaces only |
| `.env.example` | Clerk publishable + secret key entries |

## What this does NOT do

- No `AccountRecord` migration (localStorage → Clerk metadata). That's v2.
- No route gates. Clerk just seeds auth state; all existing flows continue unchanged.
- No child sign-in. Minors stay device-bound.

## Test plan

- [x] `bun run build` green locally
- [x] `bun run dev` serves `/sign-in`, `/sign-up`, `/privacy` all 200 with Clerk middleware headers
- [ ] Vercel preview: create test account, sign out, close browser, return, sign in, session restored
- [ ] Smoke: existing age-gate + VPC + withdraw + feedback flows unchanged

## Tracker
- Parent: 8gi-foundation/8gi-governance#114 (closed)
- DPIA: 8gi-governance `docs/legal/2026-04-21-8gentjr-dpia-interim.md`