### PR TITLE
Talk: Keyboard tab, faster phrase add, mobile scroll fixes

### DIFF
--- a/src/app/talk/page.tsx
+++ b/src/app/talk/page.tsx
@@ -14,14 +14,16 @@ import { SupercoreGrid } from "@/components/SupercoreGrid";
 import AACHome from "@/components/AACHome";
 import { VoiceCardCreator } from "@/components/VoiceCardCreator";
 import { QuickPhrases } from "@/components/QuickPhrases";
+import { KeyboardSurface } from "@/components/KeyboardSurface";
 import { useSentence } from "@/hooks/useSentence";
 
-type ViewMode = "core" | "browse" | "phrases";
+type ViewMode = "core" | "browse" | "phrases" | "keyboard";
 
 const TABS: { id: ViewMode; label: string; icon: string }[] = [
-  { id: "core",    label: "Core",    icon: "⊞" },
-  { id: "browse",  label: "Browse",  icon: "🗂" },
-  { id: "phrases", label: "Phrases", icon: "💬" },
+  { id: "core",     label: "Core",     icon: "⊞" },
+  { id: "browse",   label: "Browse",   icon: "🗂" },
+  { id: "phrases",  label: "Phrases",  icon: "💬" },
+  { id: "keyboard", label: "Keyboard", icon: "⌨" },
 ];
 
 export default function TalkPage() {
@@ -61,9 +63,10 @@ export default function TalkPage() {
 
       {/* ── Main content ─────────────────────────────────── */}
       <div className="flex-1 overflow-hidden min-h-0" role="tabpanel">
-        {viewMode === "core"    && <SupercoreGrid />}
-        {viewMode === "browse"  && <AACHome />}
-        {viewMode === "phrases" && <QuickPhrases currentSentence={sentenceText} />}
+        {viewMode === "core"     && <SupercoreGrid />}
+        {viewMode === "browse"   && <AACHome />}
+        {viewMode === "phrases"  && <QuickPhrases currentSentence={sentenceText} />}
+        {viewMode === "keyboard" && <KeyboardSurface />}
       </div>
 
       {/* ── Parent voice card creator — floating mic ─────── */}

--- a/src/components/KeyboardSurface.tsx
+++ b/src/components/KeyboardSurface.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+/**
+ * KeyboardSurface — the "Keyboard" Talk tab.
+ *
+ * Surfaces the (previously unwired) AACKeyboard for users who want to type /
+ * spell words for core needs, alongside the symbol grid. Typed words feed the
+ * SAME shared sentence store the Core grid uses, so spelling and tapping mix
+ * in one sentence. Speaks each added word, and the whole sentence, in the
+ * voice chosen in Settings.
+ */
+
+import { useCallback } from "react";
+import AACKeyboard from "@/components/AACKeyboard";
+import { useSentence } from "@/hooks/useSentence";
+import { useApp } from "@/context/AppContext";
+import { speak } from "@/lib/tts";
+
+export function KeyboardSurface() {
+  const { words, addWord, removeWord, clear } = useSentence();
+  const { settings } = useApp();
+
+  const say = useCallback(
+    (text: string) => {
+      if (!text.trim()) return;
+      speak({ text, voiceId: settings.selectedVoiceId ?? undefined, rate: settings.ttsRate }).catch(() => {});
+    },
+    [settings.selectedVoiceId, settings.ttsRate],
+  );
+
+  const handleWord = useCallback(
+    (word: string) => {
+      addWord({ label: word });
+      say(word);
+    },
+    [addWord, say],
+  );
+
+  const sentenceText = words.map((w) => w.label).join(" ");
+
+  return (
+    <div className="flex flex-col h-full bg-[#F7F5F2]">
+      {/* Sentence bar */}
+      <div className="shrink-0 bg-gray-800 px-3 py-2 flex items-center gap-2">
+        <button
+          onClick={() => say(sentenceText)}
+          disabled={words.length === 0}
+          aria-label="Speak the sentence"
+          className="shrink-0 w-12 h-12 rounded-full bg-[#E8610A] text-white flex items-center justify-center text-xl disabled:opacity-40 active:scale-90 transition-transform"
+        >
+          ▶
+        </button>
+        <div className="flex-1 min-w-0 overflow-x-auto no-scrollbar">
+          {words.length === 0 ? (
+            <span className="text-white/40 text-sm">Type a word to start.</span>
+          ) : (
+            <div className="flex gap-1.5">
+              {words.map((w, i) => (
+                <button
+                  key={i}
+                  onClick={() => say(w.label)}
+                  className="shrink-0 px-3 py-1.5 rounded-lg bg-white/15 text-white text-sm font-semibold whitespace-nowrap active:scale-95 transition-transform"
+                >
+                  {w.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <button
+          onClick={() => words.length && removeWord(words.length - 1)}
+          disabled={words.length === 0}
+          aria-label="Delete last word"
+          className="shrink-0 w-11 h-11 rounded-full bg-white/10 text-white flex items-center justify-center text-lg disabled:opacity-30 active:scale-90 transition-transform"
+        >
+          ⌫
+        </button>
+        <button
+          onClick={clear}
+          disabled={words.length === 0}
+          aria-label="Clear the sentence"
+          className="shrink-0 w-11 h-11 rounded-full bg-red-500/90 text-white flex items-center justify-center text-lg disabled:opacity-30 active:scale-90 transition-transform"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Keyboard */}
+      <div className="flex-1 overflow-y-auto min-h-0 p-4 touch-pan-y">
+        <AACKeyboard onWordSelect={handleWord} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/QuickPhrases.tsx
+++ b/src/components/QuickPhrases.tsx
@@ -275,7 +275,7 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
       )}
 
       {/* ── Phrase list ───────────────────────────────────── */}
-      <div className="flex-1 overflow-y-auto min-h-0 px-4 pt-3 pb-24">
+      <div className="flex-1 overflow-y-auto min-h-0 px-4 pt-3 pb-24 touch-pan-y">
         {isEmpty ? (
           <div className="flex flex-col items-center justify-center h-full gap-4 text-center pb-16">
             <p className="text-[22px] font-semibold text-[#1a1a2e] leading-snug max-w-[260px]">
@@ -308,6 +308,8 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
                       onPointerDown={() => onPressStart(phrase.id)}
                       onPointerUp={onPressEnd}
                       onPointerLeave={onPressEnd}
+                      onPointerCancel={onPressEnd}
+                      style={{ touchAction: "pan-y" }}
                     >
                       {/* Play button */}
                       <button
@@ -370,9 +372,10 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
         )}
       </div>
 
-      {/* ── FAB ───────────────────────────────────────────── */}
+      {/* ── FAB — opens straight to the keyboard (the common path);
+              the sheet's back arrow still reaches voice / word-build. ── */}
       <button
-        onClick={() => openSheet("choose")}
+        onClick={() => openSheet("text")}
         className="absolute bottom-6 right-5 w-16 h-16 rounded-full bg-[#E8610A] text-white flex items-center justify-center shadow-[0_4px_20px_rgba(232,97,10,0.45)] active:scale-90 transition-transform z-10"
         style={{ fontSize: 36, lineHeight: 1 }}
         aria-label="Add a phrase"

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -547,7 +547,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
       </div>
 
       {/* Scrollable grid area */}
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className="flex-1 min-h-0 overflow-y-auto touch-pan-y">
 
         {/* T2.4 Predictive next-word strip - 4 cards, recomputes on every
             tap. Sits above Your Words (frequency) + Suggested (stage) +


### PR DESCRIPTION
Builds wishlist items from field testing (epic #204).

## ⌨️ Keyboard tab (#206)
`AACKeyboard` already existed but was imported nowhere. Added a **Keyboard** tab to Talk → `KeyboardSurface` wires it into the **shared sentence store**, so spelled/typed words mix with tapped symbols in one sentence and speak in the **voice chosen in Settings**. Has its own sentence bar (speak / backspace / clear).

## ⚡ Faster phrase add (#209)
The Phrases **+** now opens **straight to the keyboard** instead of a 'choose method' step (the tester's friction: 'phrases → add → type'). The sheet's back arrow still reaches voice / word-build.

## 📜 Mobile scroll robustness (#205)
- `touch-pan-y` on the phrase list and the core grid scroll areas.
- Cancel the long-press timer on `pointercancel` so a scroll drag on a phrase card can't trip into delete mode.
- **Note:** the global CSS already had momentum + overscroll-contain and the layout is correct for iOS, so I couldn't reproduce the Android-only report from here — these are the most plausible safe fixes. **Needs confirmation on the tester's Android device** before closing #205.

## Not in this PR (need decisions)
- **#207 folders** (topic folders for words + phrases): a real feature (data model + nav) — happy to build next.
- **#208 separate child/parent profiles**: intersects COPPA / the consent epic (#176); I won't half-build children's auth without a product + compliance decision.
- **#210 PWA install clarity**: small, queued next.

Typechecks clean (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)