### PR TITLE
fix(tts): always fall back to Web Speech when ElevenLabs returns no audio

### DIFF
--- a/src/lib/tts.ts
+++ b/src/lib/tts.ts
@@ -196,9 +196,12 @@ async function speakElevenLabs(
   let res: Response;
   try {
     res = await fetch(`/api/tts?${params.toString()}`, { signal: controller.signal });
-  } catch {
-    // AbortError = user tapped something else — stay silent, don't trigger browser TTS
-    return 'elevenlabs';
+  } catch (err) {
+    // AbortError = user tapped another card; stay silent so we don't speak
+    // the stale word on top of the new one.
+    if ((err as { name?: string })?.name === 'AbortError') return 'elevenlabs';
+    // Any other fetch failure (offline, DNS, CORS) — fall back to Web Speech.
+    return 'none';
   } finally {
     if (currentAbortController === controller) currentAbortController = null;
   }
@@ -206,12 +209,13 @@ async function speakElevenLabs(
   // 204 = not configured — fall back to browser TTS
   if (res.status === 204) return 'none';
 
-  // 503 = configured but failed — stay silent, no robot fallback
-  if (!res.ok) return 'elevenlabs';
+  // Any non-OK response (503 upstream fail, 429, 500…) — fall back so the
+  // child always hears *something* instead of silence.
+  if (!res.ok) return 'none';
 
   const blob = await res.blob();
-  // Empty blob — configured but silent failure; don't trigger robot voice
-  if (blob.size === 0) return 'elevenlabs';
+  // Empty payload — fall back rather than swallowing silently.
+  if (blob.size === 0) return 'none';
 
   // Cache the blob for instant replay
   audioCache.set(cacheKey, blob);


### PR DESCRIPTION
## Summary

Child tapping an AAC card and hearing nothing is worse than hearing the robot voice. \`tts.ts\` was swallowing several ElevenLabs failure modes silently (503, empty blob, non-abort network errors) to avoid triggering browser TTS. That tradeoff is wrong for non-prewarmed cards: first tap on an uncached word + a flaky connection = silent card.

This flips the defaults:

| Case | Before | After |
|---|---|---|
| 503 / non-OK response | silent | Web Speech fallback |
| Empty blob | silent | Web Speech fallback |
| Network error (offline, DNS) | silent | Web Speech fallback |
| AbortError (user tapped another card) | silent | **still silent** (correct) |
| 204 not configured | Web Speech | Web Speech (unchanged) |
| Cache hit / 200 OK | ElevenLabs | ElevenLabs (unchanged) |

Abort stays silent so we don't speak the stale word on top of the new one the child just tapped.

## Test plan

- [ ] Deploy preview
- [ ] Tap a supercore card (prewarmed) - hear ElevenLabs, fast
- [ ] Tap a non-prewarmed card in QuickPhrases/Builder - hear ElevenLabs (first tap ~1s, then cached)
- [ ] Disable network in DevTools, tap any card - hear Web Speech robot voice (instant)
- [ ] Rapid-tap several cards - only last tap speaks, no overlap
- [ ] Re-enable network, tap - ElevenLabs resumes

## Related

- Follows the prewarm-tts work (commit 35dbd05) - covers the long tail the prewarm misses