### PR TITLE
chore(ci): notify governance on push to main

### DIFF
--- a/.github/workflows/notify-governance.yml
+++ b/.github/workflows/notify-governance.yml
@@ -1,0 +1,18 @@
+name: Notify governance on push to main
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to 8gi-governance
+        env:
+          GH_TOKEN: ${{ secrets.GH_SYNC_PAT }}
+        run: |
+          gh api repos/8gi-foundation/8gi-governance/dispatches \
+            --method POST \
+            --field event_type="repo-push" \
+            --field client_payload='{"repo":"${{ github.repository }}","ref":"${{ github.ref }}"}'


### PR DESCRIPTION
Fires `repository_dispatch` to `8gi-governance` on every push to main, triggering STATUS.md regeneration + AGENTS.md sync across all 8GI repos. Requires `GH_SYNC_PAT` secret (repo scope PAT). Part of 8gi-foundation/8gi-governance#191.