### PR TITLE
feat(glp): T3.7 on-device stage estimator banner

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,9 +2,11 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { useApp, type AppSettings } from '@/context/AppContext';
-import { GLP_STAGES } from '@/lib/glp/stages';
+import { GLP_STAGES, getStage } from '@/lib/glp/stages';
 import SmartSuggestionsToggle from '@/components/SmartSuggestionsToggle';
+import { estimateStage, type StageEstimate } from '@/lib/stage-estimator';
 
 /**
  * 8gent Jr Settings Page
@@ -41,6 +43,13 @@ export default function SettingsPage() {
   const { settings, updateSettings } = useApp();
 
   const accent = settings.primaryColor || '#4CAF50';
+
+  // Read-only stage estimate from on-device session-logger events (T3.7).
+  // Computed client-side after mount so SSR stays deterministic.
+  const [estimate, setEstimate] = useState<StageEstimate | null>(null);
+  useEffect(() => {
+    setEstimate(estimateStage());
+  }, []);
 
   const resetDefaults = () => {
     updateSettings(DEFAULTS);
@@ -85,6 +94,9 @@ export default function SettingsPage() {
             }}
           />
         </Section>
+
+        {/* ── Stage estimate banner (read-only, T3.7) ── */}
+        <StageEstimateBanner estimate={estimate} />
 
         {/* ── GLP Stage ── */}
         <Section title="Language Stage" icon={<IconStage />}>
