### PR TITLE
Clarify PWA install / always-available Add to Home Screen (#210)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,15 @@ import { speak } from '@/lib/tts';
 import { GLP_STAGES, getStage } from '@/lib/glp/stages';
 import SmartSuggestionsToggle from '@/components/SmartSuggestionsToggle';
 import { estimateStage, type StageEstimate } from '@/lib/stage-estimator';
+import {
+  initPwaInstall,
+  subscribePwaInstall,
+  hasInstallPrompt,
+  promptInstall,
+  isStandalone,
+  detectPlatform,
+  type InstallPlatform,
+} from '@/lib/pwa-install';
 
 /**
  * 8gent Jr Settings Page
@@ -275,6 +284,11 @@ export default function SettingsPage() {
           </button>
         </Section>
 
+        {/* ── Install app / Add to Home Screen ── */}
+        <Section title="Install app" icon={<IconDownload />}>
+          <InstallSection accent={accent} />
+        </Section>
+
         {/* ── Privacy & Consent ── */}
         <Section title="Privacy & Consent" icon={<IconShield />}>
           <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
@@ -446,6 +460,123 @@ function VoicePicker({ accent }: { accent: string }) {
   );
 }
 
+/* ── Install app / Add to Home Screen (PWA) ── */
+function InstallSection({ accent }: { accent: string }) {
+  const [installed, setInstalled] = useState(false);
+  const [platform, setPlatform] = useState<InstallPlatform>('other');
+  const [canPrompt, setCanPrompt] = useState(false);
+
+  useEffect(() => {
+    initPwaInstall();
+    setInstalled(isStandalone());
+    setPlatform(detectPlatform());
+    setCanPrompt(hasInstallPrompt());
+    const unsub = subscribePwaInstall(() => setCanPrompt(hasInstallPrompt()));
+    return unsub;
+  }, []);
+
+  const handleInstall = async () => {
+    const outcome = await promptInstall();
+    if (outcome === 'accepted') setInstalled(true);
+  };
+
+  // Already installed → confirmation, nothing else to do.
+  if (installed) {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-xl px-4 py-3 border-2"
+        style={{ borderColor: accent, backgroundColor: `${accent}12` }}
+        aria-live="polite"
+      >
+        <span
+          className="w-6 h-6 rounded-full flex items-center justify-center text-white text-sm font-bold flex-shrink-0"
+          style={{ backgroundColor: accent }}
+          aria-hidden="true"
+        >
+          ✓
+        </span>
+        <p className="font-semibold" style={{ color: 'var(--warm-text, #1A1614)' }}>
+          Installed — running as an app
+        </p>
+      </div>
+    );
+  }
+
+  // iOS / Safari: no beforeinstallprompt — show manual steps.
+  if (platform === 'ios' || (!canPrompt && platform === 'other')) {
+    return (
+      <div>
+        <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
+          Add 8gent Jr to your Home Screen so it opens full screen, like a real app —
+          no browser bar.
+        </p>
+        <div
+          className="rounded-xl px-4 py-3 border-2 space-y-2"
+          style={{ borderColor: 'var(--warm-border, #E8E0D6)', backgroundColor: 'white' }}
+        >
+          <div className="flex items-center gap-2">
+            <span
+              className="w-6 h-6 rounded-full flex items-center justify-center text-white text-xs font-bold flex-shrink-0"
+              style={{ backgroundColor: accent }}
+              aria-hidden="true"
+            >
+              1
+            </span>
+            <p className="text-sm" style={{ color: 'var(--warm-text, #1A1614)' }}>
+              Tap the{' '}
+              <span className="font-bold" style={{ color: accent }}>Share</span> button
+              in your browser&apos;s toolbar.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="w-6 h-6 rounded-full flex items-center justify-center text-white text-xs font-bold flex-shrink-0"
+              style={{ backgroundColor: accent }}
+              aria-hidden="true"
+            >
+              2
+            </span>
+            <p className="text-sm" style={{ color: 'var(--warm-text, #1A1614)' }}>
+              Choose{' '}
+              <span className="font-bold" style={{ color: accent }}>Add to Home Screen</span>.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Android / Chromium: one-tap native install when a deferred prompt exists.
+  return (
+    <div>
+      <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
+        Install 8gent Jr as an app — opens full screen, no browser bar, works offline.
+        This is the app; there is no separate download.
+      </p>
+      <button
+        type="button"
+        onClick={handleInstall}
+        disabled={!canPrompt}
+        aria-label="Install 8gent Jr as an app"
+        className="w-full min-h-[44px] py-3 rounded-xl font-bold text-base transition-all active:scale-[0.98] disabled:opacity-60"
+        style={{
+          backgroundColor: canPrompt ? accent : 'white',
+          color: canPrompt ? 'white' : 'var(--warm-text-muted, #9A9088)',
+          border: `2px solid ${canPrompt ? accent : 'var(--warm-border, #E8E0D6)'}`,
+        }}
+      >
+        {canPrompt ? 'Add to Home Screen' : 'Install not available yet'}
+      </button>
+      {!canPrompt && (
+        <p className="text-xs mt-2" style={{ color: 'var(--warm-text-muted, #9A9088)' }}>
+          Open this page in Chrome on Android to install. If you already installed it,
+          open it from your Home Screen.
+        </p>
+      )}
+    </div>
+  );
+}
+
 /* ── Section wrapper ── */
 function Section({ title, icon, children }: { title: string; icon: React.ReactNode; children: React.ReactNode }) {
   return (
@@ -523,6 +654,16 @@ function IconStar() {
   return (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <polygon points="12 2 15.1 8.6 22 9.3 16.7 14 18.2 21 12 17.3 5.8 21 7.3 14 2 9.3 8.9 8.6 12 2" />
+    </svg>
+  );
+}
+
+function IconDownload() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
     </svg>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -496,18 +496,18 @@ function InstallSection({ accent }: { accent: string }) {
           ✓
         </span>
         <p className="font-semibold" style={{ color: 'var(--warm-text, #1A1614)' }}>
-          Installed — running as an app
+          Installed - running as an app
         </p>
       </div>
     );
   }
 
-  // iOS / Safari: no beforeinstallprompt — show manual steps.
+  // iOS / Safari: no beforeinstallprompt - show manual steps.
   if (platform === 'ios' || (!canPrompt && platform === 'other')) {
     return (
       <div>
         <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
-          Add 8gent Jr to your Home Screen so it opens full screen, like a real app —
+          Add 8gent Jr to your Home Screen so it opens full screen, like a real app -
           no browser bar.
         </p>
         <div
@@ -550,7 +550,7 @@ function InstallSection({ accent }: { accent: string }) {
   return (
     <div>
       <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
-        Install 8gent Jr as an app — opens full screen, no browser bar, works offline.
+        Install 8gent Jr as an app - opens full screen, no browser bar, works offline.
         This is the app; there is no separate download.
       </p>
       <button

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -33,7 +33,7 @@ export function InstallPrompt() {
     // Start capturing the deferred prompt app-wide (idempotent).
     initPwaInstall();
 
-    // Already installed as standalone — never show the banner.
+    // Already installed as standalone - never show the banner.
     if (isStandalone()) return;
 
     // User previously dismissed.
@@ -43,7 +43,7 @@ export function InstallPrompt() {
     setPlatform(detected);
 
     if (detected === "ios") {
-      // iOS has no beforeinstallprompt — show manual steps after a short delay
+      // iOS has no beforeinstallprompt - show manual steps after a short delay
       // so it doesn't flash on page load.
       const t = setTimeout(() => setShow(true), 2000);
       return () => clearTimeout(t);
@@ -87,8 +87,8 @@ export function InstallPrompt() {
             </p>
             <p className="text-[#8a7e70] text-xs mt-0.5 leading-snug">
               {platform === "ios"
-                ? "Adds 8gent Jr to your Home Screen — opens full screen, no browser bar."
-                : "Opens full screen, no browser bar — works offline. This is the app."}
+                ? "Adds 8gent Jr to your Home Screen - opens full screen, no browser bar."
+                : "Opens full screen, no browser bar - works offline. This is the app."}
             </p>
           </div>
           <button

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,69 +1,65 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
+import {
+  initPwaInstall,
+  subscribePwaInstall,
+  hasInstallPrompt,
+  promptInstall,
+  isStandalone,
+  detectPlatform,
+  type InstallPlatform,
+} from "@/lib/pwa-install";
 
 /**
  * PWA install prompt with platform-specific handling.
  *
- * Android/Chrome: captures `beforeinstallprompt` → one-tap native install.
+ * Android/Chrome: uses the app-wide deferred `beforeinstallprompt` (captured in
+ *   `@/lib/pwa-install`) → one-tap native install.
  * iOS/Safari: shows manual instructions (Share → Add to Home Screen).
- * Hides itself if already running in standalone mode or user dismissed.
+ * Hides itself if already running in standalone mode or the user dismissed it.
+ *
+ * The same install plumbing also powers the always-available entry in Settings,
+ * so this banner is just the proactive nudge, not the only way in.
  */
-
-interface BeforeInstallPromptEvent extends Event {
-  prompt(): Promise<void>;
-  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
-}
-
-type Platform = "ios" | "android" | "other" | null;
 
 const DISMISS_KEY = "8gentjr_install_dismissed";
 
 export function InstallPrompt() {
-  const [platform, setPlatform] = useState<Platform>(null);
+  const [platform, setPlatform] = useState<InstallPlatform | null>(null);
   const [show, setShow] = useState(false);
-  const deferredPrompt = useRef<BeforeInstallPromptEvent | null>(null);
 
   useEffect(() => {
-    // Already installed as standalone — hide prompt
-    if (window.matchMedia("(display-mode: standalone)").matches) return;
+    // Start capturing the deferred prompt app-wide (idempotent).
+    initPwaInstall();
 
-    // User previously dismissed
+    // Already installed as standalone — never show the banner.
+    if (isStandalone()) return;
+
+    // User previously dismissed.
     if (localStorage.getItem(DISMISS_KEY)) return;
 
-    // Detect platform
-    const ua = navigator.userAgent.toLowerCase();
-    const isIOS = /ipad|iphone|ipod/.test(ua);
-    const isAndroid = /android/.test(ua);
+    const detected = detectPlatform();
+    setPlatform(detected);
 
-    if (isIOS) {
-      setPlatform("ios");
-      // Small delay so it doesn't flash on page load
+    if (detected === "ios") {
+      // iOS has no beforeinstallprompt — show manual steps after a short delay
+      // so it doesn't flash on page load.
       const t = setTimeout(() => setShow(true), 2000);
       return () => clearTimeout(t);
     }
 
-    setPlatform(isAndroid ? "android" : "other");
-
-    // Chrome/Edge/Samsung: listen for native install prompt
-    const handler = (e: Event) => {
-      e.preventDefault();
-      deferredPrompt.current = e as BeforeInstallPromptEvent;
-      setShow(true);
-    };
-
-    window.addEventListener("beforeinstallprompt", handler);
-    return () => window.removeEventListener("beforeinstallprompt", handler);
+    // Android/Chromium: reveal as soon as a native prompt is available.
+    if (hasInstallPrompt()) setShow(true);
+    const unsub = subscribePwaInstall(() => {
+      if (hasInstallPrompt()) setShow(true);
+    });
+    return unsub;
   }, []);
 
   const handleInstall = useCallback(async () => {
-    if (!deferredPrompt.current) return;
-    await deferredPrompt.current.prompt();
-    const { outcome } = await deferredPrompt.current.userChoice;
-    if (outcome === "accepted") {
-      setShow(false);
-    }
-    deferredPrompt.current = null;
+    const outcome = await promptInstall();
+    if (outcome === "accepted") setShow(false);
   }, []);
 
   const handleDismiss = useCallback(() => {
@@ -76,7 +72,7 @@ export function InstallPrompt() {
   return (
     <div
       role="dialog"
-      aria-label="Install app"
+      aria-label="Install 8gent Jr as an app"
       className="fixed bottom-20 inset-x-0 z-[9990] flex justify-center px-4 animate-slide-up"
     >
       <div className="w-full max-w-sm bg-white rounded-2xl shadow-2xl border border-[#f0e6d6] p-4">
@@ -87,18 +83,19 @@ export function InstallPrompt() {
           </div>
           <div className="flex-1 min-w-0">
             <p className="font-bold text-[#1a1a2e] text-[15px] leading-tight">
-              Add 8gent Jr to Home Screen
+              Install 8gent Jr as an app
             </p>
             <p className="text-[#8a7e70] text-xs mt-0.5 leading-snug">
               {platform === "ios"
-                ? "Opens full screen — just like a real app"
-                : "One tap to install — opens full screen"}
+                ? "Adds 8gent Jr to your Home Screen — opens full screen, no browser bar."
+                : "Opens full screen, no browser bar — works offline. This is the app."}
             </p>
           </div>
           <button
             onClick={handleDismiss}
+            type="button"
             className="w-7 h-7 shrink-0 rounded-full bg-[#f0e6d6] text-[#8a7e70] flex items-center justify-center text-xs border-none cursor-pointer hover:bg-[#e0d6c6] transition-colors"
-            aria-label="Dismiss"
+            aria-label="Dismiss install prompt"
           >
             ✕
           </button>
@@ -111,7 +108,7 @@ export function InstallPrompt() {
             <div className="flex items-center gap-2 bg-[#FFF8F0] rounded-xl px-3 py-2.5">
               <span className="text-lg">
                 {/* Share icon approximation */}
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#E8610A" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#E8610A" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8" />
                   <polyline points="16 6 12 2 8 6" />
                   <line x1="12" y1="2" x2="12" y2="15" />
@@ -128,9 +125,11 @@ export function InstallPrompt() {
             /* Android/Chrome/Other: one-tap install */
             <button
               onClick={handleInstall}
-              className="w-full py-3 rounded-xl bg-gradient-to-r from-[#FF6B35] to-[#E8610A] text-white font-bold text-sm border-none cursor-pointer active:scale-95 transition-transform shadow-md"
+              type="button"
+              aria-label="Install 8gent Jr as an app"
+              className="w-full min-h-[44px] py-3 rounded-xl bg-gradient-to-r from-[#FF6B35] to-[#E8610A] text-white font-bold text-sm border-none cursor-pointer active:scale-95 transition-transform shadow-md"
             >
-              Install App
+              Install app
             </button>
           )}
         </div>

--- a/src/lib/pwa-install.ts
+++ b/src/lib/pwa-install.ts
@@ -27,8 +27,14 @@ function notify() {
 }
 
 /**
- * Begin capturing the deferred install prompt. Idempotent — safe to call from
+ * Begin capturing the deferred install prompt. Idempotent - safe to call from
  * multiple components; only the first call wires the window listeners.
+ *
+ * `beforeinstallprompt` fires once, early. To avoid losing it we register the
+ * listener at module-evaluation time (see the self-init at the bottom of this
+ * file), not inside a React effect. Importing this module anywhere is enough to
+ * start capturing, so the deferred event survives even when the user's first
+ * page is onboarding or sign-in.
  */
 export function initPwaInstall(): void {
   if (initialized || typeof window === "undefined") return;
@@ -45,6 +51,13 @@ export function initPwaInstall(): void {
     deferredPrompt = null;
     notify();
   });
+}
+
+// Self-initialize as soon as this module is evaluated on the client. This runs
+// before any consuming component's effect, so the one-shot install event is
+// captured at the earliest possible moment regardless of which route mounts.
+if (typeof window !== "undefined") {
+  initPwaInstall();
 }
 
 /** Subscribe to deferred-prompt availability changes. Returns an unsubscribe fn. */

--- a/src/lib/pwa-install.ts
+++ b/src/lib/pwa-install.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared PWA install state.
+ *
+ * The browser fires `beforeinstallprompt` exactly once, early, and only on
+ * Chromium (Android/desktop). Whoever calls `preventDefault()` owns the only
+ * reference to that event. This module captures it app-wide so BOTH the
+ * transient InstallPrompt banner AND the always-available Settings entry can
+ * trigger the native install dialog at any time.
+ *
+ * iOS/Safari has no `beforeinstallprompt`; installs are manual
+ * (Share → Add to Home Screen), handled by the consuming components.
+ */
+
+export interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+export type InstallPlatform = "ios" | "android" | "other";
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+const listeners = new Set<() => void>();
+let initialized = false;
+
+function notify() {
+  for (const l of listeners) l();
+}
+
+/**
+ * Begin capturing the deferred install prompt. Idempotent — safe to call from
+ * multiple components; only the first call wires the window listeners.
+ */
+export function initPwaInstall(): void {
+  if (initialized || typeof window === "undefined") return;
+  initialized = true;
+
+  window.addEventListener("beforeinstallprompt", (e: Event) => {
+    e.preventDefault();
+    deferredPrompt = e as BeforeInstallPromptEvent;
+    notify();
+  });
+
+  // Once installed, drop the stale prompt so UI can flip to "Installed".
+  window.addEventListener("appinstalled", () => {
+    deferredPrompt = null;
+    notify();
+  });
+}
+
+/** Subscribe to deferred-prompt availability changes. Returns an unsubscribe fn. */
+export function subscribePwaInstall(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Whether a native (one-tap) install prompt is currently available. */
+export function hasInstallPrompt(): boolean {
+  return deferredPrompt !== null;
+}
+
+/**
+ * Trigger the native install dialog if available.
+ * Returns the user's choice, or `null` if no deferred prompt exists.
+ */
+export async function promptInstall(): Promise<"accepted" | "dismissed" | null> {
+  if (!deferredPrompt) return null;
+  await deferredPrompt.prompt();
+  const { outcome } = await deferredPrompt.userChoice;
+  // A prompt can only be used once.
+  deferredPrompt = null;
+  notify();
+  return outcome;
+}
+
+/** True when the app is already running as an installed standalone PWA. */
+export function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    // iOS Safari legacy flag
+    (window.navigator as Navigator & { standalone?: boolean }).standalone === true
+  );
+}
+
+/** Best-effort platform detection for install-instruction copy. */
+export function detectPlatform(): InstallPlatform {
+  if (typeof navigator === "undefined") return "other";
+  const ua = navigator.userAgent.toLowerCase();
+  if (/ipad|iphone|ipod/.test(ua)) return "ios";
+  if (/android/.test(ua)) return "android";
+  return "other";
+}


### PR DESCRIPTION
## Why

Closes #210. A field tester on Android did not realise the web app is installable - they thought the install banner was "just saving from the browser". This makes installability obvious and reachable at any time, not only when the transient banner happens to show.

## What

**New shared module `src/lib/pwa-install.ts`**
The browser fires `beforeinstallprompt` exactly once, early, and only whoever calls `preventDefault()` owns the reference. This module captures it app-wide so BOTH the banner and Settings can trigger the native install dialog at any time. Exposes `initPwaInstall`, `subscribePwaInstall`, `hasInstallPrompt`, `promptInstall`, `isStandalone`, `detectPlatform`.

**Settings: new "Install app" section** (always findable)
- Android/Chromium: one-tap "Add to Home Screen" using the deferred prompt.
- iOS/Safari (no `beforeinstallprompt`): manual numbered Share -> Add to Home Screen steps.
- Already installed (`display-mode: standalone`): shows "Installed - running as an app".

**InstallPrompt copy** made unambiguous that this IS the app: "Install 8gent Jr as an app - opens full screen, no browser bar, works offline." Banner now reads the deferred prompt from the shared module instead of its own local ref.

## Accessibility
Real `<button>` elements with `type` and `aria-label`, min 44px targets, `aria-live` on status. No new purple/violet hues - reuses the existing accent and warm palette only.

## Scope
Only three files touched: `src/lib/pwa-install.ts` (new), `src/components/InstallPrompt.tsx`, `src/app/settings/page.tsx`.

## Test plan
- `npx tsc --noEmit` -> 0 errors.
- Android Chrome: Settings -> Install app -> native dialog fires; banner still works.
- iOS Safari: manual steps render.
- Installed PWA: both surfaces show the "Installed" state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)