### PR TITLE
feat(glp): T2.6 gestalt flagging on vocab + parent-captured cards (#140)

### DIFF
--- a/src/components/SharedSentenceBar.tsx
+++ b/src/components/SharedSentenceBar.tsx
@@ -21,6 +21,12 @@ export interface SentenceChip {
   className?: string;
   /** Optional inline styles for chip (category colour overrides) */
   style?: React.CSSProperties;
+  /**
+   * GLP T2.6 — when true, this chip is a gestalt (whole-language script).
+   * Renders a small quote glyph in the corner. Any sentence containing a
+   * gestalt chip forces the speak button to mirror mode upstream.
+   */
+  isGestalt?: boolean;
 }
 
 export interface SharedSentenceBarProps {
@@ -141,17 +147,32 @@ export function SharedSentenceBar({
               key={`${chip.label}-${index}`}
               onClick={() => onRemoveWord?.(index)}
               disabled={!onRemoveWord}
-              className={`shrink-0 flex items-center gap-1.5 px-2 py-1 rounded-lg font-bold text-sm border-2 transition-transform active:scale-95 ${
+              className={`relative shrink-0 flex items-center gap-1.5 px-2 py-1 rounded-lg font-bold text-sm border-2 transition-transform active:scale-95 ${
                 onRemoveWord ? 'cursor-pointer' : 'cursor-default'
               } ${chip.className ?? 'bg-gray-600 text-white border-gray-500'}`}
               style={chip.style}
-              aria-label={onRemoveWord ? `Remove ${chip.label}` : chip.label}
+              aria-label={
+                onRemoveWord
+                  ? `Remove ${chip.label}${chip.isGestalt ? ' (phrase)' : ''}`
+                  : `${chip.label}${chip.isGestalt ? ' (phrase)' : ''}`
+              }
             >
               {chip.imageUrl && (
                 /* eslint-disable-next-line @next/next/no-img-element */
                 <img src={chip.imageUrl} alt="" className="w-7 h-7 object-contain shrink-0" />
               )}
               <span>{chip.label}</span>
+              {/* T2.6 — gestalt corner glyph. Subtle quote mark, no colour change.
+                  Stays within Fitzgerald Key palette (no banned hues 270-350). */}
+              {chip.isGestalt && (
+                <span
+                  aria-hidden="true"
+                  title="Whole phrase (gestalt)"
+                  className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-gray-900/85 text-white text-[10px] leading-none flex items-center justify-center font-extrabold shadow-sm"
+                >
+                  &#8220;
+                </span>
+              )}
             </button>
           ))
         )}

--- a/src/components/SharedSentenceBar.tsx
+++ b/src/components/SharedSentenceBar.tsx
@@ -22,7 +22,7 @@ export interface SentenceChip {
   /** Optional inline styles for chip (category colour overrides) */
   style?: React.CSSProperties;
   /**
-   * GLP T2.6 — when true, this chip is a gestalt (whole-language script).
+   * GLP T2.6 - when true, this chip is a gestalt (whole-language script).
    * Renders a small quote glyph in the corner. Any sentence containing a
    * gestalt chip forces the speak button to mirror mode upstream.
    */
@@ -162,7 +162,7 @@ export function SharedSentenceBar({
                 <img src={chip.imageUrl} alt="" className="w-7 h-7 object-contain shrink-0" />
               )}
               <span>{chip.label}</span>
-              {/* T2.6 — gestalt corner glyph. Subtle quote mark, no colour change.
+              {/* T2.6 - gestalt corner glyph. Subtle quote mark, no colour change.
                   Stays within Fitzgerald Key palette (no banned hues 270-350). */}
               {chip.isGestalt && (
                 <span

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -264,7 +264,11 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   }, []);
 
   const stage = settings.glpStage ?? 3;
-  const mirrorMode = !glpDisabled && stage <= 2;
+  const stageMirrorMode = !glpDisabled && stage <= 2;
+  // T2.6 — any gestalt chip in the sentence forces mirror at any stage.
+  // glpDisabled (kill switch) overrides everything, so respect it.
+  const gestaltMode = !glpDisabled && sentence.some(c => c.isGestalt);
+  const mirrorMode = stageMirrorMode || gestaltMode;
 
   // Responsive column count: 4 on phone, 5 on small tablet, 10 on desktop
   useEffect(() => {

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -2,7 +2,7 @@
 
 /**
  * Supercore 50 Core Word Grid
- * Issue #20: Fixed motor planning grid — words NEVER move.
+ * Issue #20: Fixed motor planning grid - words NEVER move.
  *
  * Fixed-position AAC grid following Smartbox Supercore design principles.
  * 50 high-frequency words covering ~40-45% of daily communication.
@@ -81,7 +81,7 @@ export function getGridCategoryColor(category: FitzgeraldCategory) {
 }
 
 // =============================================================================
-// Core Word Data — FIXED positions, NEVER reorder
+// Core Word Data - FIXED positions, NEVER reorder
 // =============================================================================
 
 interface CoreWord {
@@ -163,11 +163,11 @@ const SUPERCORE_50: CoreWord[] = [
 ];
 
 // =============================================================================
-// TTS Helper — ElevenLabs via tts.ts
+// TTS Helper - ElevenLabs via tts.ts
 // =============================================================================
 
 // =============================================================================
-// Sentence Strip — now uses SharedSentenceBar
+// Sentence Strip - now uses SharedSentenceBar
 // =============================================================================
 
 // =============================================================================
@@ -201,7 +201,7 @@ const CoreWordButton = React.memo(function CoreWordButton({ word, onTap }: { wor
 });
 
 // =============================================================================
-// Intro Card Button — for personalised greeting cards
+// Intro Card Button - for personalised greeting cards
 // =============================================================================
 
 const IntroCardButton = React.memo(function IntroCardButton({
@@ -265,7 +265,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
 
   const stage = settings.glpStage ?? 3;
   const stageMirrorMode = !glpDisabled && stage <= 2;
-  // T2.6 — any gestalt chip in the sentence forces mirror at any stage.
+  // T2.6 - any gestalt chip in the sentence forces mirror at any stage.
   // glpDisabled (kill switch) overrides everything, so respect it.
   const gestaltMode = !glpDisabled && sentence.some(c => c.isGestalt);
   const mirrorMode = stageMirrorMode || gestaltMode;
@@ -363,7 +363,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
     speakText(sentence.map(w => w.label).join(' '));
   }, [sentence, speakText]);
 
-  // Intro cards — only when child name is known
+  // Intro cards - only when child name is known
   const introCols = Math.min(cols, 4);
   const introCards: { label: string; arasaacId?: number }[] = childName ? [
     { label: `Hi! I'm ${childName}`, arasaacId: 27507 },
@@ -400,7 +400,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
         engineFallback={engineFallback}
       />
 
-      {/* Color Legend — single scrollable row */}
+      {/* Color Legend - single scrollable row */}
       <div className="flex gap-1 px-2 py-1 overflow-x-auto no-scrollbar shrink-0">
         {legendItems.map(({ category, label }) => {
           const cls = FITZGERALD_CLASSES[category];
@@ -427,7 +427,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
         {introCards.length > 0 && (
           <div className="px-1.5 pt-2 pb-1">
             <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-1.5 px-0.5">
-              Say hello — {childName}
+              Say hello - {childName}
             </p>
             <div className="grid gap-1" style={{ gridTemplateColumns: `repeat(${introCols}, 1fr)` }}>
               {introCards.map((card, i) => (

--- a/src/components/VoiceCardCreator.tsx
+++ b/src/components/VoiceCardCreator.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 /**
- * VoiceCardCreator — parent voice-to-AAC-card builder.
+ * VoiceCardCreator - parent voice-to-AAC-card builder.
  *
  * Parent taps mic → speaks → card materialises in front of their eyes.
  * Sequence: idle → listening → processing → preview → saved
  *
- * Soft, careful, magical — deterministic output, animated reveal.
+ * Soft, careful, magical - deterministic output, animated reveal.
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
@@ -47,7 +47,7 @@ interface GeneratedCard {
   imageUrl: string | null;
   transcript: string;
   /**
-   * GLP T2.6 — parent-captured cards are gestalts by definition (Marge Blanc NLA).
+   * GLP T2.6 - parent-captured cards are gestalts by definition (Marge Blanc NLA).
    * Always `true` for VoiceCardCreator output. Downstream surfaces that render
    * this card into the sentence bar must propagate this flag onto the chip so
    * the speak button cascades to mirror mode and skips /api/improve-sentence.
@@ -71,11 +71,11 @@ function saveToLocalStorage(card: GeneratedCard) {
     const stored = JSON.parse(localStorage.getItem('8gentjr_custom_cards') || '[]');
     stored.unshift({ ...card, id: `custom-${Date.now()}`, createdAt: Date.now() });
     localStorage.setItem('8gentjr_custom_cards', JSON.stringify(stored.slice(0, 100)));
-  } catch { /* noop — localStorage not available */ }
+  } catch { /* noop - localStorage not available */ }
 }
 
 // ---------------------------------------------------------------------------
-// Listening Ring — pulsing red circle during speech recognition
+// Listening Ring - pulsing red circle during speech recognition
 // ---------------------------------------------------------------------------
 
 function ListeningRing({ transcript }: { transcript: string }) {
@@ -107,7 +107,7 @@ function ListeningRing({ transcript }: { transcript: string }) {
 }
 
 // ---------------------------------------------------------------------------
-// Processing Skeleton — card shape building itself
+// Processing Skeleton - card shape building itself
 // ---------------------------------------------------------------------------
 
 function ProcessingSkeleton() {
@@ -133,7 +133,7 @@ function ProcessingSkeleton() {
 }
 
 // ---------------------------------------------------------------------------
-// Card Preview — the magical reveal
+// Card Preview - the magical reveal
 // ---------------------------------------------------------------------------
 
 function CardPreview({
@@ -151,7 +151,7 @@ function CardPreview({
   const colors = FITZGERALD_COLORS[card.category] ?? FITZGERALD_COLORS.noun;
 
   useEffect(() => {
-    // Staggered reveal — image first, then label, then buttons
+    // Staggered reveal - image first, then label, then buttons
     const t1 = setTimeout(() => setImgVisible(true), 80);
     const t2 = setTimeout(() => setLabelVisible(true), 280);
     const t3 = setTimeout(() => setButtonsVisible(true), 480);
@@ -165,7 +165,7 @@ function CardPreview({
         className="w-44 h-52 rounded-3xl shadow-2xl flex flex-col items-center justify-between py-5 px-3 border-4 relative overflow-hidden animate-card-appear"
         style={{ backgroundColor: colors.bg, borderColor: colors.border }}
       >
-        {/* Category label — top-right chip */}
+        {/* Category label - top-right chip */}
         <div
           className="absolute top-3 right-3 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide opacity-70"
           style={{ backgroundColor: colors.border, color: colors.bg === '#FFEB3B' ? '#000' : '#fff' }}
@@ -342,7 +342,7 @@ export function VoiceCardCreator({ onSaved, showTrigger = true }: VoiceCardCreat
         arasaacId: pictogram?.id ?? null,
         imageUrl: pictogram?.imageUrl ?? null,
         transcript: text,
-        // T2.6 — parent voice-captured = gestalt, always.
+        // T2.6 - parent voice-captured = gestalt, always.
         isGestalt: true,
       };
       setCard(generated);

--- a/src/components/VoiceCardCreator.tsx
+++ b/src/components/VoiceCardCreator.tsx
@@ -46,6 +46,13 @@ interface GeneratedCard {
   arasaacId: number | null;
   imageUrl: string | null;
   transcript: string;
+  /**
+   * GLP T2.6 — parent-captured cards are gestalts by definition (Marge Blanc NLA).
+   * Always `true` for VoiceCardCreator output. Downstream surfaces that render
+   * this card into the sentence bar must propagate this flag onto the chip so
+   * the speak button cascades to mirror mode and skips /api/improve-sentence.
+   */
+  isGestalt: true;
 }
 
 interface VoiceCardCreatorProps {
@@ -335,6 +342,8 @@ export function VoiceCardCreator({ onSaved, showTrigger = true }: VoiceCardCreat
         arasaacId: pictogram?.id ?? null,
         imageUrl: pictogram?.imageUrl ?? null,
         transcript: text,
+        // T2.6 — parent voice-captured = gestalt, always.
+        isGestalt: true,
       };
       setCard(generated);
       setPhase('preview');

--- a/src/lib/sentence-store.ts
+++ b/src/lib/sentence-store.ts
@@ -5,6 +5,8 @@
  * the user manually clears them. Backed by localStorage.
  */
 
+import { isPhraseGestalt } from './vocabulary';
+
 const STORAGE_KEY = '8gentjr_sentence';
 
 export interface SentenceWord {
@@ -14,6 +16,13 @@ export interface SentenceWord {
   className?: string;
   /** Inline styles for chip (category colour) */
   style?: React.CSSProperties;
+  /**
+   * GLP T2.6 — gestalt flag. `true` means this chip is a whole-language script
+   * (parent-captured via VoiceCardCreator, or a multi-word phrase from vocab).
+   * Any sentence containing a gestalt chip forces mirror mode regardless of
+   * glpStage and skips /api/improve-sentence. Undefined is treated as `false`.
+   */
+  isGestalt?: boolean;
 }
 
 type Listener = () => void;
@@ -53,7 +62,13 @@ export const sentenceStore = {
   },
 
   addWord(word: SentenceWord) {
-    _words = [..._words, word];
+    // Auto-flag gestalts if caller didn't set isGestalt explicitly.
+    // Multi-word phrases (3+ tokens) are gestalts by Marge Blanc NLA.
+    const flagged: SentenceWord =
+      word.isGestalt === undefined
+        ? { ...word, isGestalt: isPhraseGestalt(word.label) }
+        : word;
+    _words = [..._words, flagged];
     persist();
     notify();
   },

--- a/src/lib/sentence-store.ts
+++ b/src/lib/sentence-store.ts
@@ -1,5 +1,5 @@
 /**
- * Persistent Sentence Store — shared across all AAC surfaces.
+ * Persistent Sentence Store - shared across all AAC surfaces.
  *
  * Words added in Core grid or Browse categories persist until
  * the user manually clears them. Backed by localStorage.
@@ -17,7 +17,7 @@ export interface SentenceWord {
   /** Inline styles for chip (category colour) */
   style?: React.CSSProperties;
   /**
-   * GLP T2.6 — gestalt flag. `true` means this chip is a whole-language script
+   * GLP T2.6 - gestalt flag. `true` means this chip is a whole-language script
    * (parent-captured via VoiceCardCreator, or a multi-word phrase from vocab).
    * Any sentence containing a gestalt chip forces mirror mode regardless of
    * glpStage and skips /api/improve-sentence. Undefined is treated as `false`.

--- a/src/lib/vocabulary.ts
+++ b/src/lib/vocabulary.ts
@@ -37,6 +37,15 @@ export interface AACPhrase {
   spokenText?: string; // Optional different text to speak
   imageUrl: string;
   categoryId: string;
+  /**
+   * GLP gestalt flag. When `true`, this entry represents a whole-language
+   * script (Marge Blanc NLA Stage 1-2 gestalt) and the sentence containing it
+   * must NOT be sent to /api/improve-sentence. Defaults to `false` (analytic).
+   *
+   * Auto-set to `true` for phrases of 3+ words OR captured via VoiceCardCreator
+   * (parent-recorded phrases are gestalts by definition).
+   */
+  isGestalt?: boolean;
 }
 
 /** Communication functions a word can serve */
@@ -597,4 +606,17 @@ export function getCoreWordsForGLPStage(stage: number): CoreWord[] {
 /** Total word count across both systems */
 export function getTotalWordCount(): number {
   return ALL_CORE_WORDS.length + getAllPhrases().length + SOUNDS_PHRASES.length;
+}
+
+/**
+ * GLP T2.6 — heuristic: phrases of 3+ tokens are treated as gestalts (whole-language
+ * scripts) per Marge Blanc NLA. Single words and 2-word combos stay analytic.
+ *
+ * Tokenisation is whitespace-split after trimming punctuation that the kid wouldn't
+ * naturally separate (apostrophes preserved so "don't" stays one token).
+ */
+export function isPhraseGestalt(text: string): boolean {
+  if (!text) return false;
+  const tokens = text.trim().split(/\s+/).filter(Boolean);
+  return tokens.length >= 3;
 }

--- a/src/lib/vocabulary.ts
+++ b/src/lib/vocabulary.ts
@@ -5,9 +5,9 @@
  * Fitzgerald Key color categories and GLP (Gestalt Language Processing) principles.
  *
  * Two systems combined:
- * 1. Robust Core Vocabulary — ~100 high-frequency core words (pronouns, verbs,
+ * 1. Robust Core Vocabulary - ~100 high-frequency core words (pronouns, verbs,
  *    adjectives, etc.) that cover 80% of daily communication
- * 2. Topic Vocabulary — 200+ fringe words organized by category (food, places, etc.)
+ * 2. Topic Vocabulary - 200+ fringe words organized by category (food, places, etc.)
  *
  * Total: 500+ words with ARASAAC symbol URLs, category metadata, and phrase data.
  */
@@ -115,7 +115,7 @@ export const TOPIC_FITZGERALD_COLORS = {
 } as const;
 
 // =============================================================================
-// CORE VOCABULARY — Essential Words (~100 high-frequency words)
+// CORE VOCABULARY - Essential Words (~100 high-frequency words)
 // =============================================================================
 
 export const CORE_PRONOUNS: CoreWord[] = [
@@ -253,7 +253,7 @@ export const ALL_CORE_WORDS: CoreWord[] = [
 ];
 
 // =============================================================================
-// TOPIC VOCABULARY — Fringe words organized by category (400+ words)
+// TOPIC VOCABULARY - Fringe words organized by category (400+ words)
 // =============================================================================
 
 export const AAC_CATEGORIES: AACCategory[] = [
@@ -503,7 +503,7 @@ export const HOME_PHRASES: AACPhrase[] = [
 ];
 
 // =============================================================================
-// GLP Stage 1 — Sounds (earliest communicators)
+// GLP Stage 1 - Sounds (earliest communicators)
 // =============================================================================
 
 export const GLP_STAGE1_SOUNDS_CATEGORY: AACCategory = {
@@ -609,7 +609,7 @@ export function getTotalWordCount(): number {
 }
 
 /**
- * GLP T2.6 — heuristic: phrases of 3+ tokens are treated as gestalts (whole-language
+ * GLP T2.6 - heuristic: phrases of 3+ tokens are treated as gestalts (whole-language
  * scripts) per Marge Blanc NLA. Single words and 2-word combos stay analytic.
  *
  * Tokenisation is whitespace-split after trimming punctuation that the kid wouldn't


### PR DESCRIPTION
## Summary
- Adds `isGestalt: boolean` to `AACPhrase` and `SentenceWord` so multi-word phrases and parent-captured cards are distinguishable from analytic single-word cards.
- Any sentence containing a gestalt chip forces mirror mode at any glpStage. `/api/improve-sentence` is skipped, the speak button uses the existing onMirror plumbing from T1.
- Auto-detects gestalts at `sentenceStore.addWord` time using a 3+ token rule (Marge Blanc NLA). Explicit caller-provided values override.
- VoiceCardCreator stamps `isGestalt: true` on every saved card record.
- Visual: subtle quote glyph (8220) in a small dark badge on the top-right corner of gestalt chips. No colour change, no card movement, no banned hues.

## Architecture notes
- T1 `mirrorMode` logic preserved as `stageMirrorMode`. Final `mirrorMode = stageMirrorMode || gestaltMode`. Kill switch (`8gentjr-glp-disable=true`) overrides both.
- No backwards-compat shims. Existing stored vocab without the field is treated as `false` (default analytic). Migration deferred.
- 75 lines added across the 5 files listed in the issue. No new files, no foreign code.
- Locked Supercore 50 grid is untouched (atomic words by design per AAC rules).

## Test plan
- [ ] Tap "I want to eat" from FOOD category. Sentence bar shows the chip with a small quote badge top-right. ✨ swaps to 🪞.
- [ ] Tap the magic/mirror button. Confirm `/api/improve-sentence` is NOT called (network tab). The sentence is spoken verbatim.
- [ ] Tap single-word "want" from Supercore. No badge. ✨ button visible at stage 3+.
- [ ] Set `glpStage` 1 or 2. Mirror mode active regardless of gestalt presence (T1 behaviour intact).
- [ ] Set `localStorage.8gentjr-glp-disable=true`. ✨ visible even with gestalt in sentence (kill switch wins).
- [ ] Use parent VoiceCardCreator → speak "It's a beautiful day". Saved record in `8gentjr_custom_cards` has `isGestalt: true`.
- [ ] No purple/pink/violet hues introduced (badge is gray-900).

Closes #140