### PR TITLE
fix(consent): persist audit log to Vercel Blob (fixes 500 on /api/consent/initiate)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@huggingface/transformers": "^4.2.0",
         "@remotion/media-utils": "^4.0.448",
         "@remotion/player": "^4.0.448",
+        "@vercel/blob": "^2.3.3",
         "next": "^15.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -166,6 +167,8 @@
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
+    "@vercel/blob": ["@vercel/blob@2.3.3", "", { "dependencies": { "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^6.23.0" } }, "sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg=="],
+
     "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
@@ -173,6 +176,8 @@
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+
+    "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
     "autoprefixer": ["autoprefixer@10.4.27", "", { "dependencies": { "browserslist": "^4.28.1", "caniuse-lite": "^1.0.30001774", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA=="],
 
@@ -264,11 +269,15 @@
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
+    "is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
+
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -356,6 +365,8 @@
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
@@ -396,6 +407,8 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
+    "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
@@ -407,6 +420,8 @@
     "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@huggingface/transformers": "^4.2.0",
     "@remotion/media-utils": "^4.0.448",
     "@remotion/player": "^4.0.448",
+    "@vercel/blob": "^2.3.3",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/lib/consent/audit-store.ts
+++ b/src/lib/consent/audit-store.ts
@@ -1,19 +1,22 @@
 /**
  * VPC Audit Store
  *
- * Immutable, append-only JSONL audit log for COPPA parental consent events.
- * File-backed for now (data/consent/vpc-audit.jsonl). Each row captures:
- *   timestamp, event, sid, email (lowercased), step, tokenHash, ip, userAgent.
+ * Immutable, append-only audit log for COPPA parental consent events.
  *
- * Read path supports the admin audit route. Single-use tracking is enforced
- * via the consumedTokenHashes() lookup - a token hash that already appears
- * in a 'step-N-confirmed' or 'step-N-consumed' row is invalid.
+ * Two backends, selected at runtime:
+ *   - Vercel Blob (private store) when BLOB_READ_WRITE_TOKEN is present
+ *     — one blob per row under prefix `vpc-audit/`. Works on Vercel's
+ *     read-only serverless filesystem. Rows survive cold starts.
+ *   - JSONL file at data/consent/vpc-audit.jsonl otherwise
+ *     — dev default; tests override VPC_AUDIT_DIR to a tmp dir.
  *
- * Swap this for a real DB row-by-row when we move off file storage.
+ * Single-use token enforcement and step ordering depend on every row
+ * being durably persisted — never swallow errors from appendAudit.
  */
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { get, list, put } from '@vercel/blob';
 
 export type VpcEvent =
   | 'step1-sent'
@@ -24,11 +27,11 @@ export type VpcEvent =
   | 'withdrawn';
 
 export interface VpcAuditRow {
-  ts: string;              // ISO8601
+  ts: string;
   event: VpcEvent;
-  sid: string;             // consent session id
-  email: string;           // lowercased parent email
-  step: 1 | 2 | null;      // step index where relevant
+  sid: string;
+  email: string;
+  step: 1 | 2 | null;
   tokenHash: string | null;
   ip: string | null;
   userAgent: string | null;
@@ -37,6 +40,16 @@ export interface VpcAuditRow {
 }
 
 const DEFAULT_NOTICE_VERSION = '2026-04-10';
+const BLOB_PREFIX = 'vpc-audit/';
+
+interface Backend {
+  append(row: VpcAuditRow): Promise<void>;
+  readAll(): Promise<VpcAuditRow[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem backend — local dev + tests
+// ---------------------------------------------------------------------------
 
 function auditPath(): string {
   const dir =
@@ -45,36 +58,110 @@ function auditPath(): string {
   return path.join(dir, 'vpc-audit.jsonl');
 }
 
-async function ensureDir(): Promise<void> {
-  const dir = path.dirname(auditPath());
-  await fs.mkdir(dir, { recursive: true });
+const fileBackend: Backend = {
+  async append(row) {
+    const file = auditPath();
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.appendFile(file, JSON.stringify(row) + '\n', 'utf8');
+  },
+  async readAll() {
+    try {
+      const raw = await fs.readFile(auditPath(), 'utf8');
+      return raw
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as VpcAuditRow);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw err;
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Vercel Blob backend — prod / anywhere the store is linked
+// ---------------------------------------------------------------------------
+
+function rowPathname(row: VpcAuditRow): string {
+  // ts sorts lexicographically, sid+event disambiguate parallel rows.
+  const safeTs = row.ts.replace(/[:.]/g, '-');
+  return `${BLOB_PREFIX}${safeTs}__${row.sid}__${row.event}.json`;
 }
+
+const blobBackend: Backend = {
+  async append(row) {
+    await put(rowPathname(row), JSON.stringify(row), {
+      access: 'private',
+      addRandomSuffix: false,
+      contentType: 'application/json',
+      allowOverwrite: false,
+    });
+  },
+  async readAll() {
+    const rows: VpcAuditRow[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await list({ prefix: BLOB_PREFIX, cursor, limit: 1000 });
+      const fetched = await Promise.all(
+        page.blobs.map(async (b) => {
+          const result = await get(b.pathname, { access: 'private' });
+          if (!result || result.statusCode !== 200) {
+            throw new Error(`blob get failed for ${b.pathname}`);
+          }
+          const text = await new Response(result.stream).text();
+          return JSON.parse(text) as VpcAuditRow;
+        }),
+      );
+      rows.push(...fetched);
+      cursor = page.cursor;
+    } while (cursor);
+    rows.sort((a, b) => a.ts.localeCompare(b.ts));
+    return rows;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Backend selection
+// ---------------------------------------------------------------------------
+
+function pickBackend(): Backend {
+  // Tests force the filesystem path by setting VPC_AUDIT_DIR; honor that
+  // even if a Blob token happens to be in the dev env.
+  if (process.env.VPC_AUDIT_DIR) return fileBackend;
+  if (process.env.BLOB_READ_WRITE_TOKEN) return blobBackend;
+  return fileBackend;
+}
+
+let backendSingleton: Backend | null = null;
+function getBackend(): Backend {
+  if (!backendSingleton) backendSingleton = pickBackend();
+  return backendSingleton;
+}
+
+/** Test helper: reset the backend selection cache (honors env changes between tests). */
+export function __resetBackendForTests(): void {
+  backendSingleton = null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API — unchanged signatures
+// ---------------------------------------------------------------------------
 
 export async function appendAudit(
   row: Omit<VpcAuditRow, 'ts' | 'noticeVersion'> & { noticeVersion?: string },
 ): Promise<VpcAuditRow> {
-  await ensureDir();
   const { noticeVersion, ...rest } = row;
   const full: VpcAuditRow = {
     ts: new Date().toISOString(),
     noticeVersion: noticeVersion ?? DEFAULT_NOTICE_VERSION,
     ...rest,
   };
-  await fs.appendFile(auditPath(), JSON.stringify(full) + '\n', 'utf8');
+  await getBackend().append(full);
   return full;
 }
 
 export async function readAudit(): Promise<VpcAuditRow[]> {
-  try {
-    const raw = await fs.readFile(auditPath(), 'utf8');
-    return raw
-      .split('\n')
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as VpcAuditRow);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
-    throw err;
-  }
+  return getBackend().readAll();
 }
 
 export async function findByEmail(email: string): Promise<VpcAuditRow[]> {


### PR DESCRIPTION
## Summary

Fixes the 500 returned by `POST /api/consent/initiate` on production (https://8gentjr.com/parent-email-verification). Root cause: `audit-store.ts` wrote the COPPA audit log to `data/consent/vpc-audit.jsonl` via `fs.appendFile`, which throws `EROFS` on Vercel's read-only serverless filesystem.

## Fix

`src/lib/consent/audit-store.ts` now has dual backends, selected at runtime:

- **Vercel Blob** (`access: 'private'`) when `BLOB_READ_WRITE_TOKEN` is present — one blob per row at `vpc-audit/{ts}__{sid}__{event}.json`. Survives cold starts, durable, COPPA-compliant retention.
- **JSONL file** otherwise — preserved unchanged for tests (`VPC_AUDIT_DIR` override) and local dev.

Public API (`appendAudit` / `readAudit` / `findByEmail` / `findBySid` / `consumedTokenHashes` / `isStep1Confirmed` / `isStep2Confirmed`) is unchanged. Single-use token enforcement and step ordering still work because every row is durably persisted before the next handler reads it.

## Infra

Created Vercel Blob store `8gentjr-consent-v2` in `iad1`, private access, linked to all three environments.

## Test plan

- [x] `bun test src/lib/consent/__tests__/flow.test.ts` — 10 pass, 0 fail (file backend, `VPC_AUDIT_DIR` override)
- [x] `bun x tsc --noEmit` — clean
- [ ] Preview deploy: `POST /api/consent/initiate` returns 200, audit row lands in blob store
- [ ] Prod deploy: real email submission at https://8gentjr.com/parent-email-verification completes step 1 without 500