### PR TITLE
Layout presets for Talk Core (customise what goes where)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import { speak } from '@/lib/tts';
 import { GLP_STAGES, getStage } from '@/lib/glp/stages';
 import SmartSuggestionsToggle from '@/components/SmartSuggestionsToggle';
 import { estimateStage, type StageEstimate } from '@/lib/stage-estimator';
+import { LAYOUT_PRESETS, type LayoutPreset } from '@/lib/layout-presets';
 
 /**
  * 8gent Jr Settings Page
@@ -38,6 +39,12 @@ const DEFAULTS: Partial<AppSettings> = {
   ttsRate: 1.0,
   gridColumns: 3,
   glpStage: 3,
+  // Restore the default layout (matches the "Big & Simple" preset).
+  cardSize: 'large',
+  showPredictions: false,
+  showPersonalVocab: true,
+  density: 'relaxed',
+  activeLayoutPreset: 'big-simple',
 };
 
 export default function SettingsPage() {
@@ -178,6 +185,16 @@ export default function SettingsPage() {
           </div>
         </Section>
 
+        {/* ── Layout Presets ── */}
+        <Section title="Layout" icon={<IconLayout />}>
+          <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
+            Pick a ready-made layout for the Talk screen. Choosing one sets the
+            grid size, card size and helper rows together. Tweak any of those
+            below and the layout becomes &ldquo;Custom&rdquo;.
+          </p>
+          <LayoutPresetPicker accent={accent} />
+        </Section>
+
         {/* ── Grid Columns ── */}
         <Section title="Grid Size" icon={<IconGrid />}>
           <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
