### PR TITLE
feat(glp): T3.8 Blend engine for stage-2 mix-and-match

### DIFF
--- a/src/app/api/improve-sentence/route.ts
+++ b/src/app/api/improve-sentence/route.ts
@@ -1,105 +1,145 @@
 import { NextRequest } from 'next/server';
 import { createAIProviderWithFallback } from '@/lib/ai-provider';
+import { IMPROVE_PROMPT, BLEND_PROMPT } from '@/lib/glp-prompts';
 
 /**
- * 8gent Jr — Sentence Improvement API (Magic Button)
+ * 8gent Jr - Sentence Improvement / Blend API
  *
- * Takes raw AAC card words and returns a grammatically improved sentence.
- * Uses local Ollama (free) with Groq (free tier) as cloud fallback.
- * Ported from NickOS improve-sentence endpoint.
+ * Two modes:
+ * - 'improve' (default, stage 3+): grammar clean-up of word-by-word AAC input.
+ *   Returns JSON with { improved, explanation, missing }.
+ * - 'blend' (stage 2 mix-and-match): fuses 2+ whole gestalts into a single
+ *   coherent gestalt without inventing new words. Returns JSON with
+ *   { blended, original }. Falls back to plain concatenation on any error.
  *
- * Issue: #53
+ * Same provider chain (local Ollama with Groq fallback). Same auth.
+ *
+ * Issues: #53 (improve), #142 (blend)
  */
 
