### PR TITLE
chore(consent): VPC step-2 default to 24h (COPPA email-plus)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,9 @@ PRIVACY_ADMIN_TOKEN=             # required to hit /api/privacy/admin; empty = 4
 # COPPA email-plus Verifiable Parental Consent
 # HMAC secret for signed step-1/step-2 tokens. Required in production.
 VPC_TOKEN_SECRET=
-# Delay in ms between step-1 confirmation and step-2 email send. Default 600000 (10 min).
-VPC_STEP2_DELAY_MS=600000
+# Delay in ms between step-1 confirmation and step-2 email send.
+# Default 86400000 (24h, FTC 16 CFR 312.5(b)(2) email-plus 24-72h band).
+VPC_STEP2_DELAY_MS=86400000
 # Shared-secret bearer token for the admin audit log route. Rotate often.
 VPC_ADMIN_TOKEN=
 # Directory for the JSONL audit log + email outbox stub. Defaults to ./data/consent

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ yarn-error.log*
 # local data
 data/health/
 data/consent/
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/src/app/parent-email-verification/page.tsx
+++ b/src/app/parent-email-verification/page.tsx
@@ -6,7 +6,8 @@ import ParentEmailForm from '@/components/ParentEmailForm';
  *
  * Child-path accounts land here after the age gate. The form posts to
  * /api/consent/initiate which issues a signed step-1 token and sends email
- * #1. Step 2 is scheduled ~10 minutes after step-1 confirmation.
+ * #1. Step 2 is scheduled ~24 hours after step-1 confirmation
+ * (FTC 16 CFR 312.5(b)(2) email-plus 24-72h band).
  *
  * DPIA reference:
  *   8gi-governance/docs/legal/2026-04-21-8gentjr-dpia-interim.md

--- a/src/lib/consent/flow.ts
+++ b/src/lib/consent/flow.ts
@@ -11,7 +11,8 @@
  *   confirmStep2 - consume step-2 token, activate child profile
  *
  * Delay between step-1 confirmation and step-2 send is controlled by
- * VPC_STEP2_DELAY_MS (default 600_000 = 10 min). Set 0 in tests.
+ * VPC_STEP2_DELAY_MS (default 86_400_000 = 24h, per FTC 16 CFR 312.5(b)(2)
+ * email-plus 24-72h band). Set 0 in tests.
  */
 
 import {
@@ -72,7 +73,7 @@ export async function initiate(input: InitiateInput): Promise<InitiateOutput> {
       '',
       url,
       '',
-      'A second confirmation email will arrive within about 10 minutes. Both must be clicked for the child account to activate. Links expire in 7 days.',
+      'A second confirmation email will arrive within 24 hours. Both must be clicked for the child account to activate. Links expire in 7 days.',
       '',
       'If you did not request this, you can safely ignore the email.',
       '',
@@ -138,10 +139,12 @@ export async function confirmStep1(
 }
 
 function getStep2DelayMs(): number {
+  // Default 24h per FTC 16 CFR 312.5(b)(2) email-plus 24-72h band.
+  const DEFAULT_DELAY_MS = 24 * 60 * 60 * 1000;
   const raw = process.env.VPC_STEP2_DELAY_MS;
-  if (raw === undefined) return 10 * 60 * 1000;
+  if (raw === undefined) return DEFAULT_DELAY_MS;
   const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? n : 10 * 60 * 1000;
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_DELAY_MS;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Lift `VPC_STEP2_DELAY_MS` default from 600000 (10 min) to 86400000 (24h) in `.env.example` so dev clones match prod.
- Update in-code fallback in `getStep2DelayMs()` (`src/lib/consent/flow.ts`) to 24h. Previously returned 10 min when env var unset or invalid, which silently undercut the FTC email-plus 24-72h band on any deploy missing the override.
- Update email-1 body copy from "within about 10 minutes" to "within 24 hours" so the parent expectation matches the actual schedule.
- Update header doc comment + the parent-email-verification page header comment to reference FTC 16 CFR 312.5(b)(2) and the 24h default.
- Drive-by: add `/.clerk/` to `.gitignore` so a Clerk SDK-generated config that may include secrets cannot be committed accidentally.

Prod was lifted to 24h on 2026-04-24 in PR #130. This PR aligns the defaults so the repo can no longer drift back. Closes Compliance Audit 2026-04-24 §C item 4 (MEDIUM).

Refs `8gi-foundation/8gi-governance#168` (governance bundle context: ROPA, EU AI Act memo, AADC + DPC mappings, TIA bundle, DPIA appendices E + F + amended C).

## Test plan

- [x] `bun test src/lib/consent/__tests__/flow.test.ts` (10 pass, 0 fail)
- [x] `VPC_STEP2_DELAY_MS=0` override path still works (tests use 0)
- [x] Invalid value (e.g. `VPC_STEP2_DELAY_MS=abc`) falls back to 24h, not 10 min (verified via `getStep2DelayMs()` second branch)
- [x] No remaining "10 min" / "600000" copy in non-test source (`grep -rn` confirms only timer/page.tsx Bubble Timer presets which are unrelated)

SIGN-OFF:
  VOICE:    say -v Karen "VPC step 2 default lifted to 24 hours, aligned with prod and FTC email-plus band."
  VALIDATE: https://8gentjr.com (no user-visible change, internal default only)
  VISUAL:   Deploy pending; pre-merge preview will be Vercel-attached
  COMMIT:   chore(consent): VPC step-2 default to 24h (COPPA email-plus) - fd8c65d on chore/vpc-default-24h-delay-coppa
  PUSHED:   8gi-foundation/8gentjr chore/vpc-default-24h-delay-coppa
  ISSUE:    https://github.com/8gi-foundation/8gentjr/issues/110 (open, COPPA #110)
  PR:       (this PR)