### PR TITLE
feat(glp): T3.9 rewrite stages.ts to match Marge Blanc NLA

### DIFF
--- a/src/lib/glp/stages.ts
+++ b/src/lib/glp/stages.ts
@@ -1,18 +1,19 @@
 /**
- * 8gent Jr — Graded Language Proficiency (GLP) Stages
+ * 8gent Jr - Gestalt Language Processing (GLP) Stages
  *
- * Six stages modelled on typical AAC/SLP progression:
- *   1. Single words (requesting, labelling)
- *   2. Two-word combinations (agent + action, action + object)
- *   3. Three-word sentences (subject + verb + object)
- *   4. Simple sentences (4-5 words with grammar)
- *   5. Complex sentences (conjunctions, questions, temporal)
- *   6. Conversation (multi-turn, narrative, social)
+ * Six stages modelled on Marge Blanc's Natural Language Acquisition (NLA)
+ * framework for gestalt language processors:
+ *   1. Echolalia / whole gestalts (scripted chunks repeated as a unit)
+ *   2. Mitigated gestalts (chunks trimmed, mixed, recombined)
+ *   3. Isolated single words breaking out from gestalts
+ *   4. Early original sentences (2-3 word novel combinations)
+ *   5. Complex grammar (questions, conjunctions, articles, prepositions)
+ *   6. Full conversation (multi-turn, narrative, social-pragmatic)
  *
- * Each stage defines the max utterance length, grammar features,
+ * Each stage defines the typical max utterance length, grammar features,
  * and the vocabulary tier the child can access.
  *
- * Issue: #53
+ * Issues: #53, #143
  */
 
 // ---------------------------------------------------------------------------