@@ -189,7 +206,7 @@ export default function SettingsPage() {
               return (
                 <button
                   key={cols}
-                  onClick={() => updateSettings({ gridColumns: cols })}
+                  onClick={() => updateSettings({ gridColumns: cols, activeLayoutPreset: 'custom' })}
                   className="flex-1 py-3 rounded-xl font-bold text-lg transition-all active:scale-95"
                   style={{
                     backgroundColor: active ? accent : 'white',
@@ -251,7 +268,7 @@ export default function SettingsPage() {
             type="button"
             role="switch"
             aria-checked={settings.showPersonalVocab !== false}
-            onClick={() => updateSettings({ showPersonalVocab: !(settings.showPersonalVocab !== false) })}
+            onClick={() => updateSettings({ showPersonalVocab: !(settings.showPersonalVocab !== false), activeLayoutPreset: 'custom' })}
             className="w-full flex items-center justify-between px-4 py-3 rounded-xl border-2 transition-colors active:scale-[0.98]"
             style={{
               borderColor: settings.showPersonalVocab !== false ? accent : 'var(--warm-border, #E8E0D6)',
@@ -446,6 +463,124 @@ function VoicePicker({ accent }: { accent: string }) {
   );
 }
 
+/* ── Layout preset picker (radiogroup) ── */
+function LayoutPresetPicker({ accent }: { accent: string }) {
+  const { settings, updateSettings } = useApp();
+  const activeId = settings.activeLayoutPreset ?? 'custom';
+
+  const applyPreset = (preset: LayoutPreset) => {
+    updateSettings({
+      gridColumns: preset.gridColumns,
+      cardSize: preset.cardSize,
+      showPredictions: preset.showPredictions,
+      showPersonalVocab: preset.showPersonalVocab,
+      density: preset.density,
+      activeLayoutPreset: preset.id,
+    });
+  };
+
+  return (
+    <div className="space-y-2" role="radiogroup" aria-label="Talk screen layout">
+      {LAYOUT_PRESETS.map((preset) => {
+        const active = activeId === preset.id;
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => applyPreset(preset)}
+            className="w-full flex items-center gap-3 text-left px-3 py-3 rounded-xl border-2 transition-all active:scale-[0.98]"
+            style={{
+              borderColor: active ? accent : 'var(--warm-border, #E8E0D6)',
+              backgroundColor: active ? `${accent}12` : 'white',
+            }}
+          >
+            <PresetHint preset={preset} />
+            <span className="flex-1 min-w-0">
+              <span className="flex items-center gap-2">
+                <span className="font-bold" style={{ color: active ? accent : 'var(--warm-text, #1A1614)' }}>
+                  {preset.name}
+                </span>
+                {active && (
+                  <span
+                    className="w-5 h-5 rounded-full flex items-center justify-center text-white text-xs font-bold flex-shrink-0"
+                    style={{ backgroundColor: accent }}
+                    aria-hidden="true"
+                  >
+                    ✓
+                  </span>
+                )}
+              </span>
+              <span className="block text-sm mt-0.5" style={{ color: 'var(--warm-text-muted, #9A9088)' }}>
+                {preset.description}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+
+      {/* Custom state row: not selectable, only reflects hand-tuned settings. */}
+      {activeId === 'custom' && (
+        <div
+          className="w-full flex items-center gap-3 px-3 py-3 rounded-xl border-2"
+          style={{ borderColor: accent, backgroundColor: `${accent}12` }}
+          aria-live="polite"
+        >
+          <span
+            className="w-12 h-12 rounded-lg flex items-center justify-center flex-shrink-0 border-2 border-dashed"
+            style={{ borderColor: accent, color: accent }}
+            aria-hidden="true"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 20h9" />
+              <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+            </svg>
+          </span>
+          <span className="flex-1 min-w-0">
+            <span className="flex items-center gap-2">
+              <span className="font-bold" style={{ color: accent }}>Custom</span>
+              <span
+                className="w-5 h-5 rounded-full flex items-center justify-center text-white text-xs font-bold flex-shrink-0"
+                style={{ backgroundColor: accent }}
+                aria-hidden="true"
+              >
+                ✓
+              </span>
+            </span>
+            <span className="block text-sm mt-0.5" style={{ color: 'var(--warm-text-muted, #9A9088)' }}>
+              Your own mix. Pick a layout above to start over.
+            </span>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* Tiny visual hint: a mini grid preview mirroring the preset's columns/density. */
+function PresetHint({ preset }: { preset: LayoutPreset }) {
+  const cells = Array.from({ length: preset.hint.cells });
+  return (
+    <span
+      className="grid gap-0.5 w-12 h-12 p-1 rounded-lg flex-shrink-0 self-start"
+      style={{
+        gridTemplateColumns: `repeat(${preset.hint.cols}, 1fr)`,
+        backgroundColor: 'var(--warm-border-light, #F0EAE3)',
+      }}
+      aria-hidden="true"
+    >
+      {cells.map((_, i) => (
+        <span
+          key={i}
+          className="rounded-[2px]"
+          style={{ backgroundColor: preset.hint.color, opacity: 0.85 }}
+        />
+      ))}
+    </span>
+  );
+}
+
 /* ── Section wrapper ── */
 function Section({ title, icon, children }: { title: string; icon: React.ReactNode; children: React.ReactNode }) {
   return (
@@ -498,6 +633,16 @@ function IconGrid() {
       <rect x="14" y="3" width="7" height="7" rx="1.5" />
       <rect x="3" y="14" width="7" height="7" rx="1.5" />
       <rect x="14" y="14" width="7" height="7" rx="1.5" />
+    </svg>
+  );
+}
+
+function IconLayout() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <path d="M3 9h18" />
+      <path d="M9 21V9" />
     </svg>
   );
 }

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -37,6 +37,7 @@ import { useSentence } from '@/hooks/useSentence';
 import { useApp } from '@/context/AppContext';
 import { getPersonalVocab } from '@/lib/personal-vocab';
 import { predictNext, PREDICTIVE_CARD_COUNT } from '@/lib/predictive';
+import { CARD_SIZE_TOKENS, type CardSize } from '@/lib/layout-presets';
 
 // =============================================================================
 // Fitzgerald Key Color Definitions (mapped from shared vocabulary system)
@@ -178,28 +179,30 @@ const SUPERCORE_50: CoreWord[] = [
 // Single Core Word Button
 // =============================================================================
 
-const CoreWordButton = React.memo(function CoreWordButton({ word, onTap }: { word: CoreWord; onTap: (w: CoreWord) => void }) {
+const CoreWordButton = React.memo(function CoreWordButton({ word, onTap, cardSize }: { word: CoreWord; onTap: (w: CoreWord) => void; cardSize: CardSize }) {
   const cls = FITZGERALD_CLASSES[word.category];
+  const tok = CARD_SIZE_TOKENS[cardSize];
   const handleTap = useCallback(() => onTap(word), [onTap, word]);
   return (
     <TapCard
       onTap={handleTap}
       ariaLabel={word.label}
       className={`flex flex-col items-center justify-center rounded-xl border-[3px] py-1.5 px-0.5 text-center leading-tight ${cls.bg} ${cls.text} ${cls.border}`}
-      style={{ minHeight: 80 }}
+      style={{ minHeight: tok.minHeight }}
     >
       {word.arasaacId && (
         /* eslint-disable-next-line @next/next/no-img-element */
         <img
           src={ARASAAC_IMG(word.arasaacId)}
           alt={word.label}
-          width={52}
-          height={52}
-          className="w-[52px] h-[52px] object-contain pointer-events-none"
+          width={tok.imgPx}
+          height={tok.imgPx}
+          style={{ width: tok.imgPx, height: tok.imgPx }}
+          className="object-contain pointer-events-none"
           loading="lazy"
         />
       )}
-      <span className="font-bold text-[14px] leading-none mt-0.5 w-full line-clamp-2 px-0.5">{word.label}</span>
+      <span className="font-bold leading-none mt-0.5 w-full line-clamp-2 px-0.5" style={{ fontSize: tok.fontPx }}>{word.label}</span>
     </TapCard>
   );
 });
@@ -256,6 +259,12 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   const { settings } = useApp();
   const childName = settings.childName?.trim() || '';
   const showPersonalVocab = settings.showPersonalVocab !== false;
+  // Layout preset knobs. cardSize sizes the Core grid buttons; showPredictions
+  // (default true for legacy settings without the field) toggles the next-word
+  // strip. settings.gridColumns caps the desktop column count (see below).
+  const cardSize: CardSize = settings.cardSize ?? 'medium';
+  const showPredictions = settings.showPredictions !== false;
+  const preferredCols = settings.gridColumns;
   const [cols, setCols] = useState(10);
   const [isMagicLoading, setIsMagicLoading] = useState(false);
   const [isBlendLoading, setIsBlendLoading] = useState(false);
@@ -300,18 +309,21 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   const blendMode = !glpDisabled && stage === 2 && gestaltCount >= 2;
   const mirrorMode = !blendMode && (stageMirrorMode || gestaltMode);
 
-  // Responsive column count: 4 on phone, 5 on small tablet, 10 on desktop
+  // Responsive column count. Small screens stay capped for tap-target safety;
+  // on tablet/desktop the user's chosen grid size (settings.gridColumns, set
+  // directly or via a layout preset) drives the column count. Phones never
+  // exceed the preference but also never go below a readable minimum.
   useEffect(() => {
     const check = () => {
       const w = window.innerWidth;
-      if (w < 480) setCols(4);
-      else if (w < 768) setCols(5);
-      else setCols(10);
+      // Hard ceilings per breakpoint so cards stay tappable on small screens.
+      const ceiling = w < 480 ? 4 : w < 768 ? 6 : 10;
+      setCols(Math.max(1, Math.min(preferredCols, ceiling)));
     };
     check();
     window.addEventListener('resize', check);
     return () => window.removeEventListener('resize', check);
-  }, []);
+  }, [preferredCols]);
 
   // Preload all 50 core word audio clips so taps play instantly
   useEffect(() => {
@@ -552,7 +564,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
         {/* T2.4 Predictive next-word strip - 4 cards, recomputes on every
             tap. Sits above Your Words (frequency) + Suggested (stage) +
             locked grid. Hidden by the GLP kill switch. */}
-        {!glpDisabled && (
+        {!glpDisabled && showPredictions && (
           <PredictiveStrip cards={predictiveCards} cols={cols} onTap={handlePredictiveTap} />
         )}
 
@@ -594,7 +606,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
           style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
         >
           {SUPERCORE_50.map(word => (
-            <CoreWordButton key={word.id} word={word} onTap={handleWordTap} />
+            <CoreWordButton key={word.id} word={word} onTap={handleWordTap} cardSize={cardSize} />
           ))}
         </div>
 

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
 import type { AccountType } from '@/lib/account';
+import type { CardSize, LayoutDensity, LayoutPresetId } from '@/lib/layout-presets';
 
 /**
  * 8gent Jr App Context
@@ -45,6 +46,16 @@ export interface AppSettings {
    * regardless of this flag.
    */
   showPersonalVocab: boolean;
+  /**
+   * Layout preset system. cardSize + showPredictions are layout knobs bundled
+   * by presets (see src/lib/layout-presets.ts). activeLayoutPreset records the
+   * currently selected preset, or 'custom' when the user has hand-tuned any
+   * layout setting. density is advisory metadata carried alongside the bundle.
+   */
+  cardSize: CardSize;
+  showPredictions: boolean;
+  density: LayoutDensity;
+  activeLayoutPreset: LayoutPresetId;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -66,6 +77,12 @@ const DEFAULT_SETTINGS: AppSettings = {
   smartSuggestionsEnabled: false,
   smollmDownloaded: false,
   showPersonalVocab: true,
+  // Layout preset defaults match the "Big & Simple" preset (3 columns, large
+  // cards, predictions off) - the safest starting point for new communicators.
+  cardSize: 'large',
+  showPredictions: false,
+  density: 'relaxed',
+  activeLayoutPreset: 'big-simple',
 };
 
 const STORAGE_KEY = '8gentjr-app-settings';

--- a/src/lib/layout-presets.ts
+++ b/src/lib/layout-presets.ts
@@ -1,0 +1,155 @@
+/**
+ * Layout Presets for the Talk Core surface.
+ *
+ * A layout preset bundles the handful of settings that change how the Talk
+ * Core *looks and feels* - grid density, card size, and which helper rows are
+ * shown. Picking a preset writes its whole bundle at once via updateSettings.
+ *
+ * Presets are inspired by real-world AAC layout philosophies:
+ *  - "Core First" mirrors motor-planning-first systems (fixed, calm, few big
+ *    targets, no moving prediction row) used for early/emerging communicators.
+ *  - "Big & Simple" is a low-density, high-contrast layout for learners who
+ *    need large tap targets and minimal visual load.
+ *  - "Word Rich" is a high-density vocabulary layout for fluent communicators
+ *    who benefit from more words on screen plus predictions.
+ *  - "Quick Chat" foregrounds the child's own most-used words and predictions
+ *    for fast everyday conversation.
+ *  - "Custom" represents any hand-tuned combination the user has set.
+ *
+ * Each preset is intentionally small and declarative - it is just data. The
+ * Settings UI renders them as selectable cards; SupercoreGrid honours the
+ * resulting settings. No banned hues (270-350) appear in any hint colour.
+ */
+
+/** Card size affects tap-target min-height and label font on the Core grid. */
+export type CardSize = 'large' | 'medium' | 'small';
+
+/** Visual density of the overall surface. Currently advisory metadata that
+ *  pairs with cardSize/gridColumns; kept explicit so presets read clearly and
+ *  future surfaces can branch on it without re-deriving from columns. */
+export type LayoutDensity = 'relaxed' | 'balanced' | 'compact';
+
+/** Identifier for the active preset. 'custom' = user-tuned, no preset match. */
+export type LayoutPresetId =
+  | 'core-first'
+  | 'big-simple'
+  | 'word-rich'
+  | 'quick-chat'
+  | 'custom';
+
+/** The bundle of layout settings a preset applies. Mirrors the layout-related
+ *  fields on AppSettings so a preset can be spread straight into updateSettings. */
+export interface LayoutSettingsBundle {
+  gridColumns: number;
+  cardSize: CardSize;
+  showPredictions: boolean;
+  showPersonalVocab: boolean;
+  density: LayoutDensity;
+}
+
+export interface LayoutPreset extends LayoutSettingsBundle {
+  id: LayoutPresetId;
+  /** Friendly, child-facing name. */
+  name: string;
+  /** One-line description of who the layout suits. */
+  description: string;
+  /** Tiny visual hint for the picker card: a small grid preview. */
+  hint: {
+    /** Columns to render in the mini grid preview. */
+    cols: number;
+    /** Number of filled cells to render (visual density cue). */
+    cells: number;
+    /** Accent colour for the preview (NO hues 270-350). */
+    color: string;
+  };
+}
+
+/**
+ * The selectable presets, in display order. 'custom' is intentionally NOT in
+ * this list - it is a state the surface falls into when a user hand-tunes a
+ * setting, not something you pick directly.
+ */
+export const LAYOUT_PRESETS: LayoutPreset[] = [
+  {
+    id: 'core-first',
+    name: 'Core First',
+    description: 'Fewer, bigger core words. Calm and steady - no moving rows.',
+    gridColumns: 4,
+    cardSize: 'large',
+    showPredictions: false,
+    showPersonalVocab: false,
+    density: 'relaxed',
+    hint: { cols: 4, cells: 8, color: '#4CAF50' },
+  },
+  {
+    id: 'big-simple',
+    name: 'Big & Simple',
+    description: 'Three big columns with the fewest helper rows. Easy to aim at.',
+    gridColumns: 3,
+    cardSize: 'large',
+    showPredictions: false,
+    showPersonalVocab: true,
+    density: 'relaxed',
+    hint: { cols: 3, cells: 6, color: '#2196F3' },
+  },
+  {
+    id: 'word-rich',
+    name: 'Word Rich',
+    description: 'Six columns of smaller cards with next-word predictions on.',
+    gridColumns: 6,
+    cardSize: 'small',
+    showPredictions: true,
+    showPersonalVocab: true,
+    density: 'compact',
+    hint: { cols: 6, cells: 18, color: '#E8610A' },
+  },
+  {
+    id: 'quick-chat',
+    name: 'Quick Chat',
+    description: 'Your words and predictions up front for fast everyday talking.',
+    gridColumns: 4,
+    cardSize: 'medium',
+    showPredictions: true,
+    showPersonalVocab: true,
+    density: 'balanced',
+    hint: { cols: 4, cells: 12, color: '#009688' },
+  },
+];
+
+/** A friendly label + description for the 'custom' state shown in the picker. */
+export const CUSTOM_PRESET: Pick<LayoutPreset, 'id' | 'name' | 'description'> = {
+  id: 'custom',
+  name: 'Custom',
+  description: 'Your own mix. Change any layout setting and it lands here.',
+};
+
+/** Look up a preset by id. Returns undefined for 'custom' or unknown ids. */
+export function getLayoutPreset(id: LayoutPresetId | undefined): LayoutPreset | undefined {
+  return LAYOUT_PRESETS.find((p) => p.id === id);
+}
+
+/**
+ * Given the current layout settings, return the id of the preset that matches
+ * them exactly, or 'custom' if none do. Used to keep activeLayoutPreset honest
+ * when individual settings are changed outside the preset picker.
+ */
+export function matchPreset(s: LayoutSettingsBundle): LayoutPresetId {
+  const found = LAYOUT_PRESETS.find(
+    (p) =>
+      p.gridColumns === s.gridColumns &&
+      p.cardSize === s.cardSize &&
+      p.showPredictions === s.showPredictions &&
+      p.showPersonalVocab === s.showPersonalVocab &&
+      p.density === s.density,
+  );
+  return found ? found.id : 'custom';
+}
+
+/** Card sizing tokens consumed by the Core grid buttons. minHeight in px,
+ *  fontPx for the label, imgPx for the pictogram. Kept here so the preset
+ *  system fully owns the look of card size. */
+export const CARD_SIZE_TOKENS: Record<CardSize, { minHeight: number; fontPx: number; imgPx: number }> = {
+  large:  { minHeight: 104, fontPx: 16, imgPx: 60 },
+  medium: { minHeight: 80,  fontPx: 14, imgPx: 52 },
+  small:  { minHeight: 64,  fontPx: 12, imgPx: 40 },
+};

--- a/src/lib/layout-presets.ts
+++ b/src/lib/layout-presets.ts
@@ -116,35 +116,6 @@ export const LAYOUT_PRESETS: LayoutPreset[] = [
   },
 ];
 
-/** A friendly label + description for the 'custom' state shown in the picker. */
-export const CUSTOM_PRESET: Pick<LayoutPreset, 'id' | 'name' | 'description'> = {
-  id: 'custom',
-  name: 'Custom',
-  description: 'Your own mix. Change any layout setting and it lands here.',
-};
-
-/** Look up a preset by id. Returns undefined for 'custom' or unknown ids. */
-export function getLayoutPreset(id: LayoutPresetId | undefined): LayoutPreset | undefined {
-  return LAYOUT_PRESETS.find((p) => p.id === id);
-}
-
-/**
- * Given the current layout settings, return the id of the preset that matches
- * them exactly, or 'custom' if none do. Used to keep activeLayoutPreset honest
- * when individual settings are changed outside the preset picker.
- */
-export function matchPreset(s: LayoutSettingsBundle): LayoutPresetId {
-  const found = LAYOUT_PRESETS.find(
-    (p) =>
-      p.gridColumns === s.gridColumns &&
-      p.cardSize === s.cardSize &&
-      p.showPredictions === s.showPredictions &&
-      p.showPersonalVocab === s.showPersonalVocab &&
-      p.density === s.density,
-  );
-  return found ? found.id : 'custom';
-}
-
 /** Card sizing tokens consumed by the Core grid buttons. minHeight in px,
  *  fontPx for the label, imgPx for the pictogram. Kept here so the preset
  *  system fully owns the look of card size. */


### PR DESCRIPTION
Builds the **preset layouts** ask: pick a ready-made layout and the Talk Core reconfigures (columns, card size, which helper rows show).

- New `src/lib/layout-presets.ts` — `LayoutPreset` type + named presets (Core First / Big & Simple / Word Rich / Quick Chat / Custom), each bundling gridColumns, cardSize, showPredictions, showPersonalVocab.
- `AppContext` — new persisted settings (cardSize, showPredictions, activeLayoutPreset).
- Settings — a **Layout** section: pick a preset (applies its bundle); changing any layout setting flips to Custom.
- `SupercoreGrid` honours cardSize + showPredictions alongside the existing gridColumns/personal-vocab.

tsc clean. Built by a subagent; under spec + code-quality review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)