### PR TITLE
feat(glp): T2.4 predictive next-word strip (#138)

### DIFF
--- a/src/components/PredictiveStrip.tsx
+++ b/src/components/PredictiveStrip.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+/**
+ * PredictiveStrip: GLP Tier 2.4 next-word prediction.
+ *
+ * Four cards directly above the locked Supercore grid that recompute on
+ * every sentence tap. Source is today's bigrams unioned with the stage
+ * word bank - see `src/lib/predictive.ts`.
+ *
+ * Visual signature is intentionally distinct from neighbours:
+ *   - Predictive (this row): solid sky-100 fill + sky-300 border ("what's next")
+ *   - Suggested row:         dashed amber-400 border on amber-50
+ *   - Your Words row:        solid amber-200 fill + amber-500 border + star
+ *   - Locked grid below:     Fitzgerald category colors
+ *
+ * Cards in this row CAN move - prediction adapts. Motor planning lives
+ * in the locked grid below.
+ *
+ * Issue: #138
+ */
+
+import React, { useCallback } from 'react';
+import { TapCard } from '@/components/TapCard';
+import type { PredictiveCandidate } from '@/lib/predictive';
+
+export interface PredictiveStripProps {
+  cards: PredictiveCandidate[];
+  cols: number;
+  /** Called with the candidate text when a card is tapped. */
+  onTap: (text: string) => void;
+}
+
+const PredictiveCard = React.memo(function PredictiveCard({
+  text,
+  onTap,
+}: {
+  text: string;
+  onTap: (text: string) => void;
+}) {
+  const handleTap = useCallback(() => onTap(text), [onTap, text]);
+  return (
+    <TapCard
+      onTap={handleTap}
+      ariaLabel={`Next word suggestion: ${text}`}
+      className="flex items-center justify-center rounded-xl border-2 border-sky-300 bg-sky-100 text-sky-900 px-2 py-2 text-center leading-tight"
+      style={{ minHeight: 56 }}
+    >
+      <span className="font-bold text-[13px] leading-tight w-full line-clamp-2">{text}</span>
+    </TapCard>
+  );
+});
+
+export function PredictiveStrip({ cards, cols, onTap }: PredictiveStripProps) {
+  if (cards.length === 0) return null;
+
+  // Always 4 cards in the row - cap columns so they stay readable on the
+  // 10-col desktop grid without stretching to full width.
+  const rowCols = Math.min(cols, cards.length);
+
+  return (
+    <div className="px-1.5 pt-2 pb-1">
+      <p className="text-[10px] font-semibold text-sky-700/80 uppercase tracking-wider mb-1.5 px-0.5">
+        What's next
+      </p>
+      <div
+        className="grid gap-1"
+        style={{ gridTemplateColumns: `repeat(${rowCols}, 1fr)` }}
+      >
+        {cards.map((c, i) => (
+          <PredictiveCard key={`${c.text}-${i}`} text={c.text} onTap={onTap} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default PredictiveStrip;

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -30,11 +30,13 @@ import { logWord } from '@/lib/session-logger';
 import { speak as elevenLabsSpeak, preloadAudio } from '@/lib/tts';
 import { SharedSentenceBar } from '@/components/SharedSentenceBar';
 import { SuggestedRow } from '@/components/SuggestedRow';
+import { PredictiveStrip } from '@/components/PredictiveStrip';
 import { TapCard } from '@/components/TapCard';
 import { YourWordsRow, type YourWordsCard } from '@/components/YourWordsRow';
 import { useSentence } from '@/hooks/useSentence';
 import { useApp } from '@/context/AppContext';
 import { getPersonalVocab } from '@/lib/personal-vocab';
+import { predictNext, PREDICTIVE_CARD_COUNT } from '@/lib/predictive';
 
 // =============================================================================
 // Fitzgerald Key Color Definitions (mapped from shared vocabulary system)
@@ -407,6 +409,38 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
     logWord(text);
   }, [speakText, addWord]);
 
+  // T2.4 - predictive next-word strip. Recomputes on every sentence change
+  // (sentence.length covers add/remove/clear; lastWord covers identity).
+  // The bigram read inside predictNext is O(events-today) and runs <50ms
+  // for realistic logs; keeping it inside useMemo means it never blocks
+  // the tap path itself.
+  const lastWord = sentence.length > 0 ? sentence[sentence.length - 1].label : null;
+  const predictiveCards = useMemo(() => {
+    if (glpDisabled) return [];
+    return predictNext(lastWord, stage, PREDICTIVE_CARD_COUNT);
+    // sentence.length is intentional - bigrams are derived from the event
+    // log which appends on every tap, so we want the memo to recompute on
+    // any sentence change, not just last-word identity changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [glpDisabled, stage, lastWord, sentence.length]);
+
+  const handlePredictiveTap = useCallback((text: string) => {
+    speakText(text);
+    // Predictive chips reuse the locked-grid look when the candidate maps
+    // to a Supercore word, so the sentence strip stays consistent. Otherwise
+    // fall back to a sky chip (matches the strip's visual signature).
+    const match = supercoreByLabel.get(text.toLowerCase());
+    const className = match
+      ? `${FITZGERALD_CLASSES[match.category].bg} ${FITZGERALD_CLASSES[match.category].text} ${FITZGERALD_CLASSES[match.category].border}`
+      : 'bg-sky-100 text-sky-900 border-sky-300';
+    addWord({
+      label: match ? match.label : text,
+      imageUrl: match?.arasaacId ? ARASAAC_IMG(match.arasaacId) : undefined,
+      className,
+    });
+    logWord(text);
+  }, [speakText, addWord, supercoreByLabel]);
+
   const handleMirrorSpeak = useCallback(() => {
     if (sentence.length === 0) return;
     speakText(sentence.map(w => w.label).join(' '));
@@ -466,6 +500,13 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
 
       {/* Scrollable grid area */}
       <div className="flex-1 min-h-0 overflow-y-auto">
+
+        {/* T2.4 Predictive next-word strip - 4 cards, recomputes on every
+            tap. Sits above Your Words (frequency) + Suggested (stage) +
+            locked grid. Hidden by the GLP kill switch. */}
+        {!glpDisabled && (
+          <PredictiveStrip cards={predictiveCards} cols={cols} onTap={handlePredictiveTap} />
+        )}
 
         {/* Your Words: frequency-sorted personal vocab pinned at the very top.
             Sits above SuggestedRow + intro + locked grid. Hidden entirely

--- a/src/lib/predictive.ts
+++ b/src/lib/predictive.ts
@@ -1,0 +1,177 @@
+/**
+ * Predictive next-word ranking - GLP Tier 2.4.
+ *
+ * Reads today's `word_used` events from session-logger, walks consecutive
+ * pairs to build a `(prev -> next -> count)` bigram map, then ranks
+ * candidates that follow the last tapped word. Falls back to the GLP
+ * stage word bank when bigram coverage is thin (cold start, brand new
+ * combinations, or recency window empty).
+ *
+ * Design notes:
+ * - "Today" only for v1. Cross-session bigrams add complexity without a
+ *   measured win at this stage.
+ * - No LLM. Deterministic, local, sub-50ms - the strip recomputes on
+ *   every sentence change and is never on the hot path of a tap.
+ * - Empty `lastWord` (empty sentence) seeds straight from the stage bank.
+ *
+ * Issue: #138
+ */
+'use client';
+
+import { getAllEvents, type SessionEvent } from '@/lib/session-logger';
+import { suggestByStage } from '@/lib/suggestions';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Strip width - 4 cards above the sentence bar. */
+export const PREDICTIVE_CARD_COUNT = 4;
+
+/** Bigram window. v1 is today only (resets at local midnight). */
+export const PREDICTIVE_WINDOW_MS = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** prev word -> next word -> tap count (today). */
+export type BigramMap = Map<string, Map<string, number>>;
+
+export interface PredictiveCandidate {
+  /** The word/phrase to display. Lowercase for bigram-derived entries. */
+  text: string;
+  /** Source of the suggestion - useful for analytics and debugging. */
+  source: 'bigram' | 'stage';
+  /** Bigram count when source === 'bigram', else 0. */
+  count: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Local midnight (today's start) in ms. */
+function todayStartMs(now: number): number {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/** Normalise a label to the same shape `logWord` writes (lowercase + trim). */
+function normalise(word: string): string {
+  return word.toLowerCase().trim();
+}
+
+// ---------------------------------------------------------------------------
+// Bigram extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build today's bigram counts from the session log.
+ *
+ * Walks `word_used` events in chronological order; each consecutive pair
+ * (prev, next) inside today's window contributes one count. Events outside
+ * the window are skipped, and the chain breaks across the boundary so an
+ * old word never seeds a new prefix.
+ */
+export function getTodaysBigrams(now: number = Date.now()): BigramMap {
+  const cutoff = todayStartMs(now);
+  const events: SessionEvent[] = getAllEvents();
+
+  const bigrams: BigramMap = new Map();
+  let prev: string | null = null;
+
+  for (const e of events) {
+    if (e.type !== 'word_used') continue;
+    if (e.timestamp < cutoff) {
+      // Older event - skip and reset the chain so we don't bridge yesterday
+      // to today on the next event.
+      prev = null;
+      continue;
+    }
+    const word = typeof e.data.word === 'string' ? normalise(e.data.word) : '';
+    if (!word) {
+      prev = null;
+      continue;
+    }
+    if (prev) {
+      let inner = bigrams.get(prev);
+      if (!inner) {
+        inner = new Map();
+        bigrams.set(prev, inner);
+      }
+      inner.set(word, (inner.get(word) ?? 0) + 1);
+    }
+    prev = word;
+  }
+
+  return bigrams;
+}
+
+// ---------------------------------------------------------------------------
+// Ranking
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick up to `count` next-word candidates following `lastWord`.
+ *
+ * Algorithm:
+ *   1. Empty `lastWord` -> first N stage bank entries (cold start).
+ *   2. Bigrams that follow `lastWord`, sorted by count desc (ties broken
+ *      alphabetically for stable rendering).
+ *   3. Top up from `suggestByStage(glpStage)` excluding already-picked
+ *      and excluding `lastWord` itself.
+ *   4. If still short (eg. unknown stage), keep raw stage suggestions.
+ *
+ * Pure - no DOM, no React state. Caller memoises against the sentence so
+ * we only recompute on tap.
+ */
+export function predictNext(
+  lastWord: string | null,
+  glpStage: number,
+  count: number = PREDICTIVE_CARD_COUNT,
+  bigrams?: BigramMap,
+): PredictiveCandidate[] {
+  const stageSuggestions = suggestByStage(glpStage);
+
+  // Cold start - no last word means seed straight from the stage bank.
+  if (!lastWord) {
+    return stageSuggestions
+      .slice(0, count)
+      .map((s) => ({ text: s.text, source: 'stage' as const, count: 0 }));
+  }
+
+  const prev = normalise(lastWord);
+  const map = (bigrams ?? getTodaysBigrams()).get(prev);
+
+  const picked: PredictiveCandidate[] = [];
+  const seen = new Set<string>([prev]);
+
+  if (map && map.size > 0) {
+    const sorted = [...map.entries()].sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      return a[0].localeCompare(b[0]);
+    });
+    for (const [next, c] of sorted) {
+      if (picked.length >= count) break;
+      if (seen.has(next)) continue;
+      picked.push({ text: next, source: 'bigram', count: c });
+      seen.add(next);
+    }
+  }
+
+  // Top up from the stage bank. Match against the lowercased text so we
+  // don't double-pick "I want" both as a bigram chain and a stage entry.
+  if (picked.length < count) {
+    for (const s of stageSuggestions) {
+      if (picked.length >= count) break;
+      const key = normalise(s.text);
+      if (seen.has(key)) continue;
+      picked.push({ text: s.text, source: 'stage', count: 0 });
+      seen.add(key);
+    }
+  }
+
+  return picked;
+}


### PR DESCRIPTION
## Summary

Four-card sky-blue predictive strip directly below the sentence bar that recomputes on every tap. Source = today's bigrams from `session-logger` UNION `suggestByStage(glpStage)`. Cold start (empty sentence, no bigram coverage) seeds straight from the stage bank.

Render order (top to bottom):
1. Sentence bar
2. **Predictive strip (this PR)**
3. Your Words row (T2.5)
4. Personalised intro row
5. Suggested row (T1)
6. Locked Supercore 50 grid

## Files (3, well inside the 5-file budget)

- `src/lib/predictive.ts` (new): `getTodaysBigrams()` + `predictNext()`. Pure, deterministic, sub-50ms on realistic logs. Today-only window; chain breaks across local midnight so yesterday's last word never seeds today's first prefix.
- `src/components/PredictiveStrip.tsx` (new): 4-card row, solid `sky-100` fill + `sky-300` border. Visually distinct from the dashed amber Suggested row and the solid amber-200 + star Your Words row.
- `src/components/SupercoreGrid.tsx`: `useMemo` keyed on `glpDisabled`, `stage`, `lastWord`, `sentence.length`. Tap handler reuses Fitzgerald chip styling when the candidate maps to a Supercore word; falls back to a sky chip otherwise.

## Algorithm

1. Empty sentence -> first 4 from `suggestByStage(stage)`.
2. Build today's bigrams from `getAllEvents()` walking consecutive `word_used` pairs.
3. Pick top 4 candidates following `lastWord` (count desc, alphabetical tie-break for stable rendering).
4. Top up from the stage bank, excluding `lastWord` and any already-picked text.

## Kill-switch

Existing `localStorage 8gentjr-glp-disable=true` hides the Predictive strip alongside the Suggested row. No new toggle.

## Test plan

- [ ] Seed bigram events via Playwright, simulate a tap, assert the strip shows count-sorted predictions for that prefix
- [ ] Empty sentence renders 4 cards from the stage bank for stages 1-6
- [ ] Tapping a predictive card adds the chip to the sentence, speaks it, and logs the word (verifies stage bank top-up still flows through `logWord`)
- [ ] Locked grid stays in fixed positions throughout (motor planning preserved)
- [ ] `localStorage 8gentjr-glp-disable=true` hides Predictive + Suggested rows
- [ ] Recompute latency under 50ms on a populated event log
- [ ] Visual smoke: sky strip distinguishable from amber Suggested and amber-with-star Your Words

Closes #138