@@ -20,7 +21,7 @@
 // ---------------------------------------------------------------------------
 
 export interface GLPStage {
-  /** Stage number 1-6 */
+  /** Stage number 1-6 (NLA order) */
   id: number;
   /** Short label */
   name: string;
@@ -37,56 +38,77 @@ export interface GLPStage {
 }
 
 // ---------------------------------------------------------------------------
-// Stage definitions
+// Stage definitions (Marge Blanc NLA)
 // ---------------------------------------------------------------------------
 
 export const GLP_STAGES: GLPStage[] = [
   {
     id: 1,
-    name: 'Single Words',
-    description: 'Requesting and labelling with single words. Focus on high-frequency core vocabulary.',
-    maxWords: 1,
-    grammarFeatures: [],
-    wordCategories: ['noun', 'verb', 'social'],
-    examples: ['more', 'stop', 'help', 'water', 'play', 'yes', 'no'],
+    name: 'Echolalia / Whole Gestalts',
+    description:
+      'Whole scripted chunks repeated as a single unit. The child uses memorised phrases (often from songs, shows, or caregivers) to communicate intent. Treat each gestalt as one indivisible message.',
+    maxWords: 6,
+    grammarFeatures: ['whole-gestalt', 'scripted-chunk'],
+    wordCategories: ['gestalt', 'social'],
+    examples: ["let's go", 'all done', 'time to eat', 'I love you', 'see you later'],
   },
   {
     id: 2,
-    name: 'Two-Word Combinations',
-    description: 'Combining two words: agent+action, action+object, attribute+object.',
-    maxWords: 2,
-    grammarFeatures: ['agent-action', 'action-object'],
-    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective'],
-    examples: ['want more', 'go home', 'big toy', 'I want', 'help me', 'play music'],
+    name: 'Mitigated Gestalts',
+    description:
+      'Gestalts begin to be trimmed, mixed, and recombined. The child swaps parts of one script with parts of another, producing partial scripts that point toward flexibility.',
+    maxWords: 6,
+    grammarFeatures: ['whole-gestalt', 'scripted-chunk', 'gestalt-mix', 'partial-script'],
+    wordCategories: ['gestalt', 'social', 'noun', 'verb'],
+    examples: ["let's eat", 'all done play', 'time to go', 'I love water', 'see you home'],
   },
   {
     id: 3,
-    name: 'Three-Word Sentences',
-    description: 'Subject + verb + object structures. Basic sentence formation.',
-    maxWords: 3,
-    grammarFeatures: ['agent-action', 'action-object', 'subject-verb-object'],
-    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective', 'determiner'],
-    examples: ['I want water', 'she is happy', 'play the game', 'I feel sad'],
+    name: 'Single Words from Gestalts',
+    description:
+      'Isolated single words begin to break free of gestalts. The child labels, requests, and refuses with one word at a time. Focus on high-frequency core vocabulary.',
+    maxWords: 1,
+    grammarFeatures: ['single-word'],
+    wordCategories: ['noun', 'verb', 'social', 'pronoun'],
+    examples: ['more', 'stop', 'help', 'water', 'play', 'yes', 'no'],
   },
   {
     id: 4,
-    name: 'Simple Sentences',
-    description: 'Full simple sentences with articles, prepositions, and basic grammar.',
-    maxWords: 5,
-    grammarFeatures: ['agent-action', 'action-object', 'subject-verb-object', 'prepositions', 'articles'],
-    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective', 'determiner', 'preposition'],
-    examples: ['I want to go home', 'can I have more water', 'I am happy today'],
+    name: 'Early Original Sentences',
+    description:
+      'Novel 2-3 word combinations the child has never heard as a script. Agent + action, action + object, attribute + object, subject + verb + object.',
+    maxWords: 3,
+    grammarFeatures: ['agent-action', 'action-object', 'subject-verb-object'],
+    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective', 'determiner'],
+    examples: ['want more', 'go home', 'big toy', 'I want water', 'play the game', 'I feel sad'],
   },
   {
     id: 5,
-    name: 'Complex Sentences',
-    description: 'Questions, conjunctions, temporal words, and longer expressions.',
+    name: 'Complex Grammar',
+    description:
+      'Questions, conjunctions, articles, prepositions, and longer expressions. The child applies grammatical rules to build flexible original sentences.',
     maxWords: 8,
     grammarFeatures: [
-      'agent-action', 'action-object', 'subject-verb-object',
-      'prepositions', 'articles', 'questions', 'conjunctions', 'temporal',
+      'agent-action',
+      'action-object',
+      'subject-verb-object',
+      'prepositions',
+      'articles',
+      'questions',
+      'conjunctions',
+      'temporal',
     ],
-    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective', 'determiner', 'preposition', 'question', 'adverb'],
+    wordCategories: [
+      'noun',
+      'verb',
+      'social',
+      'pronoun',
+      'adjective',
+      'determiner',
+      'preposition',
+      'question',
+      'adverb',
+    ],
     examples: [
       'what do you want to play',
       'I want to go outside and play',
@@ -95,15 +117,33 @@ export const GLP_STAGES: GLPStage[] = [
   },
   {
     id: 6,
-    name: 'Conversation',
-    description: 'Multi-turn conversation, narrative, social language, and open expression.',
+    name: 'Full Conversation',
+    description:
+      'Multi-turn conversation, narrative, social-pragmatic language, and open expression. The child sustains topics, takes turns, and shares experience.',
     maxWords: 12,
     grammarFeatures: [
-      'agent-action', 'action-object', 'subject-verb-object',
-      'prepositions', 'articles', 'questions', 'conjunctions', 'temporal',
-      'narrative', 'social-pragmatic',
+      'agent-action',
+      'action-object',
+      'subject-verb-object',
+      'prepositions',
+      'articles',
+      'questions',
+      'conjunctions',
+      'temporal',
+      'narrative',
+      'social-pragmatic',
     ],
-    wordCategories: ['noun', 'verb', 'social', 'pronoun', 'adjective', 'determiner', 'preposition', 'question', 'adverb'],
+    wordCategories: [
+      'noun',
+      'verb',
+      'social',
+      'pronoun',
+      'adjective',
+      'determiner',
+      'preposition',
+      'question',
+      'adverb',
+    ],
     examples: [
       'hello, I am happy today because we played outside',
       'can you help me with the big book please',
@@ -116,7 +156,7 @@ export const GLP_STAGES: GLPStage[] = [
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Get a stage by ID (1-6). Returns stage 3 as safe default. */
+/** Get a stage by ID (1-6). Returns stage 3 (single-word emergence) as safe default. */
 export function getStage(id: number): GLPStage {
   return GLP_STAGES.find((s) => s.id === id) ?? GLP_STAGES[2];
 }

--- a/src/lib/vocabulary.ts
+++ b/src/lib/vocabulary.ts
@@ -599,6 +599,12 @@ export function getCoreWordsForFunction(fn: CommunicationFunction): CoreWord[] {
 }
 
 /** Get core words for a GLP stage (includes all lower stages) */
+// TODO(T3.9-followup): glpStage values on entries above were authored under the
+// old analytic-developmental model (1=single word, 2=two-word combo, ...). After
+// T3.9 the stage IDs follow Marge Blanc NLA order (1=echolalia gestalts,
+// 2=mitigated gestalts, 3=single words, 4=early sentences, 5=complex grammar,
+// 6=conversation). The numeric filter below is therefore slightly mis-scaled.
+// Re-grade the 600+ vocabulary entries in a dedicated PR.
 export function getCoreWordsForGLPStage(stage: number): CoreWord[] {
   return ALL_CORE_WORDS.filter(w => w.glpStage <= stage);
 }


### PR DESCRIPTION
## Summary
- Rewrites src/lib/glp/stages.ts to match Marge Blanc NLA
- Public API surface unchanged (getStage, isCategoryAvailable, getMaxWords)
- Adds TODO at vocabulary.ts line ~603 for follow-up re-grading

## Test plan
- [ ] npx tsc --noEmit clean
- [ ] /settings slider reads sensibly under NLA terminology
- [ ] /talk Suggested row at stage 1 still shows gestalts
- [ ] /talk Suggested row at stage 3 still shows single words
- [ ] No em dashes in diff
- [ ] No regression in T2.4 / T2.5 / T2.6 behavior

Closes #143