### PR TITLE
feat(glp): T2.5 personal vocab promotion (Your Words row) (#139)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -219,6 +219,40 @@ export default function SettingsPage() {
           <SmartSuggestionsToggle accent={accent} />
         </Section>
 
+        {/* ── Your Words row (GLP T2.5 personal vocab promotion) ── */}
+        <Section title="Your Words row" icon={<IconStar />}>
+          <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
+            Pin the child&apos;s most-tapped words at the top of Talk. Hidden
+            automatically until a word has been tapped 5+ times in the last 7 days.
+          </p>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.showPersonalVocab !== false}
+            onClick={() => updateSettings({ showPersonalVocab: !(settings.showPersonalVocab !== false) })}
+            className="w-full flex items-center justify-between px-4 py-3 rounded-xl border-2 transition-colors active:scale-[0.98]"
+            style={{
+              borderColor: settings.showPersonalVocab !== false ? accent : 'var(--warm-border, #E8E0D6)',
+              backgroundColor: settings.showPersonalVocab !== false ? `${accent}12` : 'white',
+            }}
+          >
+            <span className="font-semibold" style={{ color: 'var(--warm-text, #1A1614)' }}>
+              {settings.showPersonalVocab !== false ? 'Showing Your Words' : 'Hidden'}
+            </span>
+            <span
+              className="relative inline-block w-11 h-6 rounded-full transition-colors"
+              style={{ backgroundColor: settings.showPersonalVocab !== false ? accent : '#CBC5BC' }}
+            >
+              <span
+                className="absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform"
+                style={{
+                  transform: settings.showPersonalVocab !== false ? 'translateX(20px)' : 'translateX(0)',
+                }}
+              />
+            </span>
+          </button>
+        </Section>
+
         {/* ── Privacy & Consent ── */}
         <Section title="Privacy & Consent" icon={<IconShield />}>
           <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
@@ -324,6 +358,14 @@ function IconSpark() {
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M12 3l1.9 5.6L19.5 10l-5.6 1.9L12 17l-1.9-5.1L4.5 10l5.6-1.4z" />
       <path d="M19 16l.7 2 2 .7-2 .7-.7 2-.7-2-2-.7 2-.7z" />
+    </svg>
+  );
+}
+
+function IconStar() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polygon points="12 2 15.1 8.6 22 9.3 16.7 14 18.2 21 12 17.3 5.8 21 7.3 14 2 9.3 8.9 8.6 12 2" />
     </svg>
   );
 }

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -24,15 +24,17 @@
  * - Red:     Negation (no, don't, stop)
  */
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { FITZGERALD_COLORS, type WordCategory } from '@/lib/fitzgerald-key';
 import { logWord } from '@/lib/session-logger';
 import { speak as elevenLabsSpeak, preloadAudio } from '@/lib/tts';
 import { SharedSentenceBar } from '@/components/SharedSentenceBar';
 import { SuggestedRow } from '@/components/SuggestedRow';
 import { TapCard } from '@/components/TapCard';
+import { YourWordsRow, type YourWordsCard } from '@/components/YourWordsRow';
 import { useSentence } from '@/hooks/useSentence';
 import { useApp } from '@/context/AppContext';
+import { getPersonalVocab } from '@/lib/personal-vocab';
 
 // =============================================================================
 // Fitzgerald Key Color Definitions (mapped from shared vocabulary system)
@@ -251,9 +253,19 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   const { words: sentence, addWord, removeWord, clear } = useSentence();
   const { settings } = useApp();
   const childName = settings.childName?.trim() || '';
+  const showPersonalVocab = settings.showPersonalVocab !== false;
   const [cols, setCols] = useState(10);
   const [isMagicLoading, setIsMagicLoading] = useState(false);
   const [engineFallback, setEngineFallback] = useState(false);
+  const [yourWords, setYourWords] = useState<YourWordsCard[]>([]);
+
+  // Lowercase label -> Supercore entry, for hydrating Your Words cards with
+  // pictograms when the tapped word lives on the locked grid. Built once.
+  const supercoreByLabel = useMemo(() => {
+    const map = new Map<string, CoreWord>();
+    for (const w of SUPERCORE_50) map.set(w.label.toLowerCase(), w);
+    return map;
+  }, []);
 
   // Kill-switch read once at mount. localStorage 8gentjr-glp-disable=true
   // hides the Suggested row and forces the magic button on regardless of stage.
@@ -287,6 +299,26 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   useEffect(() => {
     preloadAudio(SUPERCORE_50.map(w => w.label));
   }, []);
+
+  // Recompute Your Words on mount and after every sentence-strip change
+  // (each tap appends a word, which may push something past the threshold).
+  // Skipped entirely when the parent has hidden the row.
+  useEffect(() => {
+    if (!showPersonalVocab) {
+      setYourWords([]);
+      return;
+    }
+    const entries = getPersonalVocab();
+    const cards: YourWordsCard[] = entries.map(({ word, count }) => {
+      const match = supercoreByLabel.get(word);
+      return {
+        word,
+        count,
+        imageUrl: match?.arasaacId ? ARASAAC_IMG(match.arasaacId) : undefined,
+      };
+    });
+    setYourWords(cards);
+  }, [showPersonalVocab, sentence.length, supercoreByLabel]);
 
   const speakText = useCallback(async (text: string) => {
     if (onSpeak) { onSpeak(text); return; }
@@ -347,6 +379,23 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
     });
     logWord(label);
   }, [speakText, addWord]);
