### PR TITLE
feat(math): /math route with Wave lesson, calm-mode aware sketches

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,29 @@
+# 8gent Jr — Roadmap
+
+_Living roadmap. Generated 2026-06-14 from repo state. Edit freely — the glasses read this aloud._
+
+## Now / In progress
+- [ ] **Math route** — finish `feat/math-route`: the Wave lesson, calm-mode sketches, and Dock entry are built but uncommitted-to-main and not yet merged.
+- [ ] **Fix the broken build** — `bun run build` exits 1 prerendering `/talk/core` and `/math/wave`; add `dynamic = 'force-dynamic'` and a build CI job.
+- [ ] **Truthful onboarding copy** — onboarding claims "all data stays on this device", but prod TTS and autocomplete go to ElevenLabs and Groq; soften to match `/privacy`.
+
+## Next
+- [ ] **Wire consent to the real VPC engine** — default path skips the email-plus flow; route onboarding through `/api/consent/initiate` and gate egress on `parentEmailConfirmed`.
+- [ ] **Durable VPC scheduling** — the 24h second email uses in-process `setTimeout`, which Vercel kills; move to Vercel Cron or a queue.
+- [ ] **Keyboard and switch-access taps** — `TapCard` fires only on pointer-up, so switch hardware and screen readers cannot select a word; add click and Enter/Space.
+- [ ] **Social preview images** — `public/og.png` and `public/logo.png` are referenced but missing; add them or a dynamic OG image.
+
+## Later
+- [ ] **Public front door** — the home page is redirect-only; build a marketing route group for parents, educators, and therapists.
+- [ ] **Offline support** — add a service worker and cache the app shell, last board, and a subset of ARASAAC pictograms for PWA offline use.
+- [ ] **Simplify navigation** — the Dock buries 14 flat items in one More overlay; mirror the iOS Daily / Play & Explore / For grown-ups structure.
+- [ ] **Wire or delete dead motor-lock** — `src/lib/motor-lock.ts` exists but nothing imports it, so web still duplicates chips on rapid taps.
+- [ ] **Changelog and version** — stuck at 0.1.0 with no CHANGELOG across ~15 shipped PRs; add one and bump.
+
+## Done (recent)
+- **Math route v1** — `/math` with a Wave lesson and calm-mode-aware sketches.
+- **Educator and government guides** — `/guides/educator` IEP walkthrough and `/guides/government` public-sector brief.
+- **EU AI Act guard** — CI blocks emotion and affect-detection imports.
+- **GLP adaptive AAC layer** — Blend engine, on-device stage estimator, predictive next-word strip, and personal vocab promotion.
+- **Email-plus VPC consent flow** — COPPA child-account flow with age gate, HMAC tokens, and an immutable audit log.
+- **On-device smart suggestions** — SmolLM2-135M plus a rules engine for local autocomplete.

