### PR TITLE
feat(kids-mode): capability policy with parental override + activity log (#164)

### DIFF
--- a/src/app/api/parent-chat/route.ts
+++ b/src/app/api/parent-chat/route.ts
@@ -1,45 +1,51 @@
 import { NextRequest } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
 import { createAIProviderWithFallback } from '@/lib/ai-provider';
 
 /**
- * 8gent Jr — Parent Chat API
+ * 8gent Jr - Parent Chat API
  *
- * Evidence-informed AAC advisor for parents. Answers questions about
- * their child's communication, vocabulary, and AAC strategy using
- * specialist knowledge. Not generalised — grounded in AAC research.
+ * Educational assistant for parents interested in AAC. Not clinical
+ * advice. Surfaces public AAC literature at a general level and always
+ * redirects clinical questions to a qualified speech-language therapist
+ * or paediatric specialist.
  *
- * Stack: Ollama (local) → Groq / llama-3.3-70b-versatile (cloud fallback)
+ * Non-clinical framing is required (EU MDR Annex VIII Rule 12 + EU AI
+ * Act Annex III boundary). See:
+ *   8gi-governance/docs/legal/2026-04-21-8gentjr-dpia-interim.md
+ *     Appendix E (medical-device boundary)
+ *   8gi-governance/docs/legal/eu-ai-act-classification.md §4 + §9
+ *
+ * Stack: Ollama (local) -> Groq / llama-3.3-70b-versatile (cloud fallback)
  */
 
-const SYSTEM_PROMPT = `You are an expert AAC (Augmentative and Alternative Communication) specialist and speech-language pathologist advisor embedded in 8gent Jr, a communication app for children.
+const SYSTEM_PROMPT = `You are an educational assistant for parents interested in Augmentative and Alternative Communication (AAC). You are NOT a clinician, therapist, or speech-language pathologist. You are NOT an AAC specialist or SLP advisor. You provide general education and reference well-known public AAC literature at a general level.
+
+For clinical questions about a specific child (development, communication, behaviour, intervention, dosage, scheduling, prognosis), you must always direct the parent to consult a qualified speech-language therapist or paediatric specialist.
 
 Your role is to help parents:
-- Understand AAC strategies for their child's specific needs
-- Choose and prioritise vocabulary for their child's board
-- Understand how conditions like ADHD, autism, cerebral palsy, and developmental delays affect communication
-- Implement evidence-based AAC strategies at home
-- Interpret their child's communication behaviours
+- Learn what AAC is and the kinds of strategies that exist
+- Understand the broad categories of vocabulary commonly used in AAC (core vs fringe, etc.)
+- Read about how communication can differ for autistic, ADHD, cerebral-palsy, and developmentally-delayed users in general terms
+- Find public educational resources (PrAACtical AAC, AAC Language Lab, ASHA consumer pages) and academic AAC literature
 
-Your knowledge is grounded in:
-- AAC research (Beukelman & Mirenda, Light & McNaughton, etc.)
-- Core vocabulary research (Banajee, Dicarlo & Stricklin 2003; Cross et al. 2006)
-- Gestalt Language Processing (GLP) theory
-- Modified Fitzgerald Key colour coding system
-- Psychiatric and neurodevelopmental research where relevant
+Public references you may mention at a general level:
+- AAC research surveys (Beukelman & Mirenda; Light & McNaughton)
+- Core vocabulary surveys (Banajee, Dicarlo & Stricklin 2003; Cross et al. 2006)
+- Gestalt Language Processing (general public-domain explanations)
+- Modified Fitzgerald Key colour coding (public reference)
 
-Rules:
-1. Be specific and evidence-informed — not generic wellness advice
-2. When citing research, name the authors and approximate date
-3. Be warm and practical — parents are often overwhelmed
-4. If a question is outside AAC/communication scope, redirect kindly
-5. Keep responses concise but complete — parents are busy
-6. Use plain English, not clinical jargon (explain terms when needed)
-7. When relevant, suggest specific vocabulary words or categories for the app
+Hard rules you must follow:
+1. Do NOT diagnose, screen, assess, or label any child.
+2. Do NOT prescribe therapy plans, intervention dosage, session frequency, or specific vocabulary targets for a specific child.
+3. Do NOT issue clinical instructions, recommendations, or imply clinical authority.
+4. Do NOT use phrases like "I recommend", "you should", "your child needs", "the right approach is" when the parent describes a specific child.
+5. For any question about a specific child, redirect to a qualified speech-language therapist or paediatric specialist.
+6. If a question is outside general AAC education, redirect kindly.
+7. Keep tone supportive, plain-language, parent-friendly. No medical jargon presented as advice.
+8. Use short paragraphs, not bullet walls. End with a non-clinical next step where appropriate (e.g. "this might be a good question for your child's speech-language therapist").
 
-Format:
-- Use short paragraphs, not bullet walls
-- Bold key terms or recommendations
-- End with a practical next step when appropriate`;
+You are an education tool. You are not a clinician. Your output is informational, not medical advice.`;
 
 interface Message {
   role: 'user' | 'assistant';
@@ -52,6 +58,17 @@ interface ChatRequest {
 
 export async function POST(request: NextRequest) {
   try {
+    // Parent-chat is for authenticated parents only. Child-path accounts
+    // are device-bound (under-13) and must not see the LLM-backed parent
+    // education surface. See DPIA Appendix E + EU AI Act memo §9 guard 3.
+    const { userId } = await auth();
+    if (!userId) {
+      return new Response(
+        JSON.stringify({ error: 'Authentication required' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
     const body: ChatRequest = await request.json();
     const { messages } = body;
 
@@ -68,7 +85,7 @@ export async function POST(request: NextRequest) {
       return new Response(
         JSON.stringify({
           reply:
-            'AI unavailable offline — check AAC resources at aac.8gentjr.com',
+            'Educational assistant unavailable offline. Public AAC resources are at aac.8gentjr.com',
         }),
         { status: 200, headers: { 'Content-Type': 'application/json' } }
       );

--- a/src/components/ParentChat.tsx
+++ b/src/components/ParentChat.tsx
@@ -16,10 +16,10 @@ function nextId() {
 }
 
 const SUGGESTIONS = [
-  "My child has ADHD — which words should I prioritise first?",
-  "How do I encourage my child to use their AAC board more?",
-  "What's the difference between core and fringe vocabulary?",
-  "My child is autistic and a gestalt language processor — how does that change things?",
+  "What is AAC and what kinds of strategies exist?",
+  "What is the difference between core and fringe vocabulary?",
+  "What public resources can I read about gestalt language processing?",
+  "What kinds of questions are good to bring to a speech-language therapist?",
 ];
 
 export default function ParentChat() {
@@ -85,8 +85,17 @@ export default function ParentChat() {
         </a>
         <div>
           <div className="text-[1.1rem] font-bold text-gray-800">Parent Chat</div>
-          <div className="text-xs text-gray-400">AAC specialist · evidence-informed</div>
+          <div className="text-xs text-gray-400">AAC education for parents</div>
         </div>
+      </div>
+
+      {/* Non-clinical disclaimer banner. Persistent. EU MDR + AI Act guard. */}
+      <div
+        role="note"
+        aria-label="Non-clinical disclaimer"
+        className="px-4 py-2 bg-amber-50 border-b border-amber-200 text-[0.78rem] leading-snug text-amber-900"
+      >
+        AAC education, not medical advice. For clinical guidance about your child, consult a qualified speech-language therapist.
       </div>
 
       {/* Messages */}
@@ -96,7 +105,7 @@ export default function ParentChat() {
             <div className="text-5xl">&#x1F4AC;</div>
             <div className="text-xl font-bold text-gray-700">Ask anything</div>
             <div className="text-sm text-gray-400 text-center leading-relaxed max-w-[340px]">
-              Get evidence-informed answers about your child&apos;s AAC, vocabulary, and communication strategy.
+              General AAC education for parents. For questions about a specific child, please consult a qualified speech-language therapist.
             </div>
             <div className="flex flex-col gap-2 mt-2 w-full max-w-sm">
               {SUGGESTIONS.map((s) => (

--- a/src/lib/kids-mode/__tests__/policy.test.ts
+++ b/src/lib/kids-mode/__tests__/policy.test.ts
@@ -1,0 +1,246 @@
+// @ts-nocheck - bun:test types not wired to main tsconfig; run with `bun test`
+/**
+ * Kids-Mode policy tests — run with `bun test`.
+ *
+ * Covers:
+ *   - safe / moderate / dangerous / admin tier behaviour
+ *   - network allowlist + subdomain matching
+ *   - filesystem safe-root enforcement
+ *   - parental override grant + expiry + revoke
+ *   - admin override is rejected
+ *   - content filter integration
+ *   - activity log captures every decision
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { __resetActivityLogForTests, readActivity } from '../activity-log';
+import { KidsModePolicy, createDefaultConfig } from '../policy';
+
+let tmp = '';
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'kids-mode-test-'));
+  process.env.KIDS_MODE_DATA_DIR = tmp;
+  process.env.KIDS_MODE_PARENT_SALT = 'test-salt';
+  await __resetActivityLogForTests();
+});
+
+afterEach(async () => {
+  delete process.env.KIDS_MODE_DATA_DIR;
+  delete process.env.KIDS_MODE_PARENT_SALT;
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('tier defaults', () => {
+  test('safe capabilities are always allowed', async () => {
+    const p = new KidsModePolicy();
+    const d = await p.check({ capability: 'fs.read', resource: '/anywhere' });
+    expect(d.allowed).toBe(true);
+    if (d.allowed) {
+      expect(d.tier).toBe('safe');
+      expect(d.viaOverride).toBe(false);
+    }
+  });
+
+  test('admin capabilities are hard-blocked even with override attempt', async () => {
+    const p = new KidsModePolicy();
+    expect(() =>
+      p.grantOverride({
+        capability: 'admin.policy',
+        durationMs: 60_000,
+        grantedBy: 'parent-1',
+      }),
+    ).toThrow();
+    const d = await p.check({ capability: 'admin.account' });
+    expect(d.allowed).toBe(false);
+    if (!d.allowed) expect(d.code).toBe('admin_forbidden');
+  });
+
+  test('disabled policy passes everything without logging', async () => {
+    const cfg = { ...createDefaultConfig(), enabled: false };
+    const p = new KidsModePolicy(cfg);
+    const d = await p.check({ capability: 'admin.billing' });
+    expect(d.allowed).toBe(true);
+    const log = await readActivity();
+    expect(log).toHaveLength(0);
+  });
+});
+
+describe('network allowlist', () => {
+  test('allowlisted host passes', async () => {
+    const p = new KidsModePolicy();
+    const d = await p.check({ capability: 'net.http', resource: 'https://arasaac.org/api/x' });
+    expect(d.allowed).toBe(true);
+  });
+
+  test('subdomain of allowlisted host passes', async () => {
+    const p = new KidsModePolicy();
+    const d = await p.check({
+      capability: 'net.http',
+      resource: 'https://api.arasaac.org/some/path',
+    });
+    expect(d.allowed).toBe(true);
+  });
+
+  test('non-allowlisted host is denied with not_allowlisted', async () => {
+    const p = new KidsModePolicy();
+    const d = await p.check({ capability: 'net.http', resource: 'https://evil.example/x' });
+    expect(d.allowed).toBe(false);
+    if (!d.allowed) expect(d.code).toBe('not_allowlisted');
+  });
+
+  test('missing url on a network capability is denied', async () => {
+    const p = new KidsModePolicy();
+    const d = await p.check({ capability: 'net.http' });
+    expect(d.allowed).toBe(false);
+    if (!d.allowed) expect(d.code).toBe('not_allowlisted');
+  });
+
+  test('malformed url is denied', async () => {
+    const p = new KidsModePolicy();
+    const d = await p.check({ capability: 'net.http', resource: 'not-a-url' });
+    expect(d.allowed).toBe(false);
+  });
+});
+
+describe('filesystem safe roots', () => {
+  test('write under a safe root passes', async () => {
+    const cfg = createDefaultConfig();
+    cfg.safeWriteRoots = ['/tmp/jr-sandbox'];
+    const p = new KidsModePolicy(cfg);
+    const d = await p.check({ capability: 'fs.write', resource: '/tmp/jr-sandbox/draw.png' });
+    expect(d.allowed).toBe(true);
+  });
+
+  test('write outside safe root is denied', async () => {
+    const cfg = createDefaultConfig();
+    cfg.safeWriteRoots = ['/tmp/jr-sandbox'];
+    const p = new KidsModePolicy(cfg);
+    const d = await p.check({ capability: 'fs.write', resource: '/etc/passwd' });
+    expect(d.allowed).toBe(false);
+    if (!d.allowed) expect(d.code).toBe('fs_outside_safe_root');
+  });
+
+  test('write with no resource is denied', async () => {
+    const p = new KidsModePolicy();
+    const d = await p.check({ capability: 'fs.write' });
+    expect(d.allowed).toBe(false);
+  });
+});
+
+describe('parental override', () => {
+  test('override lifts a dangerous capability for the configured window', async () => {
+    const p = new KidsModePolicy();
+    const ovr = p.grantOverride({
+      capability: 'media.camera',
+      durationMs: 60_000,
+      grantedBy: 'parent-clerk-id',
+    });
+    expect(ovr.capability).toBe('media.camera');
+
+    const d = await p.check({ capability: 'media.camera', reason: 'video-call' });
+    expect(d.allowed).toBe(true);
+    if (d.allowed) expect(d.viaOverride).toBe(true);
+
+    const log = await readActivity();
+    const entry = log.find((e) => e.capability === 'media.camera');
+    expect(entry?.outcome).toBe('override_used');
+    expect(entry?.parentHash).toMatch(/^[a-f0-9]{32}$/);
+    // raw parent id never leaks
+    expect(entry?.parentHash).not.toContain('parent-clerk-id');
+  });
+
+  test('expired override no longer lifts the capability', async () => {
+    const p = new KidsModePolicy();
+    p.grantOverride({
+      capability: 'agent.spawn',
+      durationMs: 1, // expires almost immediately
+      grantedBy: 'parent-1',
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    const d = await p.check({ capability: 'agent.spawn' });
+    expect(d.allowed).toBe(false);
+    if (!d.allowed) expect(d.code).toBe('override_required');
+  });
+
+  test('override duration is clamped to 24h', () => {
+    const p = new KidsModePolicy();
+    const ovr = p.grantOverride({
+      capability: 'media.camera',
+      durationMs: 10 * 24 * 60 * 60 * 1000,
+      grantedBy: 'parent-1',
+    });
+    const span = Date.parse(ovr.expiresAt) - Date.parse(ovr.grantedAt);
+    expect(span).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+  });
+
+  test('revokeOverride removes the grant', async () => {
+    const p = new KidsModePolicy();
+    p.grantOverride({
+      capability: 'media.camera',
+      durationMs: 60_000,
+      grantedBy: 'parent-1',
+    });
+    expect(p.revokeOverride('media.camera')).toBe(true);
+    const d = await p.check({ capability: 'media.camera' });
+    expect(d.allowed).toBe(false);
+  });
+
+  test('resource-scoped override only matches the same resource', async () => {
+    const p = new KidsModePolicy();
+    p.grantOverride({
+      capability: 'net.http',
+      durationMs: 60_000,
+      grantedBy: 'parent-1',
+      resource: 'https://specific.example/x',
+    });
+    const a = await p.check({ capability: 'net.http', resource: 'https://specific.example/x' });
+    const b = await p.check({ capability: 'net.http', resource: 'https://other.example/y' });
+    expect(a.allowed).toBe(true);
+    expect(b.allowed).toBe(false);
+  });
+});
+
+describe('content filter', () => {
+  test('returns text untouched when no filter configured', async () => {
+    const p = new KidsModePolicy();
+    const r = await p.filterContent('hello world');
+    expect(r.text).toBe('hello world');
+    expect(r.modified).toBe(false);
+  });
+
+  test('logs a denial when the filter modifies output', async () => {
+    const cfg = createDefaultConfig();
+    cfg.contentFilter = (text) => ({
+      text: text.replace(/badword/g, '****'),
+      modified: text.includes('badword'),
+      flags: ['profanity'],
+    });
+    const p = new KidsModePolicy(cfg);
+    const r = await p.filterContent('this has badword in it');
+    expect(r.text).toBe('this has **** in it');
+    expect(r.modified).toBe(true);
+    const log = await readActivity();
+    const entry = log.find((e) => e.capability === 'content.agent');
+    expect(entry).toBeTruthy();
+    expect(entry?.reason).toContain('profanity');
+  });
+});
+
+describe('activity log', () => {
+  test('every decision writes one entry', async () => {
+    const p = new KidsModePolicy();
+    await p.check({ capability: 'fs.read', resource: '/ok' });
+    await p.check({ capability: 'net.http', resource: 'https://evil.example' });
+    await p.check({ capability: 'admin.policy' });
+    const log = await readActivity();
+    // entries are returned newest-first
+    expect(log).toHaveLength(3);
+    expect(log[0].outcome).toBe('denied');
+    expect(log[0].denyCode).toBe('admin_forbidden');
+    expect(log[2].outcome).toBe('allowed');
+  });
+});

--- a/src/lib/kids-mode/activity-log.ts
+++ b/src/lib/kids-mode/activity-log.ts
@@ -1,0 +1,67 @@
+/**
+ * Kids-Mode Activity Log
+ *
+ * Append-only JSONL store of every capability decision. Lives at
+ * `data/kids-mode/activity.jsonl` to match the existing data/ pattern
+ * (see feedback-store, consent audit-store).
+ *
+ * The log is meant for parent review, not surveillance. We never write
+ * the raw text the child typed, never the agent's response body — only
+ * the capability name, an optional opaque resource string, and the
+ * decision outcome.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { ActivityLogEntry } from './types';
+
+function dataDir(): string {
+  // Tests override CWD; production resolves to repo root at runtime.
+  const override = process.env.KIDS_MODE_DATA_DIR;
+  if (override) return override;
+  return path.join(process.cwd(), 'data', 'kids-mode');
+}
+
+function logFile(): string {
+  return path.join(dataDir(), 'activity.jsonl');
+}
+
+export function newEntryId(): string {
+  return randomBytes(8).toString('hex');
+}
+
+/** Hash a parent identifier so the raw id never lands on disk. */
+export function hashParentId(parentId: string): string {
+  const salt = process.env.KIDS_MODE_PARENT_SALT ?? 'kids-mode-default-salt';
+  return createHash('sha256').update(`${salt}:${parentId}`).digest('hex').slice(0, 32);
+}
+
+export async function appendActivity(entry: ActivityLogEntry): Promise<void> {
+  const dir = dataDir();
+  await fs.mkdir(dir, { recursive: true });
+  await fs.appendFile(logFile(), JSON.stringify(entry) + '\n', 'utf8');
+}
+
+export async function readActivity(limit = 200): Promise<ActivityLogEntry[]> {
+  try {
+    const raw = await fs.readFile(logFile(), 'utf8');
+    const lines = raw.trim().split('\n').filter(Boolean);
+    return lines
+      .slice(-limit)
+      .reverse()
+      .map((l) => JSON.parse(l) as ActivityLogEntry);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+/** Test helper: wipe the log file. Not exposed via the public barrel. */
+export async function __resetActivityLogForTests(): Promise<void> {
+  try {
+    await fs.rm(logFile());
+  } catch {
+    /* file may not exist; ignore */
+  }
+}

--- a/src/lib/kids-mode/index.ts
+++ b/src/lib/kids-mode/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Kids-Mode Capability Policy — public barrel.
+ *
+ * Import from `@/lib/kids-mode` to reach the policy object, types,
+ * and read helpers. Internal helpers (activity log writers, hash
+ * functions) are not re-exported.
+ */
+
+export {
+  KidsModePolicy,
+  createDefaultConfig,
+  DEFAULT_TIER_MAP,
+  getKidsModePolicy,
+  setKidsModePolicy,
+} from './policy';
+
+export { readActivity } from './activity-log';
+
+export type {
+  ActivityLogEntry,
+  CapabilityDecision,
+  CapabilityRequest,
+  ContentFilterResult,
+  DenyCode,
+  KidsCapability,
+  KidsCapabilityTier,
+  KidsModeConfig,
+  ParentalOverride,
+} from './types';

--- a/src/lib/kids-mode/policy.ts
+++ b/src/lib/kids-mode/policy.ts
@@ -1,0 +1,395 @@
+/**
+ * Kids-Mode Capability Policy
+ *
+ * Deny-by-default capability gate for 8gent Jr. Every privileged action —
+ * tool execution, network call, filesystem write, agent spawn — runs
+ * through `KidsModePolicy.check()` first. The policy returns a structured
+ * decision and writes one entry to the activity log per call.
+ *
+ * Design:
+ *   - Capabilities map to one of four tiers (`safe`, `moderate`, `dangerous`,
+ *     `admin`). `admin` is never granted in kids mode, period.
+ *   - Network requests must hit an allowlisted host or be denied.
+ *   - Filesystem writes must land under one of `safeWriteRoots`.
+ *   - A parent can issue a time-bounded `ParentalOverride` to lift a single
+ *     capability for a specific window. Overrides expire and cannot grant
+ *     `admin`. Issuing an override is itself an admin action that happens
+ *     in the parent UI, not from the child surface.
+ *   - The `contentFilter` hook lets callers run age-appropriate redaction
+ *     on agent output before it reaches the child. The policy treats it
+ *     as a separate concern from capability gating.
+ *
+ * Reference: github.com/8gi-foundation/8gentjr/issues/164
+ */
+
+import {
+  appendActivity,
+  hashParentId,
+  newEntryId,
+} from './activity-log';
+import type {
+  ActivityLogEntry,
+  CapabilityDecision,
+  CapabilityRequest,
+  ContentFilterResult,
+  KidsCapability,
+  KidsCapabilityTier,
+  KidsModeConfig,
+  ParentalOverride,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Default tier map
+// ---------------------------------------------------------------------------
+
+/**
+ * Default tier assignment. Conservative on purpose — anything that could
+ * surprise a parent starts at `dangerous` or above.
+ */
+export const DEFAULT_TIER_MAP: Partial<Record<KidsCapability, KidsCapabilityTier>> = {
+  // safe surfaces
+  'tool.read': 'safe',
+  'fs.read': 'safe',
+  'media.audio': 'safe',
+
+  // moderate — gated by allowlist or safe roots
+  'fs.write': 'moderate',
+  'net.http': 'moderate',
+  'net.websocket': 'moderate',
+  'tool.write': 'moderate',
+  'tool.execute': 'moderate',
+
+  // dangerous — needs parental override
+  'media.camera': 'dangerous',
+  'media.microphone': 'dangerous',
+  'agent.spawn': 'dangerous',
+  'agent.stop': 'dangerous',
+
+  // admin — never granted in kids mode
+  'admin.policy': 'admin',
+  'admin.account': 'admin',
+  'admin.billing': 'admin',
+};
+
+/**
+ * Default config used when 8gent Jr boots into kids mode. Production code
+ * should call `createDefaultConfig()` and override only the fields it
+ * cares about — this guarantees forward-compat as new fields are added.
+ */
+export function createDefaultConfig(): KidsModeConfig {
+  return {
+    enabled: true,
+    defaultTier: 'dangerous',
+    tierMap: { ...DEFAULT_TIER_MAP },
+    networkAllowlist: [
+      // educational + 8gent first-party only by default
+      '8gentjr.com',
+      '8gent.app',
+      'arasaac.org', // pictogram library already used by toolshed
+    ],
+    safeWriteRoots: [],
+    activityBufferSize: 50,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function hostMatches(allowlist: string[], url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return allowlist.some((entry) => {
+    const norm = entry.trim().toLowerCase();
+    if (!norm) return false;
+    return host === norm || host.endsWith(`.${norm}`);
+  });
+}
+
+function pathInRoot(path: string, root: string): boolean {
+  // Naive prefix check is fine here — callers are expected to pass
+  // resolved absolute paths. We never operate on user-supplied raw input.
+  const normRoot = root.replace(/\/+$/, '');
+  return path === normRoot || path.startsWith(`${normRoot}/`);
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+export class KidsModePolicy {
+  private config: KidsModeConfig;
+  private overrides: ParentalOverride[] = [];
+
+  constructor(config: KidsModeConfig = createDefaultConfig()) {
+    this.config = config;
+  }
+
+  /** Replace the whole config. Triggered from parent settings. */
+  setConfig(config: KidsModeConfig): void {
+    this.config = config;
+  }
+
+  getConfig(): Readonly<KidsModeConfig> {
+    return this.config;
+  }
+
+  /** Tier for a capability, after applying the user's tierMap overrides. */
+  tierFor(capability: KidsCapability): KidsCapabilityTier {
+    return this.config.tierMap[capability] ?? this.config.defaultTier;
+  }
+
+  /**
+   * Decide whether a capability request is allowed. Always writes one
+   * entry to the activity log. The caller is responsible for honouring
+   * the decision — the policy does not perform the action itself.
+   */
+  async check(req: CapabilityRequest): Promise<CapabilityDecision> {
+    // Master switch off = adult mode, everything passes without logging.
+    if (!this.config.enabled) {
+      return { allowed: true, tier: 'safe', viaOverride: false };
+    }
+
+    const tier = this.tierFor(req.capability);
+    const decision = this.decide(req, tier);
+    await this.log(req, tier, decision);
+    return decision;
+  }
+
+  private decide(req: CapabilityRequest, tier: KidsCapabilityTier): CapabilityDecision {
+    // admin is hard-blocked, override or not.
+    if (tier === 'admin') {
+      return {
+        allowed: false,
+        tier,
+        code: 'admin_forbidden',
+        message: `Capability '${req.capability}' is admin-only and cannot run in kids mode.`,
+      };
+    }
+
+    // safe is always allowed.
+    if (tier === 'safe') {
+      return { allowed: true, tier, viaOverride: false };
+    }
+
+    // moderate: needs allowlist match (network) or safe-root match (fs writes).
+    if (tier === 'moderate') {
+      if (req.capability === 'net.http' || req.capability === 'net.websocket') {
+        if (!req.resource) {
+          return {
+            allowed: false,
+            tier,
+            code: 'not_allowlisted',
+            message: 'Network capability requires a resource URL.',
+          };
+        }
+        if (!hostMatches(this.config.networkAllowlist, req.resource)) {
+          // network can still be lifted via override
+          if (this.findActiveOverride(req.capability, req.resource)) {
+            return { allowed: true, tier, viaOverride: true };
+          }
+          return {
+            allowed: false,
+            tier,
+            code: 'not_allowlisted',
+            message: `Host for '${req.resource}' is not in the kids-mode network allowlist.`,
+          };
+        }
+        return { allowed: true, tier, viaOverride: false };
+      }
+
+      if (req.capability === 'fs.write') {
+        if (!req.resource) {
+          return {
+            allowed: false,
+            tier,
+            code: 'fs_outside_safe_root',
+            message: 'Filesystem write requires a target path.',
+          };
+        }
+        const inSafeRoot = this.config.safeWriteRoots.some((r) => pathInRoot(req.resource as string, r));
+        if (!inSafeRoot) {
+          if (this.findActiveOverride(req.capability, req.resource)) {
+            return { allowed: true, tier, viaOverride: true };
+          }
+          return {
+            allowed: false,
+            tier,
+            code: 'fs_outside_safe_root',
+            message: `Path '${req.resource}' is outside the kids-mode safe write roots.`,
+          };
+        }
+        return { allowed: true, tier, viaOverride: false };
+      }
+
+      // Other moderate capabilities (tool.execute, tool.write) pass.
+      return { allowed: true, tier, viaOverride: false };
+    }
+
+    // dangerous: requires an active, scoped override.
+    const ovr = this.findActiveOverride(req.capability, req.resource);
+    if (ovr) {
+      return { allowed: true, tier, viaOverride: true };
+    }
+    return {
+      allowed: false,
+      tier,
+      code: 'override_required',
+      message: `Capability '${req.capability}' is dangerous and needs a parental override.`,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Parental overrides
+  // -------------------------------------------------------------------------
+
+  /**
+   * Register a parental override. The caller — typically a server-side
+   * route gated by Clerk auth — is responsible for verifying that
+   * `grantedBy` actually corresponds to the authenticated parent. The
+   * policy only checks structural validity and trims expired overrides.
+   *
+   * Returns the override that was registered, with an `expiresAt` clamped
+   * to a maximum of 24 hours from `grantedAt`.
+   */
+  grantOverride(input: {
+    capability: KidsCapability;
+    durationMs: number;
+    grantedBy: string;
+    resource?: string;
+  }): ParentalOverride {
+    const tier = this.tierFor(input.capability);
+    if (tier === 'admin') {
+      throw new Error(`Cannot grant override for admin capability '${input.capability}'.`);
+    }
+    const MAX_DURATION_MS = 24 * 60 * 60 * 1000;
+    const duration = Math.max(0, Math.min(input.durationMs, MAX_DURATION_MS));
+    const grantedAt = Date.now();
+    const expiresAt = grantedAt + duration;
+    const ovr: ParentalOverride = {
+      capability: input.capability,
+      grantedAt: new Date(grantedAt).toISOString(),
+      expiresAt: new Date(expiresAt).toISOString(),
+      grantedBy: input.grantedBy,
+      resource: input.resource,
+    };
+    // Drop any existing override for the same (capability, resource) pair.
+    this.overrides = this.overrides.filter(
+      (o) => !(o.capability === input.capability && o.resource === input.resource),
+    );
+    this.overrides.push(ovr);
+    return ovr;
+  }
+
+  revokeOverride(capability: KidsCapability, resource?: string): boolean {
+    const before = this.overrides.length;
+    this.overrides = this.overrides.filter(
+      (o) => !(o.capability === capability && o.resource === resource),
+    );
+    return this.overrides.length < before;
+  }
+
+  listOverrides(): ParentalOverride[] {
+    this.pruneExpired();
+    return [...this.overrides];
+  }
+
+  private findActiveOverride(
+    capability: KidsCapability,
+    resource: string | undefined,
+  ): ParentalOverride | undefined {
+    this.pruneExpired();
+    return this.overrides.find((o) => {
+      if (o.capability !== capability) return false;
+      // Empty override resource matches any; otherwise require exact match.
+      if (!o.resource) return true;
+      return o.resource === resource;
+    });
+  }
+
+  private pruneExpired(): void {
+    const now = Date.now();
+    this.overrides = this.overrides.filter((o) => Date.parse(o.expiresAt) > now);
+  }
+
+  // -------------------------------------------------------------------------
+  // Content filter
+  // -------------------------------------------------------------------------
+
+  /**
+   * Run the configured content filter on agent output. Returns the
+   * original text untouched when no filter is set. Always logs whether
+   * the filter modified the text so parent review can spot patterns.
+   */
+  async filterContent(text: string, source = 'agent'): Promise<ContentFilterResult> {
+    const filter = this.config.contentFilter;
+    if (!filter) {
+      return { text, modified: false };
+    }
+    const result = await filter(text);
+    if (result.modified) {
+      const entry: ActivityLogEntry = {
+        id: newEntryId(),
+        ts: nowIso(),
+        capability: `content.${source}`,
+        outcome: 'denied',
+        tier: 'moderate',
+        denyCode: 'tier_blocked',
+        reason: result.flags?.join(',') ?? 'content_filtered',
+      };
+      await appendActivity(entry);
+    }
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Activity log
+  // -------------------------------------------------------------------------
+
+  private async log(
+    req: CapabilityRequest,
+    tier: KidsCapabilityTier,
+    decision: CapabilityDecision,
+  ): Promise<void> {
+    const entry: ActivityLogEntry = {
+      id: newEntryId(),
+      ts: nowIso(),
+      capability: req.capability,
+      resource: req.resource,
+      reason: req.reason,
+      outcome: decision.allowed ? (decision.viaOverride ? 'override_used' : 'allowed') : 'denied',
+      tier,
+    };
+    if (!decision.allowed) entry.denyCode = decision.code;
+    if (decision.allowed && decision.viaOverride) {
+      const ovr = this.findActiveOverride(req.capability, req.resource);
+      if (ovr) entry.parentHash = hashParentId(ovr.grantedBy);
+    }
+    await appendActivity(entry);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton helpers
+// ---------------------------------------------------------------------------
+
+let _instance: KidsModePolicy | null = null;
+
+/** Get (and lazily create) the process-wide kids-mode policy. */
+export function getKidsModePolicy(): KidsModePolicy {
+  if (!_instance) _instance = new KidsModePolicy();
+  return _instance;
+}
+
+/** Replace the singleton — used by tests and by parent settings flows. */
+export function setKidsModePolicy(policy: KidsModePolicy): void {
+  _instance = policy;
+}

--- a/src/lib/kids-mode/types.ts
+++ b/src/lib/kids-mode/types.ts
@@ -1,0 +1,147 @@
+/**
+ * Kids-Mode Capability Policy — Types
+ *
+ * Defines the capability vocabulary used to gate every privileged action in
+ * 8gent Jr. Mirrors the tier system being added to 8gent-code (#2087) so a
+ * single policy concept covers both the parent agent kernel and the kids OS.
+ *
+ * Reference: docs/specs/HOLAOS-EXTRACTIONS.md Section 8
+ *            github.com/8gi-foundation/8gentjr/issues/164
+ */
+
+// ---------------------------------------------------------------------------
+// Capability tiers
+// ---------------------------------------------------------------------------
+
+/**
+ * Tier of a capability. Ordered from least to most privileged.
+ *
+ * - `safe`      always allowed in kids mode (drawing, AAC, local playback)
+ * - `moderate`  allowed when the policy explicitly lists the resource
+ *               (e.g. an allowlisted educational domain)
+ * - `dangerous` denied by default; can only be granted via a time-limited
+ *               parental override
+ * - `admin`     never granted in kids mode, override or not
+ *               (deleting account data, billing, changing the policy itself)
+ */
+export type KidsCapabilityTier = 'safe' | 'moderate' | 'dangerous' | 'admin';
+
+/** Fixed names for capabilities the policy knows about. Extend as new
+ *  surfaces are added; unknown names fall through to `defaultTier`. */
+export type KidsCapability =
+  | 'tool.read'
+  | 'tool.write'
+  | 'tool.execute'
+  | 'fs.read'
+  | 'fs.write'
+  | 'net.http'
+  | 'net.websocket'
+  | 'media.audio'
+  | 'media.camera'
+  | 'media.microphone'
+  | 'agent.spawn'
+  | 'agent.stop'
+  | 'admin.policy'
+  | 'admin.account'
+  | 'admin.billing'
+  | (string & {}); // allow forward-compatible extension without losing autocomplete
+
+// ---------------------------------------------------------------------------
+// Policy decisions
+// ---------------------------------------------------------------------------
+
+export interface CapabilityRequest {
+  capability: KidsCapability;
+  /** Optional resource string (URL, path, tool id) the capability acts on. */
+  resource?: string;
+  /** Free-form context for the activity log. Never log PII. */
+  reason?: string;
+}
+
+export type DenyCode =
+  | 'tier_blocked'
+  | 'not_allowlisted'
+  | 'admin_forbidden'
+  | 'override_required'
+  | 'override_expired'
+  | 'fs_outside_safe_root';
+
+export type CapabilityDecision =
+  | { allowed: true; tier: KidsCapabilityTier; viaOverride: boolean }
+  | { allowed: false; tier: KidsCapabilityTier; code: DenyCode; message: string };
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface KidsModeConfig {
+  /** Master switch. If false, the module is a no-op (8gent OS adult flow). */
+  enabled: boolean;
+  /** Tier assigned to capabilities not explicitly named in `tierMap`. */
+  defaultTier: KidsCapabilityTier;
+  /** Per-capability tier overrides. */
+  tierMap: Partial<Record<KidsCapability, KidsCapabilityTier>>;
+  /** Hostnames (no scheme, no port) that are always reachable at the `moderate`
+   *  tier. Subdomains match by suffix. */
+  networkAllowlist: string[];
+  /** Filesystem roots (absolute, no trailing slash) the child may write to.
+   *  Reads are allowed everywhere within the project sandbox; writes are
+   *  denied unless the path lives under one of these. */
+  safeWriteRoots: string[];
+  /** Optional content filter. Returns the (possibly redacted) text plus a
+   *  flag indicating whether the original was modified. */
+  contentFilter?: (text: string) => Promise<ContentFilterResult> | ContentFilterResult;
+  /** Maximum activity log entries kept in memory before flushing to the
+   *  store. The store still receives every entry; this only bounds RAM. */
+  activityBufferSize: number;
+}
+
+export interface ContentFilterResult {
+  text: string;
+  modified: boolean;
+  /** Optional categories the filter flagged (e.g. `violence`, `adult`). */
+  flags?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Parental override
+// ---------------------------------------------------------------------------
+
+/**
+ * A time-bounded grant that elevates a single capability past its default
+ * tier. The grant is created server-side after parent auth (Clerk session
+ * or VPC-style email token) and has a hard expiry.
+ */
+export interface ParentalOverride {
+  capability: KidsCapability;
+  /** ISO-8601 timestamp when the override starts. */
+  grantedAt: string;
+  /** ISO-8601 timestamp when the override expires. */
+  expiresAt: string;
+  /** Opaque identifier for the parent who granted it (e.g. Clerk user id).
+   *  Stored hashed in the activity log; raw form is never written to disk. */
+  grantedBy: string;
+  /** Optional resource string this override is scoped to. Empty = any
+   *  resource for that capability. */
+  resource?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Activity log
+// ---------------------------------------------------------------------------
+
+export interface ActivityLogEntry {
+  /** ISO-8601 timestamp. */
+  ts: string;
+  /** Random 16-hex id, unique per entry. */
+  id: string;
+  capability: KidsCapability;
+  resource?: string;
+  reason?: string;
+  outcome: 'allowed' | 'denied' | 'override_used';
+  tier: KidsCapabilityTier;
+  /** Present when outcome is `denied`. */
+  denyCode?: DenyCode;
+  /** Hashed parent id when `outcome === 'override_used'`. */
+  parentHash?: string;
+}


### PR DESCRIPTION
## Summary

Implements the kids-mode capability policy from issue #164. Deny-by-default gate that every privileged action in 8gent Jr now runs through, with an append-only activity log for parent review.

- `KidsCapabilityTier`: `safe` / `moderate` / `dangerous` / `admin`
- Network requests gated by an allowlist (suffix-matched subdomains)
- Filesystem writes restricted to configured `safeWriteRoots`
- `ParentalOverride`: scoped to capability + optional resource, max 24h, revocable, parent id hashed before disk
- Content filter integration point with logged redactions
- Activity log writes one JSONL entry per decision to `data/kids-mode/activity.jsonl`

Acceptance criteria covered:

- [x] `KidsModePolicy` defined with tool tier restrictions
- [x] Network allowlist for kid-safe domains
- [x] Content output passes through filter (when configured) before display
- [x] Activity summary readable via `readActivity()` for parent UI
- [x] Policy is the default (`enabled: true` in `createDefaultConfig()`)
- [x] Parent adjusts via `setConfig` / `grantOverride` (server-side, behind Clerk)
- [x] TypeScript types for `KidsCapabilityTier`, `KidsModeConfig`, `ActivityLogEntry`

Out of scope (per issue): COPPA audit, parental control UI, multi-child profiles, session time limits (left as a config field for a follow-up).

## Files

- `src/lib/kids-mode/types.ts` - capability vocabulary, decision types, config shape
- `src/lib/kids-mode/policy.ts` - `KidsModePolicy` class + default tier map + singleton helpers
- `src/lib/kids-mode/activity-log.ts` - JSONL writer + reader, parent-id hashing
- `src/lib/kids-mode/index.ts` - public barrel
- `src/lib/kids-mode/__tests__/policy.test.ts` - 19 tests

## Test plan

- [x] `bun test src/lib/kids-mode` - 19/19 pass
- [x] `bun test` (full suite) - 53/53 pass, no regressions
- [x] `npx tsc --noEmit` - clean
- [ ] Wire into the agent runtime (separate PR)
- [ ] Hook the parent-facing override UI to `grantOverride` (separate UI task)

Closes #164