### PR TITLE
feat(web): user-creatable phrase folders (#207)

### DIFF
--- a/src/components/QuickPhrases.tsx
+++ b/src/components/QuickPhrases.tsx
@@ -4,6 +4,14 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useVoiceInput } from "@/hooks/useVoiceInput";
 import { speak } from "@/lib/tts";
 import { useApp } from "@/context/AppContext";
+import {
+  loadFolders,
+  persistFolders,
+  addFolder,
+  removeFolder,
+  normaliseFolder,
+  isAutoFolder,
+} from "@/lib/phrase-folders";
 
 /* ── Types ───────────────────────────────────────────────── */
 
@@ -119,10 +127,15 @@ function persistPhrases(phrases: SavedPhrase[]) {
 export function QuickPhrases({ currentSentence }: { currentSentence?: string }) {
   const { settings } = useApp();
   const [phrases,     setPhrases]     = useState<SavedPhrase[]>([]);
+  const [folders,     setFolders]     = useState<string[]>([]);
   const [sheetOpen,   setSheetOpen]   = useState(false);
   const [inputMode,   setInputMode]   = useState<InputMode>("choose");
   const [draft,       setDraft]       = useState("");
   const [activeCat,   setActiveCat]   = useState("All");
+  // Folder chosen in the add/edit sheet. "" = auto-categorise (default fallback).
+  const [folderChoice, setFolderChoice] = useState("");
+  // Draft text for the "New folder…" input inside the sheet.
+  const [newFolder,    setNewFolder]    = useState("");
   const [speakingId,  setSpeakingId]  = useState<string | null>(null);
   const [deletingId,  setDeletingId]  = useState<string | null>(null);
   // Id of the phrase currently being edited (vs created). null = creating.
@@ -131,7 +144,7 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
   const voice                         = useVoiceInput();
   const longPressTimer                = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => { setPhrases(loadPhrases()); }, []);
+  useEffect(() => { setPhrases(loadPhrases()); setFolders(loadFolders()); }, []);
   useEffect(() => { if (voice.transcript) setDraft(voice.transcript); }, [voice.transcript]);
 
   /* ── Sheet open/close ──────────────────────────────────── */
@@ -139,6 +152,8 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
   const openSheet = useCallback((mode: InputMode = "choose") => {
     setInputMode(mode);
     setDraft("");
+    setFolderChoice("");
+    setNewFolder("");
     setSheetOpen(true);
     if (mode === "text") setTimeout(() => inputRef.current?.focus(), 320);
   }, []);
@@ -147,6 +162,8 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
     setSheetOpen(false);
     setDraft("");
     setEditingId(null);
+    setFolderChoice("");
+    setNewFolder("");
     voice.stop();
     voice.reset();
     setTimeout(() => setInputMode("choose"), 300);
@@ -154,13 +171,30 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
 
   /* ── Save (create OR edit) ─────────────────────────────── */
 
+  /**
+   * Resolve the folder for the phrase being saved.
+   * Commits a typed "New folder…" name (persisting it) when present, otherwise
+   * uses the picked folder. Falls back to autoCategory when nothing is chosen.
+   */
+  const resolveFolder = useCallback((text: string): string => {
+    const typed = normaliseFolder(newFolder);
+    if (typed) {
+      const { folders: next, name } = addFolder(folders, typed);
+      if (next !== folders) { setFolders(next); persistFolders(next); }
+      return name;
+    }
+    if (folderChoice) return folderChoice;
+    return autoCategory(text);
+  }, [folders, folderChoice, newFolder]);
+
   const savePhrase = useCallback((text: string) => {
     const trimmed = text.trim();
     if (!trimmed) return;
+    const category = resolveFolder(trimmed);
     if (editingId) {
-      // Editing an existing phrase — keep its id/createdAt, update text + category.
+      // Editing an existing phrase: keep its id/createdAt, update text + folder.
       const updated = phrases.map(p =>
-        p.id === editingId ? { ...p, text: trimmed, category: autoCategory(trimmed) } : p,
+        p.id === editingId ? { ...p, text: trimmed, category } : p,
       );
       setPhrases(updated);
       persistPhrases(updated);
@@ -170,14 +204,14 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
     const p: SavedPhrase = {
       id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
       text: trimmed,
-      category: autoCategory(trimmed),
+      category,
       createdAt: Date.now(),
     };
     const updated = [p, ...phrases];
     setPhrases(updated);
     persistPhrases(updated);
     closeSheet();
-  }, [phrases, closeSheet, editingId]);
+  }, [phrases, closeSheet, editingId, resolveFolder]);
 
   /* ── Edit ──────────────────────────────────────────────── */
 
@@ -186,6 +220,8 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
     setEditingId(p.id);
     setInputMode("text");
     setDraft(p.text);