-const SYSTEM_PROMPT = `You are an AAC sentence improver for children. Your job is to take words from communication cards and form natural sentences.
+type Mode = 'improve' | 'blend';
 
-Rules:
-1. Keep the meaning EXACTLY the same
-2. Add only necessary grammar (articles, prepositions, conjugations)
-3. Keep sentences simple and age-appropriate
-4. Output should sound natural when spoken aloud
-5. Do NOT add new concepts or change the intent
-
-Also detect if the sentence is missing important vocabulary. Return suggestions for cards that would help.
-
-Example:
-Input: "I want apple juice"
-Output: "I would like some apple juice, please"
-Missing: None
-
-Example:
-Input: "go park"
-Output: "I want to go to the park"
-Missing: ["I", "want"] - core vocabulary for expressing desires
-
-Respond with JSON:
-{
-  "improved": "the improved sentence",
-  "explanation": "brief explanation of changes",
-  "missing": [
-    {
-      "word": "missing word",
-      "category": "core|actions|feelings|etc",
-      "reason": "why this would help"
-    }
-  ]
-}`;
-
-interface ImproveRequest {
-  cards: string[];
+interface RequestBody {
+  // Legacy improve payload kept for back-compat with existing callers.
+  cards?: string[];
+  // Preferred shape going forward; both modes accept either field.
+  words?: string[];
+  mode?: Mode;
 }
 
 export async function POST(request: NextRequest) {
+  let body: RequestBody;
   try {
-    const body: ImproveRequest = await request.json();
+    body = (await request.json()) as RequestBody;
+  } catch {
+    return jsonError('Invalid JSON body', 400);
+  }
 
-    if (!body.cards || !Array.isArray(body.cards) || body.cards.length === 0) {
-      return new Response(JSON.stringify({ error: 'Cards array required' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
+  const mode: Mode = body.mode === 'blend' ? 'blend' : 'improve';
+  const words = body.words ?? body.cards ?? [];
 
+  if (!Array.isArray(words) || words.length === 0) {
+    return jsonError(
+      mode === 'blend' ? 'words array required' : 'Cards array required',
+      400
+    );
+  }
+
+  const rawSentence = words.join(' ');
+
+  try {
     const provider = await createAIProviderWithFallback('llama-3.1-8b-instant');
 
-    const rawSentence = body.cards.join(' ');
-
     if (!provider) {
-      // Graceful degradation: return the raw sentence unchanged
-      return new Response(
-        JSON.stringify({
-          original: rawSentence,
-          improved: rawSentence,
-          explanation: 'AI unavailable — sentence returned as-is',
-          missing: [],
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      return mode === 'blend'
+        ? blendFallback(words, rawSentence, 'AI unavailable - joined as-is')
+        : improveFallback(rawSentence, 'AI unavailable - sentence returned as-is');
+    }
+
+    if (mode === 'blend') {
+      const content = await provider.chat(
+        [
+          { role: 'system', content: BLEND_PROMPT },
+          {
+            role: 'user',
+            content: `Fuse these gestalts into one: ${JSON.stringify(words)}`,
+          },
+        ],
+        { max_tokens: 128 }
       );
+      const blended = sanitizeBlend(content) || rawSentence;
+      return jsonOk({ original: rawSentence, blended });
     }
 
     const content = await provider.chat(
       [
-        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'system', content: IMPROVE_PROMPT },
         { role: 'user', content: `Improve this AAC sentence: "${rawSentence}"` },
       ],
       { max_tokens: 512 }
     );
 
-    if (content) {
-      return parseAndRespond(content, rawSentence);
-    }
-
-    return new Response(JSON.stringify({ error: 'No response from AI' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    if (content) return parseAndRespond(content, rawSentence);
+    return jsonError('No response from AI', 500);
   } catch (error) {
-    console.error('[8gent Jr Improve] Error:', error);
-    return new Response(JSON.stringify({ error: 'Internal server error' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    console.error('[8gent Jr improve-sentence] Error:', error);
+    if (mode === 'blend') {
+      return blendFallback(words, rawSentence, 'Blend failed - joined as-is');
+    }
+    return jsonError('Internal server error', 500);
   }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function jsonOk(payload: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function blendFallback(words: string[], rawSentence: string, explanation: string): Response {
+  return jsonOk({
+    original: rawSentence,
+    blended: words.join(' '),
+    explanation,
+  });
+}
+
+function improveFallback(rawSentence: string, explanation: string): Response {
+  return jsonOk({
+    original: rawSentence,
+    improved: rawSentence,
+    explanation,
+    missing: [],
+  });
+}
+
+/**
+ * The blend prompt asks for plain text, but small models sometimes wrap
+ * the output in quotes, code fences, or trailing commentary. Strip those
+ * back to a single-line plain string before returning.
+ */
+function sanitizeBlend(content: string | null | undefined): string {
+  if (!content) return '';
+  let s = content.trim();
+  // Strip code fences if present
+  const fenceMatch = s.match(/```(?:\w+)?\s*([\s\S]*?)```/);
+  if (fenceMatch) s = fenceMatch[1].trim();
+  // Take first non-empty line
+  const firstLine = s.split('\n').map(l => l.trim()).find(Boolean) ?? '';
+  // Strip surrounding quotes
+  return firstLine.replace(/^["'`]+|["'`]+$/g, '').trim();
 }
 
 function parseAndRespond(content: string, rawSentence: string): Response {
@@ -110,24 +150,18 @@ function parseAndRespond(content: string, rawSentence: string): Response {
       jsonStr = jsonMatch[1].trim();
     }
     const result = JSON.parse(jsonStr);
-    return new Response(
-      JSON.stringify({
-        original: rawSentence,
-        improved: result.improved,
-        explanation: result.explanation,
-        missing: result.missing || [],
-      }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    );
+    return jsonOk({
+      original: rawSentence,
+      improved: result.improved,
+      explanation: result.explanation,
+      missing: result.missing || [],
+    });
   } catch {
-    return new Response(
-      JSON.stringify({
-        original: rawSentence,
-        improved: content.trim(),
-        explanation: 'Grammar improved',
-        missing: [],
-      }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    );
+    return jsonOk({
+      original: rawSentence,
+      improved: content.trim(),
+      explanation: 'Grammar improved',
+      missing: [],
+    });
   }
 }

--- a/src/components/SharedSentenceBar.tsx
+++ b/src/components/SharedSentenceBar.tsx
@@ -44,6 +44,14 @@ export interface SharedSentenceBarProps {
    * If both onMagic and onMirror are provided, mirror takes precedence.
    */
   onMirror?: () => void;
+  /**
+   * Optional blend button. Replaces magic AND mirror at GLP stage 2 when the
+   * sentence contains 2+ gestalt chips. Fuses the gestalts into one coherent
+   * script via /api/improve-sentence (mode='blend'). Mutually exclusive with
+   * onMagic and onMirror - if onBlend is provided, it wins.
+   */
+  onBlend?: () => void;
+  isBlendLoading?: boolean;
   placeholder?: string;
   /**
    * Set to true briefly when browser TTS fallback fired (ElevenLabs was unavailable).
@@ -60,6 +68,8 @@ export function SharedSentenceBar({
   onMagic,
   isMagicLoading = false,
   onMirror,
+  onBlend,
+  isBlendLoading = false,
   placeholder = 'Tap words to build a sentence...',
   engineFallback = false,
 }: SharedSentenceBarProps) {
@@ -101,8 +111,27 @@ export function SharedSentenceBar({
         &#9654;
       </button>
 
-      {/* 🪞 Mirror replaces magic at GLP stages 1-2 (no LLM rewrite, just re-speak) */}
-      {onMirror ? (
+      {/*
+        Button precedence (highest first):
+        1. onBlend  - GLP stage 2 with 2+ gestalt chips. Fuses gestalts.
+        2. onMirror - GLP stages 1-2 fallback. Re-speaks verbatim.
+        3. onMagic  - GLP stage 3+. Light analytic improve.
+      */}
+      {onBlend ? (
+        <button
+          onClick={onBlend}
+          disabled={words.length < 2 || isBlendLoading}
+          className={`shrink-0 w-10 h-10 rounded-xl flex items-center justify-center text-base font-bold transition-all ${
+            words.length >= 2 && !isBlendLoading
+              ? 'bg-sky-200 text-sky-700 hover:bg-sky-300 cursor-pointer active:scale-90 border-2 border-sky-700'
+              : 'bg-gray-600 text-white cursor-not-allowed'
+          } ${isBlendLoading ? 'animate-pulse' : ''}`}
+          aria-label="Blend sentence: fuse gestalts"
+          title="Blend: fuse phrases into one"
+        >
+          &#8753;
+        </button>
+      ) : onMirror ? (
         <button
           onClick={onMirror}
           disabled={words.length < 1}

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -258,6 +258,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   const showPersonalVocab = settings.showPersonalVocab !== false;
   const [cols, setCols] = useState(10);
   const [isMagicLoading, setIsMagicLoading] = useState(false);
+  const [isBlendLoading, setIsBlendLoading] = useState(false);
   const [engineFallback, setEngineFallback] = useState(false);
   const [yourWords, setYourWords] = useState<YourWordsCard[]>([]);
 
@@ -282,7 +283,22 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   // T2.6 - any gestalt chip in the sentence forces mirror at any stage.
   // glpDisabled (kill switch) overrides everything, so respect it.
   const gestaltMode = !glpDisabled && sentence.some(c => c.isGestalt);
-  const mirrorMode = stageMirrorMode || gestaltMode;
+  /**
+   * T3.8 - Blend mode (NLA stage 2 Mitigated Gestalts).
+   *
+   * Active when stage === 2 AND the sentence contains 2+ gestalt chips.
+   * Precedence (highest wins):
+   *   blendMode  -> button is "Blend" (LLM fuses gestalts).
+   *   mirrorMode -> button is "Mirror" (re-speak verbatim).
+   *   default    -> button is "Magic" (analytic improve, stage 3+).
+   *
+   * Stage 2 with only 1 gestalt + a single word still falls back to
+   * mirrorMode because stageMirrorMode (stage <= 2) covers that case.
+   * The kill switch (`!glpDisabled`) suppresses both blend and mirror.
+   */
+  const gestaltCount = sentence.filter(c => c.isGestalt).length;
+  const blendMode = !glpDisabled && stage === 2 && gestaltCount >= 2;
+  const mirrorMode = !blendMode && (stageMirrorMode || gestaltMode);
 
   // Responsive column count: 4 on phone, 5 on small tablet, 10 on desktop
   useEffect(() => {
@@ -446,6 +462,32 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
     speakText(sentence.map(w => w.label).join(' '));
   }, [sentence, speakText]);
 
+  // T3.8 - Blend handler. Calls /api/improve-sentence in 'blend' mode and
+  // speaks the fused gestalt. Falls back to plain concatenation on error.
+  const handleBlendSpeak = useCallback(async () => {
+    if (sentence.length < 2) return;
+    setIsBlendLoading(true);
+    const words = sentence.map(w => w.label);
+    try {
+      const res = await fetch('/api/improve-sentence', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'blend', words }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const blended = (data.blended as string | undefined) || words.join(' ');
+        speakText(blended);
+      } else {
+        speakText(words.join(' '));
+      }
+    } catch {
+      speakText(words.join(' '));
+    } finally {
+      setIsBlendLoading(false);
+    }
+  }, [sentence, speakText]);
+
   // Intro cards - only when child name is known
   const introCols = Math.min(cols, 4);
   const introCards: { label: string; arasaacId?: number }[] = childName ? [
@@ -475,9 +517,11 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
       <SharedSentenceBar
         words={sentence}
         onSpeak={handleSpeakAll}
-        onMagic={mirrorMode ? undefined : handleMagicSpeak}
-        onMirror={mirrorMode ? handleMirrorSpeak : undefined}
+        onMagic={blendMode || mirrorMode ? undefined : handleMagicSpeak}
+        onMirror={blendMode ? undefined : (mirrorMode ? handleMirrorSpeak : undefined)}
+        onBlend={blendMode ? handleBlendSpeak : undefined}
         isMagicLoading={isMagicLoading}
+        isBlendLoading={isBlendLoading}
         onClear={handleClear}
         onRemoveWord={removeWord}
         engineFallback={engineFallback}

--- a/src/lib/glp-prompts.ts
+++ b/src/lib/glp-prompts.ts
@@ -1,0 +1,74 @@
+/**
+ * 8gent Jr - GLP prompt templates
+ *
+ * Single source of truth for the system prompts used by
+ * /api/improve-sentence. Two modes are supported:
+ *
+ * - 'improve' (stage 3+): light analytic clean-up of mostly-single-word
+ *   chips. Adds articles / prepositions, conjugates verbs, keeps meaning.
+ *
+ * - 'blend' (stage 2): mix-and-match fusion of 2+ whole gestalts.
+ *   The output MUST stay inside the chips the child tapped - no new
+ *   vocabulary, no analytic rewrite. This respects Marge Blanc's NLA
+ *   stage 2 (Mitigated Gestalts) where the child trims and recombines
+ *   familiar scripts rather than producing novel grammar.
+ *
+ * Issue: #142
+ */
+
+export const IMPROVE_PROMPT = `You are an AAC sentence improver for children. Your job is to take words from communication cards and form natural sentences.
+
+Rules:
+1. Keep the meaning EXACTLY the same
+2. Add only necessary grammar (articles, prepositions, conjugations)
+3. Keep sentences simple and age-appropriate
+4. Output should sound natural when spoken aloud
+5. Do NOT add new concepts or change the intent
+
+Also detect if the sentence is missing important vocabulary. Return suggestions for cards that would help.
+
+Example:
+Input: "I want apple juice"
+Output: "I would like some apple juice, please"
+Missing: None
+
+Example:
+Input: "go park"
+Output: "I want to go to the park"
+Missing: ["I", "want"] - core vocabulary for expressing desires
+
+Respond with JSON:
+{
+  "improved": "the improved sentence",
+  "explanation": "brief explanation of changes",
+  "missing": [
+    {
+      "word": "missing word",
+      "category": "core|actions|feelings|etc",
+      "reason": "why this would help"
+    }
+  ]
+}`;
+
+export const BLEND_PROMPT = `You are an AAC blend assistant for a Gestalt Language Processor (GLP) child at NLA stage 2 (Mitigated Gestalts).
+
+The child taps WHOLE phrases (gestalts) they have memorised. Your only job is to fuse 2 or more of these phrases into a single coherent gestalt that the child could plausibly say next, while staying strictly inside the words they already tapped.
+
+HARD RULES:
+1. Use ONLY the words present in the input phrases. Do NOT invent or substitute words.
+2. You MAY drop a duplicate filler word (e.g. trim a trailing "we" if the next phrase starts with "we"), but never add one.
+3. Do NOT correct grammar, do NOT rephrase analytically, do NOT add articles or pronouns the child did not tap.
+4. Preserve the order of the input phrases.
+5. Output a single line of plain text. No quotes, no markdown, no explanation, no JSON.
+
+Example:
+Input phrases: ["let's go", "all done"]
+Output: let's go all done
+
+Example:
+Input phrases: ["I want it", "right now please"]
+Output: I want it right now please
+
+Example:
+Input phrases: ["time to eat", "all done", "let's go"]
+Output: time to eat all done let's go`;


### PR DESCRIPTION
## Summary

- Stage 2 (Mitigated Gestalts, NLA) now gets a dedicated **Blend** button in `SharedSentenceBar` when the sentence contains 2+ gestalt chips. Blend fuses the gestalts via `/api/improve-sentence` (`mode='blend'`) using a prompt that explicitly forbids inventing words the child did not tap.
- New `src/lib/glp-prompts.ts` holds `BLEND_PROMPT` and `IMPROVE_PROMPT` so the API route stays thin.
- API route supports `{ mode: 'improve' | 'blend', words?: string[], cards?: string[] }`. Improve path is unchanged. Blend returns `{ original, blended, explanation? }` and falls back to plain concatenation on AI failure.
- Precedence in `SupercoreGrid`: `blendMode` (stage 2 + 2+ gestalts) > `mirrorMode` (stage <= 2 OR any gestalt chip) > `magic` (stage 3+). Kill switch (`8gentjr-glp-disable=true`) suppresses both blend and mirror.
- Button styling: sky-200 / sky-700 (no purple, no pink, no violet).

Closes #142.

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] Em dash audit: `git diff main..HEAD | grep "—"` returns nothing in added lines.
- [x] No banned hues (purple/pink/violet) in additions.
- [x] Smoke test: `POST /api/improve-sentence` with `{mode: 'blend', words: ['lets go', 'all done']}` returns `{original: 'lets go all done', blended: 'lets go all done', explanation: 'Blend failed - joined as-is'}` when no AI provider is available (graceful concat fallback works).
- [x] Improve back-compat: `POST` with `{cards: [...]}` still routes through the original improve path.
- [ ] Manual UI: at stage 2 with 2 gestalt chips, magic button is replaced by sky-toned Blend button with aria-label `"Blend sentence: fuse gestalts"`.
- [ ] At stage 2 with 1 gestalt + 1 single word, button is Mirror (not Blend).
- [ ] At stage 1, button is Mirror regardless of gestalt count.
- [ ] At stage 3+, button is Magic unless any gestalt chip is present (then Mirror).