### PR TITLE
fix(auth): ungate /sign-in and /sign-up so Clerk renders

### DIFF
--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -15,8 +15,8 @@ import { InstallPrompt } from './InstallPrompt';
 import { ParentalGate } from './ParentalGate';
 import { AuthBadge } from './AuthBadge';
 
-const CHROMELESS_ROUTES = ['/onboarding', '/parent-email-verification', '/sign-in', '/sign-up'];
-const UNGATED_ROUTES = ['/privacy', '/terms', '/help', '/feedback'];
+const CHROMELESS_ROUTES = ['/onboarding', '/parent-email-verification'];
+const UNGATED_ROUTES = ['/privacy', '/terms', '/help', '/feedback', '/sign-in', '/sign-up'];
 const ADULT_AUTH_SURFACES = ['/privacy', '/terms', '/help', '/feedback', '/settings'];
 
 export function AppChrome({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- ParentalGate was intercepting `/sign-in` and `/sign-up`, forcing adults through the child-onboarding selector instead of Clerk.
- Moves both routes from CHROMELESS_ROUTES to UNGATED_ROUTES so the hosted Clerk components render directly.

Caught in prod smoke test after PR #125: `8gentjr.com/sign-up` served the 'Who is this account for?' gate, not the Clerk form.

## Test plan
- [x] Local build green
- [ ] Preview deploy green
- [ ] Prod `/sign-up` renders Clerk form
- [ ] Prod `/sign-in` renders Clerk form
- [ ] Child-facing lockscreen still gated by ParentalGate