@@ -285,6 +297,57 @@ export default function SettingsPage() {
           8gent Jr v1.0. Made with care.
         </p>
       </div>
+    </div>
+  );
+}
+
+/* ── Stage estimate banner (T3.7) ── */
+function StageEstimateBanner({ estimate }: { estimate: StageEstimate | null }) {
+  // Pre-mount or zero-confidence: show "not enough data yet" copy.
+  const notEnough = !estimate || estimate.confidence === 0;
+
+  const stageMeta = estimate ? getStage(estimate.stage) : null;
+
+  return (
+    <div
+      className="rounded-2xl px-4 py-3 border"
+      style={{
+        backgroundColor: '#F0F9FF', // sky-50
+        borderColor: '#BAE6FD',     // sky-200
+      }}
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 mb-1">
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#0369A1"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 16v-4" />
+          <path d="M12 8h.01" />
+        </svg>
+        <span className="text-xs font-bold uppercase tracking-wide" style={{ color: '#0369A1' }}>
+          Suggested stage
+        </span>
+      </div>
+      {notEnough || !stageMeta ? (
+        <p className="text-sm" style={{ color: '#0C4A6E' }}>
+          Not enough activity yet to estimate a stage. Keep using Talk and we will
+          suggest one once we have more data.
+        </p>
+      ) : (
+        <p className="text-sm" style={{ color: '#0C4A6E' }}>
+          Based on recent activity, your child appears to be at Stage {stageMeta.id}: {stageMeta.name}.
+          You can override this with the slider below.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/lib/stage-estimator.ts
+++ b/src/lib/stage-estimator.ts
@@ -1,0 +1,247 @@
+/**
+ * 8gent Jr - GLP Stage Estimator (T3.7)
+ *
+ * Pure local heuristic that turns recent session-logger events into a
+ * read-only suggestion of the child's current Marge Blanc NLA stage.
+ * The parent slider in /settings is the source of truth; this estimate
+ * is shown as an evidence-grounded banner the parent can override.
+ *
+ * Constraints:
+ *   - On-device only. No network. No ML training. Deterministic.
+ *   - Reads from session-logger.getAllEvents(); never mutates state.
+ *   - Targets <50ms on the hot path (single linear pass + small sets).
+ *
+ * Heuristic mapping under NLA (issue #141):
+ *   - Mostly multi-word / gestalt taps, few single words      -> 1 or 2
+ *   - Many isolated single-word taps, low gestalt ratio       -> 3
+ *   - Multi-word taps but no questions / conjunctions         -> 4
+ *   - Question words OR conjunctions appear                   -> 5
+ *   - Long mean utterance + multi-word + conjunctions + Qs    -> 6
+ *
+ * Confidence scales by (event count / 100). With <20 events we return
+ * stage 3 / confidence 0 so the UI can render a "not enough data yet"
+ * fallback instead of a misleading number.
+ *
+ * Sanity scenarios (synthetic events -> expected stage):
+ *   1. 30 multi-word gestalt taps ("all done", "let's go") -> stage 1 or 2
+ *   2. 50 single-word taps ("more", "stop", "water")       -> stage 3
+ *   3. 40 two-word combos ("want more", "go home"), no Qs  -> stage 4
+ *   4. 40 multi-word + a "what" / "and" tap                -> stage 5
+ *   5. 60 long phrases with question + conjunction         -> stage 6
+ *   6. 5 events total                                      -> stage 3, conf 0
+ *
+ * Issue: https://github.com/8gi-foundation/8gentjr/issues/141
+ */
+
+import { getAllEvents, type SessionEvent } from './session-logger';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface StageSignals {
+  /** Number of `word_used` events considered (capped at WINDOW). */
+  eventCount: number;
+  /** Mean tokens per tap label across the window. */
+  meanUtteranceLength: number;
+  /** Multi-word taps / total taps. 0..1. */
+  multiWordRatio: number;
+  /** Gestalt-flagged taps / total taps. 0..1. */
+  gestaltRatio: number;
+  /** Single-word taps / total taps. 0..1. */
+  singleWordRatio: number;
+  /** Tap count whose label contains a question word. */
+  questionCount: number;
+  /** Tap count whose label contains a conjunction. */
+  conjunctionCount: number;
+}
+
+export interface StageEstimate {
+  /** NLA stage 1-6. Defaults to 3 when there is not enough data. */
+  stage: 1 | 2 | 3 | 4 | 5 | 6;
+  /** 0..1 confidence. 0 means "not enough activity yet". */
+  confidence: number;
+  /** Underlying signals used to derive the stage (for debugging / UI). */
+  signals: StageSignals;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const WINDOW = 100; // last N word_used events
+const MIN_EVENTS_FOR_CONFIDENCE = 20;
+
+const QUESTION_WORDS = new Set([
+  'what',
+  'where',
+  'why',
+  'who',
+  'when',
+  'how',
+]);
+
+const CONJUNCTIONS = new Set([
+  'and',
+  'because',
+  'but',
+  'so',
+  'or',
+]);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Split a label into lowercase tokens. Returns [] for empty input. */
+function tokens(label: string): string[] {
+  if (!label) return [];
+  return label
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.replace(/[^a-z']/g, ''))
+    .filter(Boolean);
+}
+
+/** Pull the label string from a session event, however it was logged. */
+function eventLabel(ev: SessionEvent): string {
+  // logWord() writes { word: string }. Future writers may use { label }.
+  const data = ev.data ?? {};
+  if (typeof data.word === 'string') return data.word;
+  if (typeof data.label === 'string') return data.label;
+  return '';
+}
+
+/** Derive isGestalt: prefer explicit flag, otherwise infer from token count. */
+function eventIsGestalt(ev: SessionEvent, tokenCount: number): boolean {
+  const flag = ev.data?.isGestalt;
+  if (typeof flag === 'boolean') return flag;
+  // Fallback: any multi-word label is treated as a gestalt-style chunk.
+  return tokenCount >= 2;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate the child's current NLA stage from on-device session-logger data.
+ *
+ * @param now Optional timestamp override (used in tests). Currently unused
+ *   inside the heuristic; reserved for future time-decay weighting.
+ */
+export function estimateStage(_now: number = Date.now()): StageEstimate {
+  const all = getAllEvents();
+
+  // Take the last WINDOW word_used events in chronological order.
+  const wordEvents: SessionEvent[] = [];
+  for (let i = all.length - 1; i >= 0 && wordEvents.length < WINDOW; i--) {
+    if (all[i].type === 'word_used') wordEvents.push(all[i]);
+  }
+  wordEvents.reverse();
+
+  const eventCount = wordEvents.length;
+
+  // --- Default fallback when not enough data ------------------------------
+  if (eventCount < MIN_EVENTS_FOR_CONFIDENCE) {
+    return {
+      stage: 3,
+      confidence: 0,
+      signals: {
+        eventCount,
+        meanUtteranceLength: 0,
+        multiWordRatio: 0,
+        gestaltRatio: 0,
+        singleWordRatio: 0,
+        questionCount: 0,
+        conjunctionCount: 0,
+      },
+    };
+  }
+
+  // --- Single linear pass over the window --------------------------------
+  let totalTokens = 0;
+  let multiWord = 0;
+  let singleWord = 0;
+  let gestalt = 0;
+  let questionCount = 0;
+  let conjunctionCount = 0;
+
+  for (const ev of wordEvents) {
+    const t = tokens(eventLabel(ev));
+    if (t.length === 0) continue;
+
+    totalTokens += t.length;
+    if (t.length >= 2) multiWord++;
+    else singleWord++;
+
+    if (eventIsGestalt(ev, t.length)) gestalt++;
+
+    let sawQuestion = false;
+    let sawConjunction = false;
+    for (const tok of t) {
+      if (!sawQuestion && QUESTION_WORDS.has(tok)) sawQuestion = true;
+      if (!sawConjunction && CONJUNCTIONS.has(tok)) sawConjunction = true;
+    }
+    if (sawQuestion) questionCount++;
+    if (sawConjunction) conjunctionCount++;
+  }
+
+  const meanUtteranceLength = totalTokens / eventCount;
+  const multiWordRatio = multiWord / eventCount;
+  const gestaltRatio = gestalt / eventCount;
+  const singleWordRatio = singleWord / eventCount;
+
+  const signals: StageSignals = {
+    eventCount,
+    meanUtteranceLength,
+    multiWordRatio,
+    gestaltRatio,
+    singleWordRatio,
+    questionCount,
+    conjunctionCount,
+  };
+
+  // --- Stage classification ----------------------------------------------
+  // Order matters: highest stages have the strictest preconditions.
+  const hasQuestions = questionCount > 0;
+  const hasConjunctions = conjunctionCount > 0;
+  const hasGrammar = hasQuestions || hasConjunctions;
+
+  let stage: StageEstimate['stage'];
+
+  if (
+    meanUtteranceLength >= 4 &&
+    multiWordRatio >= 0.5 &&
+    hasQuestions &&
+    hasConjunctions
+  ) {
+    // Long, varied, grammatical -> full conversation.
+    stage = 6;
+  } else if (hasGrammar && multiWordRatio >= 0.3) {
+    // Question words or conjunctions appearing in multi-word context.
+    stage = 5;
+  } else if (multiWordRatio >= 0.4 && gestaltRatio < 0.6 && !hasGrammar) {
+    // Novel 2-3 word combinations dominate, but no question/conjunction yet.
+    stage = 4;
+  } else if (singleWordRatio >= 0.6 && gestaltRatio < 0.4) {
+    // Mostly isolated single-word taps -> single words from gestalts.
+    stage = 3;
+  } else if (gestaltRatio >= 0.6 && multiWordRatio >= 0.5) {
+    // Heavy gestalt usage. Distinguish 1 vs 2 by mix breadth: a high
+    // single-word ratio alongside gestalts hints at mitigated gestalts
+    // (the child is starting to break chunks apart).
+    stage = singleWordRatio >= 0.2 ? 2 : 1;
+  } else {
+    // Mixed / unclear -> stay on the safe single-word default.
+    stage = 3;
+  }
+
+  // --- Confidence ---------------------------------------------------------
+  // Linear ramp from MIN_EVENTS_FOR_CONFIDENCE..WINDOW.
+  const raw = (eventCount - MIN_EVENTS_FOR_CONFIDENCE) /
+    (WINDOW - MIN_EVENTS_FOR_CONFIDENCE);
+  const confidence = Math.max(0, Math.min(1, raw));
+
+  return { stage, confidence, signals };
+}


### PR DESCRIPTION
Closes #141.

## Summary
- New pure module `src/lib/stage-estimator.ts` exporting `estimateStage()` and the `StageEstimate` / `StageSignals` types. Reads `session-logger.getAllEvents()`, looks at the last 100 `word_used` events, computes mean utterance length, multi-word ratio, gestalt ratio, single-word ratio, question-word and conjunction counts, then maps to NLA stages 1-6.
- Read-only sky-tinted banner above the manual GLP slider in `/settings`. Copy: "Based on recent activity, your child appears to be at Stage X: {stageName}. You can override this with the slider below." When `confidence === 0` (or pre-mount): "Not enough activity yet to estimate a stage."
- Slider remains the source of truth. The estimator never writes to `settings.glpStage`.

## Heuristic mapping (NLA, Marge Blanc)
- Mean >= 4 tokens, multi-word >= 0.5, questions and conjunctions present -> Stage 6
- Question words OR conjunctions with multi-word >= 0.3 -> Stage 5
- Multi-word >= 0.4, gestalt < 0.6, no grammar -> Stage 4
- Single-word >= 0.6, gestalt < 0.4 -> Stage 3
- Gestalt >= 0.6, multi-word >= 0.5 -> Stage 1 (or 2 if singleWordRatio >= 0.2 hints at mitigation)
- Otherwise default Stage 3
- < 20 events -> Stage 3, confidence 0 (UI shows "not enough data yet")

## Constraints upheld
- COPPA / GDPR Article 35(9): no network calls, no IO, deterministic local computation. Verified `grep -E 'fetch|XMLHttpRequest|axios'` on the new module returns nothing.
- No cross-session ML training. Pure heuristic, no model state, no persistence.
- No em dashes (`git log main..HEAD -p | grep -c '—'` = 0).
- No purple/pink/violet. Banner uses sky-50 / sky-200 / sky-700/900 tones consistent with T2.4.
- TypeScript strict typecheck passes (`npx tsc --noEmit`).
- Performance: single linear pass over up to 100 events plus a couple of small Sets. Well under the 50ms budget.

## Test plan
- [ ] Open `/settings` with an empty event log -> banner shows "Not enough activity yet to estimate a stage."
- [ ] Tap 20+ multi-word gestalt cards in Talk -> banner shifts to Stage 1 or 2.
- [ ] Tap 20+ single-word cards -> banner shows Stage 3.
- [ ] Tap 20+ two-word combinations with no question/conjunction -> Stage 4.
- [ ] Tap a card whose label contains "what" or "and" alongside multi-word activity -> Stage 5.
- [ ] Override via the slider -> selection persists and banner does not fight it.
- [ ] DevTools Network tab during `/settings` load -> zero outbound requests from this module.