--- a/src/app/math/page.tsx
+++ b/src/app/math/page.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import SketchFrame from '@/components/math/SketchFrame';
+import { useCalmMode } from '@/components/math/useCalmMode';
+
+const PRIMARY = '#E8610A';
+const CANVAS_BG = '#1A1612';
+
+interface Lesson {
+  id: string;
+  href: string | null;
+  title: string;
+  subtitle: string;
+  preview: 'wave' | 'amplitude' | 'layered' | 'garden';
+}
+
+const LESSONS: Lesson[] = [
+  {
+    id: 'wave',
+    href: '/math/wave',
+    title: 'Wave',
+    subtitle: 'Numbers can wiggle',
+    preview: 'wave',
+  },
+  {
+    id: 'amplitude',
+    href: null,
+    title: 'Tall and Small',
+    subtitle: 'Two knobs, two effects',
+    preview: 'amplitude',
+  },
+  {
+    id: 'layered',
+    href: null,
+    title: 'Layers',
+    subtitle: 'Adding waves makes new shapes',
+    preview: 'layered',
+  },
+  {
+    id: 'garden',
+    href: null,
+    title: 'Garden',
+    subtitle: 'Tiny rules, big patterns',
+    preview: 'garden',
+  },
+];
+
+function previewDraw(kind: Lesson['preview'], calm: boolean) {
+  return (ctx: CanvasRenderingContext2D, t: number, w: number, h: number) => {
+    ctx.fillStyle = CANVAS_BG;
+    ctx.fillRect(0, 0, w, h);
+    ctx.save();
+    ctx.shadowColor = PRIMARY;
+    ctx.shadowBlur = calm ? 8 : 12;
+    ctx.strokeStyle = PRIMARY;
+    ctx.lineWidth = 2;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+
+    if (kind === 'wave') {
+      const phase = t * 0.6;
+      for (let i = 0; i <= 80; i++) {
+        const x = (i / 80) * w;
+        const y = h / 2 + Math.sin((i / 80) * Math.PI * 2 + phase) * h * 0.22;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+    } else if (kind === 'amplitude') {
+      const breathe = 0.18 + Math.sin(t * 0.4) * 0.1;
+      for (let i = 0; i <= 80; i++) {
+        const x = (i / 80) * w;
+        const y = h / 2 + Math.sin((i / 80) * Math.PI * 2) * h * breathe;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+    } else if (kind === 'layered') {
+      for (let i = 0; i <= 80; i++) {
+        const x = (i / 80) * w;
+        const a = Math.sin((i / 80) * Math.PI * 2 + t * 0.4);
+        const b = Math.sin((i / 80) * Math.PI * 4 + t * 0.5) * 0.5;
+        const y = h / 2 + (a + b) * h * 0.18;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+    } else {
+      ctx.shadowBlur = 0;
+      ctx.fillStyle = PRIMARY;
+      const dotCount = calm ? 90 : 160;
+      for (let i = 0; i < dotCount; i++) {
+        const a = (i / dotCount) * Math.PI * 2 + t * 0.15;
+        const r = (h * 0.34) * (0.6 + 0.4 * Math.sin(a * 5 + t * 0.3));
+        const x = w / 2 + Math.cos(a) * r;
+        const y = h / 2 + Math.sin(a) * r * 0.7;
+        ctx.globalAlpha = 0.45;
+        ctx.beginPath();
+        ctx.arc(x, y, 1.4, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.restore();
+      return;
+    }
+    ctx.stroke();
+    ctx.restore();
+  };
+}
+
+export default function MathIndexPage() {
+  const router = useRouter();
+  const [calm, setCalm] = useCalmMode();
+
+  return (
+    <div className="min-h-[100dvh] flex flex-col" style={{ backgroundColor: 'var(--brand-bg)' }}>
+      <header
+        className="flex items-center justify-between px-4 py-3 relative"
+        style={{ backgroundColor: PRIMARY }}
+      >
+        <button
+          onClick={() => router.push('/')}
+          className="flex items-center gap-0.5 text-white font-medium text-lg"
+          aria-label="Back to home"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          <span>Home</span>
+        </button>
+
+        <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-white font-semibold text-xl">
+          Math
+        </span>
+
+        <button
+          onClick={() => setCalm(!calm)}
+          aria-pressed={calm}
+          className="text-white text-xs font-medium px-3 py-1.5 rounded-full bg-white/15 active:bg-white/25 transition-colors"
+        >
+          {calm ? 'Calm' : 'Lively'}
+        </button>
+      </header>
+
+      <main className="flex-1 px-4 pt-5 pb-8 max-w-xl w-full mx-auto">
+        <p
+          className="text-center text-sm mb-5 animate-[fadeUp_500ms_ease-out]"
+          style={{ color: 'var(--brand-text-soft)' }}
+        >
+          Watch what the numbers do.
+        </p>
+
+        <ul className="grid gap-4">
+          {LESSONS.map((lesson, i) => {
+            const locked = lesson.href === null;
+            return (
+              <li
+                key={lesson.id}
+                className="animate-[fadeUp_500ms_ease-out]"
+                style={{ animationDelay: `${i * 60}ms`, animationFillMode: 'backwards' }}
+              >
+                <button
+                  onClick={() => lesson.href && router.push(lesson.href)}
+                  disabled={locked}
+                  className={`w-full text-left rounded-3xl overflow-hidden border border-[color:var(--brand-border)] bg-white shadow-sm transition-transform duration-150 ease-out ${
+                    locked ? 'opacity-60 cursor-default' : 'active:scale-[0.985]'
+                  }`}
+                >
+                  <div className="aspect-[16/7] bg-[color:var(--brand-text)] relative">
+                    <SketchFrame
+                      draw={previewDraw(lesson.preview, calm)}
+                      motion={locked ? 'off' : calm ? 'gentle' : 'on'}
+                      ariaLabel={`${lesson.title} preview`}
+                      className="w-full h-full block"
+                    />
+                    {locked && (
+                      <span className="absolute top-3 right-3 text-[10px] font-semibold uppercase tracking-wider px-2 py-1 rounded-full bg-white/85 text-[color:var(--brand-text)]">
+                        Soon
+                      </span>
+                    )}
+                  </div>
+                  <div className="px-5 py-4 flex items-center justify-between gap-3">
+                    <div>
+                      <div className="font-semibold text-base" style={{ color: 'var(--brand-text)' }}>
+                        {lesson.title}
+                      </div>
+                      <div className="text-sm" style={{ color: 'var(--brand-text-soft)' }}>
+                        {lesson.subtitle}
+                      </div>
+                    </div>
+                    {!locked && (
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={PRIMARY} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                        <polyline points="9 18 15 12 9 6" />
+                      </svg>
+                    )}
+                  </div>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </main>
+
+      <style jsx>{`
+        @keyframes fadeUp {
+          from { opacity: 0; transform: translateY(8px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .animate-\\[fadeUp_500ms_ease-out\\] { animation: none !important; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/app/math/wave/page.tsx
+++ b/src/app/math/wave/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import SketchFrame from '@/components/math/SketchFrame';
+import Knob from '@/components/math/Knob';
+import { useCalmMode } from '@/components/math/useCalmMode';
+
+const PRIMARY = '#E8610A';
+const CANVAS_BG = '#1A1612';
+
+/**
+ * Lesson 1 — Wave.
+ *
+ * One sine curve, two knobs (wiggle count and speed). The point of this
+ * lesson is "numbers can wiggle, and two knobs make two different things
+ * change". No symbols, no equations on screen — the curve itself is the
+ * teacher.
+ */
+export default function WaveLessonPage() {
+  const router = useRouter();
+  const [calm, setCalm] = useCalmMode();
+  const [frequency, setFrequency] = useState(1.5);
+  const [speed, setSpeed] = useState(calm ? 0.4 : 0.8);
+
+  const draw = (ctx: CanvasRenderingContext2D, t: number, w: number, h: number) => {
+    ctx.fillStyle = CANVAS_BG;
+    ctx.fillRect(0, 0, w, h);
+
+    const introFade = Math.min(1, t / 0.6);
+    const phase = t * speed * 1.6;
+    const amp = h * 0.3;
+    const cy = h / 2;
+
+    ctx.save();
+    ctx.globalAlpha = introFade;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.shadowColor = PRIMARY;
+    ctx.shadowBlur = calm ? 14 : 22;
+    ctx.strokeStyle = PRIMARY;
+    ctx.lineWidth = 3;
+
+    ctx.beginPath();
+    const steps = 240;
+    for (let i = 0; i <= steps; i++) {
+      const x = (i / steps) * w;
+      const angle = (i / steps) * frequency * Math.PI * 2 + phase;
+      const y = cy + Math.sin(angle) * amp;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+
+    ctx.shadowBlur = 0;
+    ctx.fillStyle = '#FFFFFF22';
+    ctx.fillRect(0, cy - 0.5, w, 1);
+    ctx.restore();
+  };
+
+  const hint =
+    frequency < 2 && speed < 0.5
+      ? 'Slow and gentle'
+      : frequency >= 3 && speed >= 1
+      ? 'Quick wiggles'
+      : frequency >= 3
+      ? 'Many wiggles, easy pace'
+      : speed >= 1
+      ? 'Few wiggles, lively pace'
+      : 'Nice and steady';
+
+  return (
+    <div className="min-h-[100dvh] flex flex-col" style={{ backgroundColor: 'var(--brand-bg)' }}>
+      <header
+        className="flex items-center justify-between px-4 py-3 relative"
+        style={{ backgroundColor: PRIMARY }}
+      >
+        <button
+          onClick={() => router.push('/math')}
+          className="flex items-center gap-0.5 text-white font-medium text-lg"
+          aria-label="Back to math"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          <span>Math</span>
+        </button>
+
+        <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-white font-semibold text-xl">
+          Wave
+        </span>
+
+        <button
+          onClick={() => setCalm(!calm)}
+          aria-pressed={calm}
+          className="text-white text-xs font-medium px-3 py-1.5 rounded-full bg-white/15 active:bg-white/25 transition-colors"
+        >
+          {calm ? 'Calm' : 'Lively'}
+        </button>
+      </header>
+
+      <main className="flex-1 px-4 pt-4 pb-8 flex flex-col gap-5 max-w-xl w-full mx-auto animate-[fadeUp_400ms_ease-out]">
+        <div
+          className="rounded-3xl overflow-hidden shadow-sm"
+          style={{ aspectRatio: '4 / 3', backgroundColor: CANVAS_BG }}
+        >
+          <SketchFrame
+            draw={draw}
+            motion={calm ? 'gentle' : 'on'}
+            deps={[frequency, speed, calm]}
+            ariaLabel={`A glowing sine wave with ${frequency.toFixed(1)} cycles, ${hint}.`}
+            className="w-full h-full block"
+          />
+        </div>
+
+        <p
+          className="text-center text-sm font-medium tabular-nums"
+          style={{ color: 'var(--brand-text-soft)' }}
+        >
+          {hint}
+        </p>
+
+        <div className="rounded-3xl bg-white/70 backdrop-blur-sm border border-[color:var(--brand-border)] p-5 flex flex-col gap-5 shadow-sm">
+          <Knob
+            label="Wiggles"
+            value={frequency}
+            min={0.5}
+            max={4}
+            step={0.1}
+            format={(v) => `${v.toFixed(1)}×`}
+            onChange={setFrequency}
+            calmMode={calm}
+          />
+          <Knob
+            label="Speed"
+            value={speed}
+            min={0}
+            max={1.5}
+            step={0.05}
+            format={(v) => (v === 0 ? 'still' : `${v.toFixed(2)}`)}
+            onChange={setSpeed}
+            calmMode={calm}
+          />
+        </div>
+
+        <p className="text-xs text-center" style={{ color: 'var(--brand-text-muted)' }}>
+          Try moving one slider at a time. What changes?
+        </p>
+      </main>
+
+      <style jsx>{`
+        @keyframes fadeUp {
+          from { opacity: 0; transform: translateY(8px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          main { animation: none !important; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/Dock.tsx
+++ b/src/components/Dock.tsx
@@ -141,6 +141,14 @@ function IconToolshed({ color }: { color: string }) {
   );
 }
 
+function IconWave({ color }: { color: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M2 12c2 -4 4 -4 6 0s4 4 6 0 4 -4 6 0 4 4 6 0" />
+    </svg>
+  );
+}
+
 function IconBrain({ color }: { color: string }) {
   return (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -213,6 +221,7 @@ const MORE_ITEMS: MoreItem[] = [
   { id: 'science', label: 'Science', icon: IconFlask, href: '/science' },
   { id: 'timer', label: 'Timer', icon: IconTimer, href: '/timer' },
   { id: 'toolshed', label: 'Toolshed', icon: IconToolshed, href: '/toolshed' },
+  { id: 'math', label: 'Math', icon: IconWave, href: '/math' },
   { id: 'intuition', label: 'Intuition', icon: IconBrain, href: '/intuition' },
   { id: 'vsd', label: 'Scenes', icon: IconImage, href: '/vsd' },
   { id: 'parent-chat', label: 'Parent Chat', icon: IconParentChat, href: '/parent-chat' },

--- a/src/components/math/Knob.tsx
+++ b/src/components/math/Knob.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useCallback, useId, useRef, useState } from 'react';
+
+/**
+ * iOS-style slider for /math sketches.
+ *
+ * Renders a labeled value, a track, and a thumb. Pointer + keyboard
+ * accessible. Emits a soft 8ms haptic tick whenever the snapped step
+ * changes (skipped when `calmMode` is on).
+ */
+
+interface KnobProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  /** Format the visible value, e.g. (v) => `${v.toFixed(1)}×`. */
+  format?: (v: number) => string;
+  onChange: (next: number) => void;
+  calmMode?: boolean;
+  accent?: string;
+}
+
+const ACCENT_DEFAULT = 'var(--brand-accent)';
+
+export default function Knob({
+  label,
+  value,
+  min,
+  max,
+  step = 0.01,
+  format,
+  onChange,
+  calmMode = false,
+  accent = ACCENT_DEFAULT,
+}: KnobProps) {
+  const id = useId();
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const lastStepRef = useRef<number>(value);
+
+  const pct = ((value - min) / (max - min)) * 100;
+  const clamped = Math.max(0, Math.min(100, pct));
+
+  const updateFromX = useCallback(
+    (clientX: number) => {
+      const track = trackRef.current;
+      if (!track) return;
+      const rect = track.getBoundingClientRect();
+      const ratio = (clientX - rect.left) / rect.width;
+      const raw = min + ratio * (max - min);
+      const snapped = Math.round(raw / step) * step;
+      const bounded = Math.max(min, Math.min(max, snapped));
+      if (bounded !== lastStepRef.current) {
+        lastStepRef.current = bounded;
+        if (!calmMode && navigator.vibrate) navigator.vibrate(8);
+        onChange(bounded);
+      }
+    },
+    [min, max, step, onChange, calmMode],
+  );
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    const span = max - min;
+    const big = step * 10;
+    let next = value;
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') next = value - step;
+    else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') next = value + step;
+    else if (e.key === 'PageDown') next = value - big;
+    else if (e.key === 'PageUp') next = value + big;
+    else if (e.key === 'Home') next = min;
+    else if (e.key === 'End') next = max;
+    else return;
+    e.preventDefault();
+    const bounded = Math.max(min, Math.min(max, next));
+    onChange(Math.round(bounded / step) * step);
+  };
+
+  return (
+    <div className="select-none">
+      <div className="flex items-baseline justify-between mb-2">
+        <label htmlFor={id} className="text-sm font-medium text-[color:var(--brand-text-soft)]">
+          {label}
+        </label>
+        <span
+          className="font-mono text-base font-semibold tabular-nums"
+          style={{ color: accent }}
+          aria-live="polite"
+        >
+          {format ? format(value) : value.toFixed(2)}
+        </span>
+      </div>
+      <div
+        ref={trackRef}
+        className="relative h-10 touch-none"
+        onPointerDown={(e) => {
+          (e.target as Element).setPointerCapture?.(e.pointerId);
+          setDragging(true);
+          updateFromX(e.clientX);
+        }}
+        onPointerMove={(e) => {
+          if (!dragging) return;
+          updateFromX(e.clientX);
+        }}
+        onPointerUp={() => setDragging(false)}
+        onPointerCancel={() => setDragging(false)}
+      >
+        <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-1.5 rounded-full bg-[color:var(--brand-border)]" />
+        <div
+          className="absolute top-1/2 -translate-y-1/2 h-1.5 rounded-full transition-[width] duration-150 ease-out"
+          style={{ width: `${clamped}%`, backgroundColor: accent }}
+        />
+        <button
+          id={id}
+          type="button"
+          role="slider"
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={value}
+          aria-label={label}
+          onKeyDown={handleKey}
+          className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 h-7 w-7 rounded-full bg-white shadow-md ring-1 ring-black/10 transition-transform duration-150 ease-out ${
+            dragging ? 'scale-110' : 'active:scale-105'
+          }`}
+          style={{ left: `${clamped}%`, boxShadow: dragging ? `0 0 0 6px ${accent}22, 0 2px 6px rgb(0 0 0 / 0.15)` : undefined }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/math/SketchFrame.tsx
+++ b/src/components/math/SketchFrame.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Canvas wrapper for /math sketches.
+ *
+ * Calls `draw(ctx, t, w, h)` on every frame. `t` is seconds since the sketch
+ * mounted. Handles devicePixelRatio, resize, and prefers-reduced-motion.
+ *
+ * Motion levels:
+ *   on     — 60fps animation loop
+ *   gentle — ~30fps, default for the math route (calm by design)
+ *   off    — single render on mount and whenever `deps` change
+ *
+ * `prefers-reduced-motion: reduce` forces `off` regardless of the prop.
+ */
+
+export type Motion = 'on' | 'gentle' | 'off';
+
+interface SketchFrameProps {
+  draw: (ctx: CanvasRenderingContext2D, t: number, w: number, h: number) => void;
+  motion?: Motion;
+  /** Re-renders on prop change so a still sketch updates when knobs move. */
+  deps?: ReadonlyArray<unknown>;
+  className?: string;
+  ariaLabel: string;
+}
+
+export default function SketchFrame({
+  draw,
+  motion = 'gentle',
+  deps = [],
+  className,
+  ariaLabel,
+}: SketchFrameProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const drawRef = useRef(draw);
+  drawRef.current = draw;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const effectiveMotion: Motion = reduceMotion ? 'off' : motion;
+    const targetFps = effectiveMotion === 'on' ? 60 : 30;
+    const frameInterval = 1000 / targetFps;
+
+    let raf = 0;
+    let mounted = true;
+    const start = performance.now();
+    let last = start;
+
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = Math.max(1, Math.round(rect.width * dpr));
+      canvas.height = Math.max(1, Math.round(rect.height * dpr));
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    const render = (t: number) => {
+      const rect = canvas.getBoundingClientRect();
+      drawRef.current(ctx, t, rect.width, rect.height);
+    };
+
+    resize();
+    render(0);
+
+    const ro = new ResizeObserver(() => {
+      resize();
+      render((performance.now() - start) / 1000);
+    });
+    ro.observe(canvas);
+
+    if (effectiveMotion !== 'off') {
+      const tick = (now: number) => {
+        if (!mounted) return;
+        if (now - last >= frameInterval) {
+          last = now;
+          render((now - start) / 1000);
+        }
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    }
+
+    return () => {
+      mounted = false;
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [motion, ...deps]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={className}
+      role="img"
+      aria-label={ariaLabel}
+    />
+  );
+}

--- a/src/components/math/useCalmMode.ts
+++ b/src/components/math/useCalmMode.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const KEY = '8gentjr-math-calm-mode';
+
+/**
+ * Calm Mode toggle for /math.
+ *
+ * On by default. Halves motion, mutes haptics, lowers density on busier
+ * sketches. Persists per-device in localStorage so a returning child stays
+ * in their preferred mode.
+ */
+export function useCalmMode(): [boolean, (next: boolean) => void] {
+  const [calm, setCalm] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = window.localStorage.getItem(KEY);
+    if (stored === 'false') setCalm(false);
+    else if (stored === 'true') setCalm(true);
+  }, []);
+
+  const update = (next: boolean) => {
+    setCalm(next);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(KEY, String(next));
+    }
+  };
+
+  return [calm, update];
+}


### PR DESCRIPTION
## Summary

First step of a progressive math visualizer for neurodivergent kids. The pedagogy is **watch the numbers move** before any symbols appear — kids slide a knob, see the curve change, and build intuition for what frequency and speed mean. iOS-shaped, calm by default, sensory-safe.

- `/math` — four lesson cards. **Wave** is live; **Tall and Small / Layers / Garden** are stubs marked `SOON` (each with a live-rendered preview that hints at the math idea behind the door).
- `/math/wave` — Lesson 1. Single sine curve on a dark canvas with a soft amber glow. Two iOS-style knobs (`Wiggles`, `Speed`). Hint text reflects the current combo (`Slow and gentle`, `Quick wiggles`, …).
- New primitives under `src/components/math/`:
  - **SketchFrame** — Canvas2D wrapper with RAF loop, devicePixelRatio, ResizeObserver, three motion levels (`on` / `gentle` / `off`). Forces `off` on `prefers-reduced-motion`.
  - **Knob** — iOS slider. Pointer + keyboard accessible (`role=slider`, arrow keys, Page/Home/End). 8 ms haptic tick on step change (muted in Calm Mode).
  - **useCalmMode** — `localStorage`-backed toggle. **On by default.** Halves shadow blur, mutes haptics, drops preview density.
- Dock: new `Math` entry under More, sine-wave icon.

No new dependencies. Raw Canvas2D matches the existing `DrawCanvas` / `ChladniVisualizer` pattern.

## Why this shape

- Calm by default. Brand orange `#E8610A` on `#1A1612` canvas keeps glow gentle. Reduced-motion shuts off animation entirely.
- Progressive disclosure. Three locked cards make the path forward visible without firing motion or sound on routes that aren't built yet.
- One file per lesson. Future lessons (`/math/amplitude`, `/math/layered`, `/math/garden`) drop in next to `wave/` without touching primitives.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `bun run scripts/check-banned-imports.ts` clean
- [x] `/math` renders, lesson cards animate previews
- [x] `/math/wave` renders, knobs move the curve, Calm toggle persists
- [x] No console errors
- [ ] Manual on-device check (iOS Safari) — haptics + reduced motion
- [ ] Reviewer eyes on whether SOON cards should be tappable to a "coming soon" splash vs the current disabled-button approach

## Screenshots

`/math` index and `/math/wave` lesson, Calm Mode on.