### PR TITLE
feat(glp): Tier 1 — stage-aware adaptive layer (closes #135, #136, #137)

### DIFF
--- a/src/components/SharedSentenceBar.tsx
+++ b/src/components/SharedSentenceBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * SharedSentenceBar — consistent sentence display bar used across all Talk screens.
+ * SharedSentenceBar - consistent sentence display bar used across all Talk screens.
  *
  * Matches the SupercoreGrid design language:
  * - bg-gray-800 bar
@@ -33,7 +33,7 @@ export interface SharedSentenceBarProps {
   onMagic?: () => void;
   isMagicLoading?: boolean;
   /**
-   * Optional mirror 🪞 button — re-speaks the current sentence verbatim.
+   * Optional mirror 🪞 button. Re-speaks the current sentence verbatim.
    * Replaces the magic button at GLP stages 1-2 to avoid corrective rewrites.
    * If both onMagic and onMirror are provided, mirror takes precedence.
    */
@@ -81,7 +81,7 @@ export function SharedSentenceBar({
       className={`flex items-center gap-1.5 px-2 py-1.5 min-h-[56px] bg-gray-800 rounded-xl mx-2 mt-2 shrink-0 transition-shadow duration-500 ${
         showFallbackGlow ? 'ring-2 ring-amber-400/70 shadow-[0_0_12px_2px_rgba(251,191,36,0.35)]' : ''
       }`}
-      title={showFallbackGlow ? 'Using backup voice — ElevenLabs unavailable' : undefined}
+      title={showFallbackGlow ? 'Using backup voice (ElevenLabs unavailable)' : undefined}
     >
       {/* ▶ Speak */}
       <button
@@ -95,7 +95,7 @@ export function SharedSentenceBar({
         &#9654;
       </button>
 
-      {/* 🪞 Mirror — replaces magic at GLP stages 1-2 (no LLM rewrite, just re-speak) */}
+      {/* 🪞 Mirror replaces magic at GLP stages 1-2 (no LLM rewrite, just re-speak) */}
       {onMirror ? (
         <button
           onClick={onMirror}
@@ -105,7 +105,7 @@ export function SharedSentenceBar({
               ? 'bg-sky-500 hover:bg-sky-400 cursor-pointer active:scale-90'
               : 'bg-gray-600 cursor-not-allowed'
           }`}
-          aria-label="Mirror — re-speak sentence as is"
+          aria-label="Mirror: re-speak sentence as is"
           title="Mirror: say it back exactly"
         >
           &#129690;

--- a/src/components/SharedSentenceBar.tsx
+++ b/src/components/SharedSentenceBar.tsx
@@ -32,6 +32,12 @@ export interface SharedSentenceBarProps {
   /** Optional magic ✨ button */
   onMagic?: () => void;
   isMagicLoading?: boolean;
+  /**
+   * Optional mirror 🪞 button — re-speaks the current sentence verbatim.
+   * Replaces the magic button at GLP stages 1-2 to avoid corrective rewrites.
+   * If both onMagic and onMirror are provided, mirror takes precedence.
+   */
+  onMirror?: () => void;
   placeholder?: string;
   /**
    * Set to true briefly when browser TTS fallback fired (ElevenLabs was unavailable).
@@ -47,6 +53,7 @@ export function SharedSentenceBar({
   onRemoveWord,
   onMagic,
   isMagicLoading = false,
+  onMirror,
   placeholder = 'Tap words to build a sentence...',
   engineFallback = false,
 }: SharedSentenceBarProps) {
@@ -88,8 +95,22 @@ export function SharedSentenceBar({
         &#9654;
       </button>
 
-      {/* ✨ Magic — only rendered when onMagic is provided */}
-      {onMagic && (
+      {/* 🪞 Mirror — replaces magic at GLP stages 1-2 (no LLM rewrite, just re-speak) */}
+      {onMirror ? (
+        <button
+          onClick={onMirror}
+          disabled={words.length < 1}
+          className={`shrink-0 w-10 h-10 rounded-xl text-white flex items-center justify-center text-base font-bold transition-all ${
+            words.length >= 1
+              ? 'bg-sky-500 hover:bg-sky-400 cursor-pointer active:scale-90'
+              : 'bg-gray-600 cursor-not-allowed'
+          }`}
+          aria-label="Mirror — re-speak sentence as is"
+          title="Mirror: say it back exactly"
+        >
+          &#129690;
+        </button>
+      ) : onMagic && (
         <button
           onClick={onMagic}
           disabled={words.length < 2 || isMagicLoading}

--- a/src/components/SuggestedRow.tsx
+++ b/src/components/SuggestedRow.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+/**
+ * SuggestedRow — adaptive layer above the locked Supercore grid.
+ *
+ * Cards CAN reorder/refresh between sessions. Locked grid below NEVER moves.
+ * Tinted background + soft pulse border signals "these can change" to children
+ * while preserving motor planning of the fixed grid.
+ *
+ * Issue: #136
+ */
+
+import React, { useCallback } from 'react';
+import { TapCard } from '@/components/TapCard';
+import { suggestByStage } from '@/lib/suggestions';
+
+export interface SuggestedRowProps {
+  glpStage: number;
+  cols: number;
+  /** Called with the suggestion text when a card is tapped. */
+  onTap: (text: string) => void;
+}
+
+const ROW_COUNT = 6;
+
+const SuggestedCard = React.memo(function SuggestedCard({
+  text,
+  onTap,
+}: {
+  text: string;
+  onTap: (text: string) => void;
+}) {
+  const handleTap = useCallback(() => onTap(text), [onTap, text]);
+  return (
+    <TapCard
+      onTap={handleTap}
+      ariaLabel={text}
+      className="flex items-center justify-center rounded-xl border-2 border-dashed border-amber-400/70 bg-amber-50 text-amber-900 px-2 py-2 text-center leading-tight animate-[pulse_3.5s_ease-in-out_infinite]"
+      style={{ minHeight: 56 }}
+    >
+      <span className="font-bold text-[13px] leading-tight w-full line-clamp-2">{text}</span>
+    </TapCard>
+  );
+});
+
+export function SuggestedRow({ glpStage, cols, onTap }: SuggestedRowProps) {
+  const suggestions = suggestByStage(glpStage).slice(0, ROW_COUNT);
+  if (suggestions.length === 0) return null;
+
+  // Cap columns so cards stay readable on the 10-col desktop grid.
+  const rowCols = Math.min(cols, ROW_COUNT);
+
+  return (
+    <div className="px-1.5 pt-2 pb-1">
+      <p className="text-[10px] font-semibold text-amber-700/80 uppercase tracking-wider mb-1.5 px-0.5">
+        Suggested for you
+      </p>
+      <div
+        className="grid gap-1"
+        style={{ gridTemplateColumns: `repeat(${rowCols}, 1fr)` }}
+      >
+        {suggestions.map((s, i) => (
+          <SuggestedCard key={`${s.text}-${i}`} text={s.text} onTap={onTap} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default SuggestedRow;

--- a/src/components/SuggestedRow.tsx
+++ b/src/components/SuggestedRow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * SuggestedRow — adaptive layer above the locked Supercore grid.
+ * SuggestedRow: adaptive layer above the locked Supercore grid.
  *
  * Cards CAN reorder/refresh between sessions. Locked grid below NEVER moves.
  * Tinted background + soft pulse border signals "these can change" to children

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -255,7 +255,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   const [isMagicLoading, setIsMagicLoading] = useState(false);
   const [engineFallback, setEngineFallback] = useState(false);
 
-  // Kill-switch — read once at mount. localStorage 8gentjr-glp-disable=true
+  // Kill-switch read once at mount. localStorage 8gentjr-glp-disable=true
   // hides the Suggested row and forces the magic button on regardless of stage.
   const [glpDisabled, setGlpDisabled] = useState(false);
   useEffect(() => {
@@ -414,7 +414,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
       {/* Scrollable grid area */}
       <div className="flex-1 min-h-0 overflow-y-auto">
 
-        {/* Adaptive Suggested row — sits above intro + locked grid */}
+        {/* Adaptive Suggested row sits above intro + locked grid */}
         {!glpDisabled && (
           <SuggestedRow glpStage={stage} cols={cols} onTap={handleSuggestedTap} />
         )}

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -29,6 +29,7 @@ import { FITZGERALD_COLORS, type WordCategory } from '@/lib/fitzgerald-key';
 import { logWord } from '@/lib/session-logger';
 import { speak as elevenLabsSpeak, preloadAudio } from '@/lib/tts';
 import { SharedSentenceBar } from '@/components/SharedSentenceBar';
+import { SuggestedRow } from '@/components/SuggestedRow';
 import { TapCard } from '@/components/TapCard';
 import { useSentence } from '@/hooks/useSentence';
 import { useApp } from '@/context/AppContext';
@@ -254,6 +255,17 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   const [isMagicLoading, setIsMagicLoading] = useState(false);
   const [engineFallback, setEngineFallback] = useState(false);
 
+  // Kill-switch — read once at mount. localStorage 8gentjr-glp-disable=true
+  // hides the Suggested row and forces the magic button on regardless of stage.
+  const [glpDisabled, setGlpDisabled] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setGlpDisabled(window.localStorage.getItem('8gentjr-glp-disable') === 'true');
+  }, []);
+
+  const stage = settings.glpStage ?? 3;
+  const mirrorMode = !glpDisabled && stage <= 2;
+
   // Responsive column count: 4 on phone, 5 on small tablet, 10 on desktop
   useEffect(() => {
     const check = () => {
@@ -332,6 +344,21 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
     logWord(label);
   }, [speakText, addWord]);
 
+  const handleSuggestedTap = useCallback((text: string) => {
+    speakText(text);
+    addWord({
+      label: text,
+      // Amber chip distinguishes adaptive suggestions from locked-grid words.
+      className: 'bg-amber-100 text-amber-900 border-amber-400',
+    });
+    logWord(text);
+  }, [speakText, addWord]);
+
+  const handleMirrorSpeak = useCallback(() => {
+    if (sentence.length === 0) return;
+    speakText(sentence.map(w => w.label).join(' '));
+  }, [sentence, speakText]);
+
   // Intro cards — only when child name is known
   const introCols = Math.min(cols, 4);
   const introCards: { label: string; arasaacId?: number }[] = childName ? [
@@ -361,7 +388,8 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
       <SharedSentenceBar
         words={sentence}
         onSpeak={handleSpeakAll}
-        onMagic={handleMagicSpeak}
+        onMagic={mirrorMode ? undefined : handleMagicSpeak}
+        onMirror={mirrorMode ? handleMirrorSpeak : undefined}
         isMagicLoading={isMagicLoading}
         onClear={handleClear}
         onRemoveWord={removeWord}
@@ -385,6 +413,11 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
 
       {/* Scrollable grid area */}
       <div className="flex-1 min-h-0 overflow-y-auto">
+
+        {/* Adaptive Suggested row — sits above intro + locked grid */}
+        {!glpDisabled && (
+          <SuggestedRow glpStage={stage} cols={cols} onTap={handleSuggestedTap} />
+        )}
 
         {/* Personalised intro row */}
         {introCards.length > 0 && (


### PR DESCRIPTION
## Summary

Three coupled changes that introduce GLP-stage awareness to /talk for the first time. Default behavior is preserved for all existing users (default `glpStage = 3`).

### T1.1 (#135) — already shipped
The `glpStage` field on `AppSettings` and the parent-visible stage selector in `/settings` already exist via #68. Stage descriptions render from `GLP_STAGES[i].description` as required. No code changes here.

### T1.2 (#136) — new SuggestedRow above the locked grid
- New `src/components/SuggestedRow.tsx` (~70 lines).
- Sources 6 cards from `suggestByStage(settings.glpStage)`.
- Sits ABOVE the personalised "Say hello" intro row and ABOVE the locked Supercore 50 grid. Locked grid does not move.
- Visually distinct: amber tint, dashed border, soft 3.5s pulse — signals "these can change" without distracting.
- Tap = speak + add to sentence + log, same flow as a core word tap.

### T1.3 (#137) — magic button stage-gated
- `SharedSentenceBar` now accepts an `onMirror` prop. When provided, the mirror button replaces the magic button entirely (no LLM call, no `/api/improve-sentence` fetch).
- `SupercoreGrid` passes `onMirror` at `glpStage <= 2` (echolalia / mitigated gestalts — corrective rewrites are the cardinal GLP violation here).
- At `glpStage >= 3`, `onMagic` is passed and the existing ✨ behavior is unchanged.

## Escape hatch

`localStorage.setItem('8gentjr-glp-disable', 'true')` will:
- Hide the Suggested row entirely.
- Force the magic button back on regardless of stage.

Read once at mount in `SupercoreGrid` (no polling). Use this if anything goes wrong in prod.

## Deferred (out of scope here)

- **T3.9 — NLA naming fix.** The current `lib/glp/stages.ts` descriptions invert Marge Blanc's NLA model (single-word → gestalt instead of gestalt → analytic). The PR uses the existing copy as-is; T3.9 will rewrite the stages module separately.
- T2.4 predictive next-word strip, T2.5 personal vocab promotion, T2.6 gestalt flagging, T3.7 auto-stage estimator, T3.8 mix-and-match — all out of scope.

## Files touched (3)

- `src/components/SuggestedRow.tsx` (new, 70 lines)
- `src/components/SupercoreGrid.tsx` (+34 lines)
- `src/components/SharedSentenceBar.tsx` (+22 lines)

## Test plan

- [ ] /settings stage selector still renders 6 stages with descriptions from `GLP_STAGES`
- [ ] At default `glpStage=3`: Suggested row appears above locked grid with words like "more", "stop", "yes", "no"; ✨ magic button still works
- [ ] Locked Supercore 50 grid does NOT move pixel-for-pixel (compare against main)
- [ ] At `glpStage=1`: Suggested row shows gestalts ("let's go", "all done", "uh oh", "my turn", "look at that", "I want that"); magic button replaced with 🪞 mirror; tapping mirror speaks the sentence verbatim with NO `/api/improve-sentence` call (verify in network tab)
- [ ] At `glpStage=4`: Suggested row shows early sentence frames ("I want", "I need", "can I" etc.); magic button back
- [ ] `localStorage.setItem('8gentjr-glp-disable','true')` then reload: Suggested row hidden, magic button always on
- [ ] /privacy, /terms, /sign-in, /onboarding, /consent unaffected (ungated routes)
- [ ] Vercel preview build green