+
+  const handleYourWordsTap = useCallback((word: string, imageUrl?: string) => {
+    speakText(word);
+    // If the word lives on the locked grid, reuse its Fitzgerald chip so the
+    // sentence strip stays consistent with grid taps. Otherwise fall back to
+    // the amber chip (matches the Your Words row's visual signature).
+    const match = supercoreByLabel.get(word);
+    const className = match
+      ? `${FITZGERALD_CLASSES[match.category].bg} ${FITZGERALD_CLASSES[match.category].text} ${FITZGERALD_CLASSES[match.category].border}`
+      : 'bg-amber-200 text-amber-950 border-amber-500';
+    addWord({
+      label: match ? match.label : word,
+      imageUrl,
+      className,
+    });
+    logWord(word);
+  }, [speakText, addWord, supercoreByLabel]);
 
   const handleSuggestedTap = useCallback((text: string) => {
     speakText(text);
@@ -417,6 +466,14 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
 
       {/* Scrollable grid area */}
       <div className="flex-1 min-h-0 overflow-y-auto">
+
+        {/* Your Words: frequency-sorted personal vocab pinned at the very top.
+            Sits above SuggestedRow + intro + locked grid. Hidden entirely
+            when the threshold yields zero qualifying words (handled inside
+            YourWordsRow via empty cards). */}
+        {showPersonalVocab && (
+          <YourWordsRow cards={yourWords} cols={cols} onTap={handleYourWordsTap} />
+        )}
 
         {/* Adaptive Suggested row sits above intro + locked grid */}
         {!glpDisabled && (

--- a/src/components/YourWordsRow.tsx
+++ b/src/components/YourWordsRow.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+/**
+ * YourWordsRow: GLP Tier 2.5 personal vocab promotion.
+ *
+ * Surfaces the child's most-tapped words (frequency-sorted) above the
+ * Suggested row and the locked Supercore grid. Cards CAN reorder by
+ * frequency between sessions; this is a separate motor zone from the
+ * locked grid below.
+ *
+ * Visual signature is distinct from both neighbours:
+ *   - Suggested row: dashed amber-400 border on amber-50 (changes-allowed)
+ *   - Locked grid:   solid Fitzgerald category colors (never moves)
+ *   - Your Words:    solid amber-200 fill + amber-500 border + favorite star
+ *
+ * Empty input hides the row entirely (no header, no container).
+ *
+ * Issue: #139
+ */
+
+import React, { useCallback } from 'react';
+import { TapCard } from '@/components/TapCard';
+
+export interface YourWordsCard {
+  /** Lowercase word as logged. */
+  word: string;
+  /** Tap count in the recency window (debug + future analytics; not rendered). */
+  count: number;
+  /** Optional ARASAAC pictogram URL when the word maps to a Supercore entry. */
+  imageUrl?: string;
+}
+
+export interface YourWordsRowProps {
+  cards: YourWordsCard[];
+  cols: number;
+  /** Called with the word text when a card is tapped. */
+  onTap: (word: string, imageUrl?: string) => void;
+}
+
+const ROW_MAX = 6;
+
+const YourWordsCardButton = React.memo(function YourWordsCardButton({
+  card,
+  onTap,
+}: {
+  card: YourWordsCard;
+  onTap: (word: string, imageUrl?: string) => void;
+}) {
+  const handleTap = useCallback(() => onTap(card.word, card.imageUrl), [onTap, card.word, card.imageUrl]);
+  return (
+    <TapCard
+      onTap={handleTap}
+      ariaLabel={`${card.word}, your favourite word`}
+      className="relative flex flex-col items-center justify-center rounded-xl border-[3px] border-amber-500 bg-amber-200 text-amber-950 py-1.5 px-0.5 text-center leading-tight"
+      style={{ minHeight: 80 }}
+    >
+      {/* Favourite star indicator - top-right corner */}
+      <span
+        aria-hidden="true"
+        className="absolute top-1 right-1 text-[14px] leading-none text-amber-700"
+        title="Favourite"
+      >
+        {'\u2605'}
+      </span>
+      {card.imageUrl && (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          src={card.imageUrl}
+          alt={card.word}
+          width={52}
+          height={52}
+          className="w-[52px] h-[52px] object-contain pointer-events-none"
+          loading="lazy"
+        />
+      )}
+      <span className="font-bold text-[14px] leading-none mt-0.5 w-full line-clamp-2 px-0.5">
+        {card.word}
+      </span>
+    </TapCard>
+  );
+});
+
+export function YourWordsRow({ cards, cols, onTap }: YourWordsRowProps) {
+  if (cards.length === 0) return null;
+
+  // Cap columns so cards stay readable on the 10-col desktop grid.
+  const rowCols = Math.min(cols, ROW_MAX);
+
+  return (
+    <div className="px-1.5 pt-2 pb-1">
+      <p className="text-[10px] font-semibold text-amber-800/90 uppercase tracking-wider mb-1.5 px-0.5">
+        Your Words
+      </p>
+      <div
+        className="grid gap-1"
+        style={{ gridTemplateColumns: `repeat(${rowCols}, 1fr)` }}
+      >
+        {cards.map((c) => (
+          <YourWordsCardButton key={c.word} card={c} onTap={onTap} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default YourWordsRow;

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -39,6 +39,12 @@ export interface AppSettings {
   smartSuggestionsEnabled: boolean;
   /** True once the model weights are cached in the browser (Cache API). */
   smollmDownloaded: boolean;
+  /**
+   * GLP Tier 2.5 - "Your Words" pinned row at the top of /talk Core.
+   * On by default. Hides the row when the child has no qualifying words yet,
+   * regardless of this flag.
+   */
+  showPersonalVocab: boolean;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -59,6 +65,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   gatedAt: null,
   smartSuggestionsEnabled: false,
   smollmDownloaded: false,
+  showPersonalVocab: true,
 };
 
 const STORAGE_KEY = '8gentjr-app-settings';

--- a/src/lib/personal-vocab.ts
+++ b/src/lib/personal-vocab.ts
@@ -1,0 +1,77 @@
+/**
+ * Personal Vocab - frequency-sorted "Your Words" promotion (GLP Tier 2.5).
+ *
+ * Wraps session-logger to surface the child's most-tapped words from the
+ * last 7 days. Cards above this row CAN move (motor-planning lives in the
+ * locked Supercore grid below). Empty result hides the row entirely.
+ *
+ * Issue: #139
+ */
+
+import { getAllEvents } from '@/lib/session-logger';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** A word qualifies once it has been tapped this many times in the window. */
+export const PERSONAL_VOCAB_MIN_TAPS = 5;
+
+/** Recency window applied to the event log. */
+export const PERSONAL_VOCAB_WINDOW_DAYS = 7;
+
+/** Maximum cards shown in the Your Words row. */
+export const PERSONAL_VOCAB_MAX_CARDS = 6;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PersonalVocabEntry {
+  /** Lowercase word as stored by logWord(). */
+  word: string;
+  /** Tap count inside the recency window. */
+  count: number;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the child's qualifying words.
+ *
+ * - Filters events to the recency window
+ * - Counts by lowercase word
+ * - Drops anything below the tap threshold
+ * - Returns top N sorted by count desc, ties broken alphabetically for stability
+ *
+ * Safe to call during SSR. Returns [] if the event log is unavailable.
+ */
+export function getPersonalVocab(now: number = Date.now()): PersonalVocabEntry[] {
+  const cutoff = now - PERSONAL_VOCAB_WINDOW_DAYS * 86_400_000;
+  const events = getAllEvents();
+
+  const freq = new Map<string, number>();
+  for (const e of events) {
+    if (e.type !== 'word_used') continue;
+    if (e.timestamp < cutoff) continue;
+    const word = typeof e.data.word === 'string' ? e.data.word : '';
+    if (!word) continue;
+    freq.set(word, (freq.get(word) ?? 0) + 1);
+  }
+
+  const qualifying: PersonalVocabEntry[] = [];
+  for (const [word, count] of freq.entries()) {
+    if (count >= PERSONAL_VOCAB_MIN_TAPS) {
+      qualifying.push({ word, count });
+    }
+  }
+
+  qualifying.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.word.localeCompare(b.word);
+  });
+
+  return qualifying.slice(0, PERSONAL_VOCAB_MAX_CARDS);
+}

--- a/src/lib/session-logger.ts
+++ b/src/lib/session-logger.ts
@@ -108,6 +108,16 @@ export function clearOldLogs(daysToKeep = 30): void {
   saveEvents(events);
 }
 
+/**
+ * Read all stored events plus any unflushed pending ones.
+ *
+ * Exposed so callers (e.g. personal-vocab) can apply their own time-window
+ * and threshold logic without reimplementing the localStorage read.
+ */
+export function getAllEvents(): SessionEvent[] {
+  return [...getEvents(), ..._pending];
+}
+
 /** Compute aggregate stats from stored events (includes unflushed pending) */
 export function getSessionStats(): SessionStats {
   const events = [...getEvents(), ..._pending];


### PR DESCRIPTION
## Summary

GLP Tier 2.5 implementation. Surfaces the child's most-tapped words in a frequency-sorted row at the top of /talk Core, above the T1 Suggested row and the locked Supercore 50 grid.

Rendering stack (top to bottom):
1. **Your Words row** (this PR) - frequency-sorted, CAN reorder
2. Personalised intro row (existing, only when `childName` is set)
3. Suggested row (T1) - stage-aware, dashed amber border
4. Locked Supercore 50 grid - NEVER moves

## Mechanics

- `src/lib/personal-vocab.ts` wraps `session-logger`. Window: last 7 days. Threshold: >=5 taps. Top 6 by count desc, alphabetical tiebreak for stable ordering.
- `src/lib/session-logger.ts` exposes a new `getAllEvents()` helper so personal-vocab does not duplicate the localStorage parse.
- Recompute fires on mount and on every `sentence.length` change, so a tap that pushes a word past the threshold surfaces within the same session.
- Empty result hides the row entirely (no header, no container).

## Visual signature

Distinct from both neighbours so children can read the layout:
- Suggested row: dashed amber-400 border on amber-50
- **Your Words: solid amber-200 fill + amber-500 border + favourite star (top-right)**
- Locked grid: solid Fitzgerald category colours

No purple/pink/violet hues introduced.

## Settings

- New `showPersonalVocab: boolean` on `AppContext`, default `true`.
- Toggle lives in /settings under "Your Words row" with copy explaining the threshold.
- Toggle off renders nothing, regardless of tap counts.

## Tap behaviour

Same as locked grid: speak + add to sentence + log. Sentence-strip chip reuses the Fitzgerald colour when the word lives on the locked grid (e.g. `snack` is not core, `eat` is). Words promoted from elsewhere fall back to the amber chip.

## Files

- `src/components/YourWordsRow.tsx` (new, 106 lines)
- `src/lib/personal-vocab.ts` (new, 77 lines)
- `src/context/AppContext.tsx` - new field + default
- `src/components/SupercoreGrid.tsx` - render row, lookup + tap handler
- `src/app/settings/page.tsx` - toggle UI
- `src/lib/session-logger.ts` - new `getAllEvents()` export

300 lines added, 1 removed.

## Test plan

- [ ] Seed `localStorage["8gentjr_session_events"]` with synthetic events: 6 taps of `snack`, 5 taps of `juice`, 4 taps of `book` (should NOT qualify), all within last 7 days
- [ ] Open /talk - confirm Your Words row appears at the top with `snack` then `juice`, no `book`
- [ ] Confirm cards have solid amber-200 background + amber-500 border + star indicator
- [ ] Tap `snack` - confirms speech, sentence strip update, log event
- [ ] Open /settings, toggle Your Words row off - row disappears immediately on /talk
- [ ] Toggle back on - row reappears
- [ ] With empty event log: confirm no row renders, no empty container
- [ ] Confirm locked Supercore grid order is unchanged
- [ ] Confirm Suggested row (T1) and intro row still render in correct stack position
- [ ] `bunx tsc --noEmit` passes (verified locally)

Closes #139