+    setFolderChoice(p.category);
+    setNewFolder("");
     setSheetOpen(true);
     setTimeout(() => inputRef.current?.focus(), 320);
   }, []);
@@ -198,6 +234,15 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
     persistPhrases(updated);
     setDeletingId(null);
   }, [phrases]);
+
+  /* ── Remove an empty custom folder ─────────────────────── */
+
+  const deleteFolder = useCallback((name: string) => {
+    const next = removeFolder(folders, name);
+    setFolders(next);
+    persistFolders(next);
+    if (activeCat === name) setActiveCat("All");
+  }, [folders, activeCat]);
 
   /* ── Speak ─────────────────────────────────────────────── */
 
@@ -225,7 +270,11 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
 
   /* ── Filter / group ────────────────────────────────────── */
 
-  const allCats = ["All", ...Array.from(new Set(phrases.map(p => p.category))).sort()];
+  // Folders that exist on phrases (auto or custom) merged with persisted
+  // custom folders, so an empty custom folder still appears as a chip.
+  const phraseCats = Array.from(new Set(phrases.map(p => p.category)));
+  const allFolders = Array.from(new Set([...phraseCats, ...folders])).sort();
+  const allCats = ["All", ...allFolders];
   const filtered = activeCat === "All" ? phrases : phrases.filter(p => p.category === activeCat);
   const grouped = filtered.reduce<Record<string, SavedPhrase[]>>((acc, p) => {
     (acc[p.category] ??= []).push(p);
@@ -242,19 +291,41 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
       {/* ── Category filter ───────────────────────────────── */}
       {!isEmpty && (
         <div className="flex gap-2 px-4 pt-3 pb-2 overflow-x-auto no-scrollbar shrink-0">
-          {allCats.map(cat => (
-            <button
-              key={cat}
-              onClick={() => setActiveCat(cat)}
-              className={`shrink-0 px-3.5 py-1.5 rounded-full text-[13px] font-semibold border transition-all duration-150 min-h-[36px] ${
-                activeCat === cat
-                  ? "bg-[#1a1a2e] text-white border-[#1a1a2e]"
-                  : "bg-white text-[#6b6460] border-[#E8E2DA]"
-              }`}
-            >
-              {cat}
-            </button>
-          ))}
+          {allCats.map(cat => {
+            const active = activeCat === cat;
+            // A custom folder with no phrases can be removed inline.
+            const isEmptyCustom =
+              cat !== "All" &&
+              !isAutoFolder(cat) &&
+              !phraseCats.includes(cat);
+            return (
+              <div
+                key={cat}
+                className={`shrink-0 flex items-center gap-1 rounded-full border transition-all duration-150 min-h-[44px] ${
+                  active
+                    ? "bg-[#1a1a2e] text-white border-[#1a1a2e]"
+                    : "bg-white text-[#6b6460] border-[#E8E2DA]"
+                }`}
+              >
+                <button
+                  onClick={() => setActiveCat(cat)}
+                  aria-pressed={active}
+                  className={`px-3.5 py-1.5 text-[13px] font-semibold ${isEmptyCustom && active ? "pr-1" : ""}`}
+                >
+                  {cat}
+                </button>
+                {isEmptyCustom && active && (
+                  <button
+                    onClick={() => deleteFolder(cat)}
+                    aria-label={`Remove empty folder: ${cat}`}
+                    className="w-9 h-9 mr-1 rounded-full flex items-center justify-center text-[15px] font-bold active:scale-90 transition-transform"
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
 
@@ -530,6 +601,54 @@ export function QuickPhrases({ currentSentence }: { currentSentence?: string }) 
                   })}
                 </div>
               )}
+
+              {/* ── Folder picker ───────────────────────────── */}
+              <div className="mb-3">
+                <p className="text-[11px] font-bold text-[#8a7e70] uppercase tracking-widest mb-2">
+                  Folder
+                </p>
+                <div className="flex flex-wrap gap-2 mb-2">
+                  {/* Auto (default) */}
+                  <button
+                    onClick={() => { setFolderChoice(""); setNewFolder(""); }}
+                    aria-pressed={folderChoice === "" && !newFolder.trim()}
+                    className={`px-3.5 py-2 rounded-full text-[13px] font-semibold border min-h-[44px] active:scale-95 transition-all ${
+                      folderChoice === "" && !newFolder.trim()
+                        ? "bg-[#1a1a2e] text-white border-[#1a1a2e]"
+                        : "bg-white text-[#6b6460] border-[#E8E2DA]"
+                    }`}
+                  >
+                    Auto
+                  </button>
+                  {allFolders.map(f => {
+                    const active = folderChoice === f && !newFolder.trim();
+                    return (
+                      <button
+                        key={f}
+                        onClick={() => { setFolderChoice(f); setNewFolder(""); }}
+                        aria-pressed={active}
+                        className={`px-3.5 py-2 rounded-full text-[13px] font-semibold border min-h-[44px] active:scale-95 transition-all ${
+                          active
+                            ? "bg-[#1a1a2e] text-white border-[#1a1a2e]"
+                            : "bg-white text-[#6b6460] border-[#E8E2DA]"
+                        }`}
+                      >
+                        {f}
+                      </button>
+                    );
+                  })}
+                </div>
+                <input
+                  type="text"
+                  value={newFolder}
+                  onChange={e => { setNewFolder(e.target.value); if (e.target.value.trim()) setFolderChoice(""); }}
+                  placeholder="New folder…"
+                  aria-label="Create a new folder"
+                  className="w-full px-4 py-3 rounded-2xl border-2 border-[#EDE8E2] focus:border-[#E8610A] text-[15px] font-medium text-[#1a1a2e] min-h-[48px] outline-none transition-colors bg-white"
+                  autoCapitalize="words"
+                  autoComplete="off"
+                />
+              </div>
 
               {/* Clear + Save */}
               <div className="flex gap-2">

--- a/src/lib/phrase-folders.test.ts
+++ b/src/lib/phrase-folders.test.ts
@@ -1,0 +1,121 @@
+// @ts-nocheck - bun:test types not wired to main tsconfig; run with `bun test`
+/**
+ * Tests for the user-created phrase folders helpers. Runs via `bun test`.
+ *
+ * Covers the edge-cases the folder logic must get right:
+ *   - normaliseFolder: trim + internal-whitespace collapse
+ *   - addFolder:       case-insensitive de-dup, canonical name return, order
+ *   - removeFolder:    exact-match removal only
+ *   - isAutoFolder:    auto names protected from custom-folder treatment
+ *   - loadFolders:     defensive parsing of malformed localStorage
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  AUTO_FOLDERS,
+  addFolder,
+  isAutoFolder,
+  loadFolders,
+  normaliseFolder,
+  removeFolder,
+} from './phrase-folders';
+
+describe('normaliseFolder', () => {
+  test('trims leading/trailing whitespace', () => {
+    expect(normaliseFolder('  Toys  ')).toBe('Toys');
+  });
+  test('collapses internal whitespace runs to single spaces', () => {
+    expect(normaliseFolder('My   Favourite\tThings')).toBe('My Favourite Things');
+  });
+  test('returns empty string for whitespace-only input', () => {
+    expect(normaliseFolder('   ')).toBe('');
+  });
+});
+
+describe('addFolder', () => {
+  test('appends a new folder preserving order', () => {
+    const { folders, name } = addFolder(['A', 'B'], 'C');
+    expect(folders).toEqual(['A', 'B', 'C']);
+    expect(name).toBe('C');
+  });
+  test('normalises the stored name on add', () => {
+    const { folders, name } = addFolder([], '  Snack  Time  ');
+    expect(folders).toEqual(['Snack Time']);
+    expect(name).toBe('Snack Time');
+  });
+  test('de-dups case-insensitively and returns the canonical existing name', () => {
+    const original = ['Toys'];
+    const { folders, name } = addFolder(original, 'toys');
+    expect(folders).toBe(original); // unchanged reference -> caller skips persist
+    expect(name).toBe('Toys');
+  });
+  test('empty/whitespace name is a no-op returning empty name', () => {
+    const original = ['Toys'];
+    const { folders, name } = addFolder(original, '   ');
+    expect(folders).toBe(original);
+    expect(name).toBe('');
+  });
+  test('does not mutate the input array when adding', () => {
+    const original = ['A'];
+    addFolder(original, 'B');
+    expect(original).toEqual(['A']);
+  });
+});
+
+describe('removeFolder', () => {
+  test('removes an exact match', () => {
+    expect(removeFolder(['A', 'B', 'C'], 'B')).toEqual(['A', 'C']);
+  });
+  test('is case-sensitive (only removes exact name)', () => {
+    expect(removeFolder(['Toys'], 'toys')).toEqual(['Toys']);
+  });
+  test('returns a list unchanged when name is absent', () => {
+    expect(removeFolder(['A'], 'Z')).toEqual(['A']);
+  });
+});
+
+describe('isAutoFolder', () => {
+  test('recognises every auto folder name', () => {
+    for (const name of AUTO_FOLDERS) expect(isAutoFolder(name)).toBe(true);
+  });
+  test('rejects custom names', () => {
+    expect(isAutoFolder('Toys')).toBe(false);
+  });
+  test('is case-sensitive', () => {
+    expect(isAutoFolder('food')).toBe(false);
+  });
+});
+
+describe('loadFolders', () => {
+  const store: Record<string, string> = {};
+  beforeEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+    globalThis.localStorage = {
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
+      clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+      key: () => null,
+      length: 0,
+    } as Storage;
+  });
+  afterEach(() => {
+    // @ts-expect-error - tearing down the test shim
+    delete globalThis.localStorage;
+  });
+
+  test('returns [] when key is unset', () => {
+    expect(loadFolders()).toEqual([]);
+  });
+  test('returns [] for malformed JSON', () => {
+    store['8gentjr_phrase_folders'] = '{not json';
+    expect(loadFolders()).toEqual([]);
+  });
+  test('returns [] when stored value is not an array', () => {
+    store['8gentjr_phrase_folders'] = '{"a":1}';
+    expect(loadFolders()).toEqual([]);
+  });
+  test('filters out non-string and blank entries', () => {
+    store['8gentjr_phrase_folders'] = JSON.stringify(['Toys', 7, '', '  ', 'Snacks', null]);
+    expect(loadFolders()).toEqual(['Toys', 'Snacks']);
+  });
+});

--- a/src/lib/phrase-folders.ts
+++ b/src/lib/phrase-folders.ts
@@ -1,0 +1,67 @@
+/**
+ * User-created phrase folders (topic categories).
+ *
+ * Phrases store their folder in `category`. Folders that a user creates are
+ * also persisted on their own so an empty folder still shows as a filter chip
+ * (a phrase-derived list alone would drop folders with no phrases in them).
+ *
+ * Mirrors the localStorage persist pattern used for phrases in QuickPhrases.
+ */
+
+const FOLDERS_STORAGE_KEY = "8gentjr_phrase_folders";
+
+/** Folder names auto-assigned by `autoCategory`; never treated as removable custom folders. */
+export const AUTO_FOLDERS = [
+  "Feelings",
+  "Requests",
+  "Questions",
+  "Social",
+  "Food",
+  "School",
+  "Body",
+  "Common",
+] as const;
+
+const AUTO_SET = new Set<string>(AUTO_FOLDERS);
+
+export function isAutoFolder(name: string): boolean {
+  return AUTO_SET.has(name);
+}
+
+export function loadFolders(): string[] {
+  try {
+    const raw = JSON.parse(localStorage.getItem(FOLDERS_STORAGE_KEY) ?? "[]");
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((f): f is string => typeof f === "string" && f.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
+export function persistFolders(folders: string[]) {
+  try {
+    localStorage.setItem(FOLDERS_STORAGE_KEY, JSON.stringify(folders));
+  } catch {}
+}
+
+/** Normalise a folder name: trim + collapse internal whitespace. */
+export function normaliseFolder(name: string): string {
+  return name.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Add a folder, preserving order and avoiding case-insensitive duplicates.
+ * Returns the (possibly unchanged) list and the canonical stored name so the
+ * caller can select the existing folder rather than create a clashing one.
+ */
+export function addFolder(folders: string[], name: string): { folders: string[]; name: string } {
+  const clean = normaliseFolder(name);
+  if (!clean) return { folders, name: "" };
+  const existing = folders.find(f => f.toLowerCase() === clean.toLowerCase());
+  if (existing) return { folders, name: existing };
+  return { folders: [...folders, clean], name: clean };
+}
+
+export function removeFolder(folders: string[], name: string): string[] {
+  return folders.filter(f => f !== name);
+}


### PR DESCRIPTION
## Summary

Closes #207. Field testers asked to organise saved phrases into their own topic folders instead of relying on the auto-assigned category. This adds a folder picker to the add/edit sheet on the Phrases surface only.

## What changed (Phrases surface only)

- **Folder picker in the add/edit bottom sheet.** Pick `Auto` (keeps the existing `autoCategory` fallback), pick an existing folder, or type a new one via a `New folder…` input. A chosen folder overrides `autoCategory`; choosing nothing keeps auto as the default.
- **Persisted folders.** User-created folder names are stored in localStorage (`8gentjr_phrase_folders`) so an empty folder still shows as a filter chip. Follows the existing phrase persist pattern via a small new `src/lib/phrase-folders.ts` helper.
- **Filter chips** merge phrase-derived categories with custom folders.
- **Remove empty folders.** A custom folder with no phrases can be removed inline from its active filter chip.
- **Edit flow** preloads the phrase's current folder so it can be changed when editing.

Preserved: add / edit / delete, voice playback, auto-category fallback. No changes to SupercoreGrid, settings, AppContext, or InstallPrompt.

## Scope

- Touches only `src/components/QuickPhrases.tsx` and a new `src/lib/phrase-folders.ts`.

## Accessibility

- Real `<button>` elements with `aria-pressed` / `aria-label`, targets >=44px.
- No purple/violet hues introduced.

## Test plan

- `npx tsc --noEmit` -> 0 errors.
- Manual: add a phrase with a new folder, confirm it appears as a chip and groups the phrase; create an empty folder, confirm chip persists and can be removed; edit a phrase and reassign its folder; verify Auto still uses autoCategory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)