### PR TITLE
Layout Primitives: structural core-screen layouts (framework, flag-gated)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,10 @@ AGENTMAIL_FROM_INBOX=privacy@8gentjr.com
 # Dashboard: https://dashboard.clerk.com
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=
+
+# Feature flags
+# layoutPrimitives — structural Talk Core layouts (fixed/adaptive/scene/text/
+# flow/orbit). DEFAULT OFF. Set to the exact string 'true' to show the six
+# primitives picker in Settings and route the Core screen by structural kind.
+# When unset/anything-else, the app behaves exactly as today.
+NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES=

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -19,6 +19,8 @@ import {
   type InstallPlatform,
 } from '@/lib/pwa-install';
 import { LAYOUT_PRESETS, type LayoutPreset } from '@/lib/layout-presets';
+import { LAYOUT_PRIMITIVES, type LayoutPrimitive } from '@/lib/layout-primitives';
+import { isLayoutPrimitivesEnabled } from '@/lib/feature-flags';
 
 /**
  * 8gent Jr Settings Page
@@ -61,6 +63,10 @@ export default function SettingsPage() {
   const { settings, updateSettings } = useApp();
 
   const accent = settings.primaryColor || '#4CAF50';
+
+  // Layout primitives are gated behind a build-time feature flag (default off).
+  // When off, this section never renders and Settings looks exactly as today.
+  const primitivesEnabled = isLayoutPrimitivesEnabled();
 
   // Read-only stage estimate from on-device session-logger events (T3.7).
   // Computed client-side after mount so SSR stays deterministic.
@@ -203,6 +209,17 @@ export default function SettingsPage() {
           </p>
           <LayoutPresetPicker accent={accent} />
         </Section>
+
+        {/* ── Layout Primitives (feature-flagged, structural surfaces) ── */}
+        {primitivesEnabled && (
+          <Section title="Layout shape" icon={<IconLayout />}>
+            <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
+              Choose the shape of the Talk screen. Each shape arranges the same
+              words a different way. Steady Grid is the classic board.
+            </p>
+            <LayoutPrimitivePicker accent={accent} />
+          </Section>
+        )}
 
         {/* ── Grid Columns ── */}
         <Section title="Grid Size" icon={<IconGrid />}>
@@ -706,6 +723,99 @@ function PresetHint({ preset }: { preset: LayoutPreset }) {
           key={i}
           className="rounded-[2px]"
           style={{ backgroundColor: preset.hint.color, opacity: 0.85 }}
+        />
+      ))}
+    </span>
+  );
+}
+
+/* ── Layout primitive picker (radiogroup, feature-flagged) ── */
+function LayoutPrimitivePicker({ accent }: { accent: string }) {
+  const { settings, updateSettings } = useApp();
+  const activeId = settings.activeLayoutPrimitive ?? 'alpha';
+
+  const applyPrimitive = (primitive: LayoutPrimitive) => {
+    // Presentation-only: apply the primitive's layout bundle and record the
+    // selection. Vocabulary, categories, personal words and phrase folders
+    // live in their own storage keys and are never touched here.
+    updateSettings({
+      gridColumns: primitive.bundle.gridColumns,
+      cardSize: primitive.bundle.cardSize,
+      showPredictions: primitive.bundle.showPredictions,
+      showPersonalVocab: primitive.bundle.showPersonalVocab,
+      density: primitive.bundle.density,
+      activeLayoutPrimitive: primitive.id,
+    });
+  };
+
+  return (
+    <div className="space-y-2" role="radiogroup" aria-label="Talk screen shape">
+      {LAYOUT_PRIMITIVES.map((primitive) => {
+        const active = activeId === primitive.id;
+        return (
+          <button
+            key={primitive.id}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => applyPrimitive(primitive)}
+            className="w-full flex items-center gap-3 text-left px-3 py-3 rounded-xl border-2 transition-all active:scale-[0.98]"
+            style={{
+              borderColor: active ? accent : 'var(--warm-border, #E8E0D6)',
+              backgroundColor: active ? `${accent}12` : 'white',
+            }}
+          >
+            <PrimitiveHint primitive={primitive} />
+            <span className="flex-1 min-w-0">
+              <span className="flex items-center gap-2">
+                <span
+                  className="text-lg font-bold leading-none"
+                  style={{ color: primitive.hint.color }}
+                  aria-hidden="true"
+                >
+                  {primitive.glyph}
+                </span>
+                <span className="font-bold" style={{ color: active ? accent : 'var(--warm-text, #1A1614)' }}>
+                  {primitive.name}
+                </span>
+                {active && (
+                  <span
+                    className="w-5 h-5 rounded-full flex items-center justify-center text-white text-xs font-bold flex-shrink-0"
+                    style={{ backgroundColor: accent }}
+                    aria-hidden="true"
+                  >
+                    ✓
+                  </span>
+                )}
+              </span>
+              <span className="block text-sm mt-0.5" style={{ color: 'var(--warm-text-muted, #9A9088)' }}>
+                {primitive.description}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/* Tiny visual hint for a primitive: a mini grid preview mirroring its shape. */
+function PrimitiveHint({ primitive }: { primitive: LayoutPrimitive }) {
+  const cells = Array.from({ length: primitive.hint.cells });
+  return (
+    <span
+      className="grid gap-0.5 w-12 h-12 p-1 rounded-lg flex-shrink-0 self-start"
+      style={{
+        gridTemplateColumns: `repeat(${primitive.hint.cols}, 1fr)`,
+        backgroundColor: 'var(--warm-border-light, #F0EAE3)',
+      }}
+      aria-hidden="true"
+    >
+      {cells.map((_, i) => (
+        <span
+          key={i}
+          className="rounded-[2px]"
+          style={{ backgroundColor: primitive.hint.color, opacity: 0.85 }}
         />
       ))}
     </span>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -18,8 +18,13 @@ import {
   detectPlatform,
   type InstallPlatform,
 } from '@/lib/pwa-install';
-import { LAYOUT_PRESETS, type LayoutPreset } from '@/lib/layout-presets';
-import { LAYOUT_PRIMITIVES, type LayoutPrimitive } from '@/lib/layout-primitives';
+import {
+  LAYOUT_PRESETS,
+  LAYOUT_PRIMITIVES,
+  activePrimitiveIdForSettings,
+  type LayoutPreset,
+  type LayoutPrimitive,
+} from '@/lib/layout-primitives';
 import { isLayoutPrimitivesEnabled } from '@/lib/feature-flags';
 
 /**
@@ -56,6 +61,8 @@ const DEFAULTS: Partial<AppSettings> = {
   showPersonalVocab: true,
   density: 'relaxed',
   activeLayoutPreset: 'big-simple',
+  // Unified layout selection matching the default Big & Simple bundle.
+  activeLayoutPrimitive: 'eta',
 };
 
 export default function SettingsPage() {
@@ -200,26 +207,29 @@ export default function SettingsPage() {
           </div>
         </Section>
 
-        {/* ── Layout Presets ── */}
+        {/* ── Layout (single unified chooser) ── */}
         <Section title="Layout" icon={<IconLayout />}>
-          <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
-            Pick a ready-made layout for the Talk screen. Choosing one sets the
-            grid size, card size and helper rows together. Tweak any of those
-            below and the layout becomes &ldquo;Custom&rdquo;.
-          </p>
-          <LayoutPresetPicker accent={accent} />
+          {primitivesEnabled ? (
+            <>
+              <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
+                Pick a layout for the Talk screen. Each one arranges the same
+                words a different way and sets the grid size, card size and
+                helper rows together. Tweak any of those below and the layout
+                becomes &ldquo;Custom&rdquo;.
+              </p>
+              <LayoutPrimitivePicker accent={accent} />
+            </>
+          ) : (
+            <>
+              <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
+                Pick a ready-made layout for the Talk screen. Choosing one sets the
+                grid size, card size and helper rows together. Tweak any of those
+                below and the layout becomes &ldquo;Custom&rdquo;.
+              </p>
+              <LayoutPresetPicker accent={accent} />
+            </>
+          )}
         </Section>
-
-        {/* ── Layout Primitives (feature-flagged, structural surfaces) ── */}
-        {primitivesEnabled && (
-          <Section title="Layout shape" icon={<IconLayout />}>
-            <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
-              Choose the shape of the Talk screen. Each shape arranges the same
-              words a different way. Steady Grid is the classic board.
-            </p>
-            <LayoutPrimitivePicker accent={accent} />
-          </Section>
-        )}
 
         {/* ── Grid Columns ── */}
         <Section title="Grid Size" icon={<IconGrid />}>
@@ -732,12 +742,16 @@ function PresetHint({ preset }: { preset: LayoutPreset }) {
 /* ── Layout primitive picker (radiogroup, feature-flagged) ── */
 function LayoutPrimitivePicker({ accent }: { accent: string }) {
   const { settings, updateSettings } = useApp();
-  const activeId = settings.activeLayoutPrimitive ?? 'alpha';
+  // Selection is bundle-derived: a preset is "active" only while the current
+  // layout still matches its bundle. Hand-tuning any knob (Grid Size, Your
+  // Words) below makes the layout fall into "Custom" automatically.
+  const activeId = activePrimitiveIdForSettings(settings);
 
   const applyPrimitive = (primitive: LayoutPrimitive) => {
     // Presentation-only: apply the primitive's layout bundle and record the
-    // selection. Vocabulary, categories, personal words and phrase folders
-    // live in their own storage keys and are never touched here.
+    // selection in ONE action, exactly like a theme switch. Vocabulary,
+    // categories, personal words and phrase folders live in their own storage
+    // keys and are never touched here.
     updateSettings({
       gridColumns: primitive.bundle.gridColumns,
       cardSize: primitive.bundle.cardSize,
@@ -745,11 +759,15 @@ function LayoutPrimitivePicker({ accent }: { accent: string }) {
       showPersonalVocab: primitive.bundle.showPersonalVocab,
       density: primitive.bundle.density,
       activeLayoutPrimitive: primitive.id,
+      // Keep the classic selection field in sync so both pickers agree if the
+      // flag is ever toggled: a classic-backed primitive maps to its preset id,
+      // anything structural counts as a hand-tuned "custom" density.
+      activeLayoutPreset: primitive.classic ? primitive.classic.id : 'custom',
     });
   };
 
   return (
-    <div className="space-y-2" role="radiogroup" aria-label="Talk screen shape">
+    <div className="space-y-2" role="radiogroup" aria-label="Talk screen layout">
       {LAYOUT_PRIMITIVES.map((primitive) => {
         const active = activeId === primitive.id;
         return (
@@ -795,6 +813,41 @@ function LayoutPrimitivePicker({ accent }: { accent: string }) {
           </button>
         );
       })}
+
+      {/* Custom state row: not selectable, only reflects hand-tuned settings. */}
+      {activeId === 'custom' && (
+        <div
+          className="w-full flex items-center gap-3 px-3 py-3 rounded-xl border-2"
+          style={{ borderColor: accent, backgroundColor: `${accent}12` }}
+          aria-live="polite"
+        >
+          <span
+            className="w-12 h-12 rounded-lg flex items-center justify-center flex-shrink-0 border-2 border-dashed"
+            style={{ borderColor: accent, color: accent }}
+            aria-hidden="true"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 20h9" />
+              <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+            </svg>
+          </span>
+          <span className="flex-1 min-w-0">
+            <span className="flex items-center gap-2">
+              <span className="font-bold" style={{ color: accent }}>Custom</span>
+              <span
+                className="w-5 h-5 rounded-full flex items-center justify-center text-white text-xs font-bold flex-shrink-0"
+                style={{ backgroundColor: accent }}
+                aria-hidden="true"
+              >
+                ✓
+              </span>
+            </span>
+            <span className="block text-sm mt-0.5" style={{ color: 'var(--warm-text-muted, #9A9088)' }}>
+              Your own mix. Pick a layout above to start over.
+            </span>
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/talk/core/page.tsx
+++ b/src/app/talk/core/page.tsx
@@ -8,14 +8,43 @@
  *
  * Route: /talk/core
  * Issue: #20
+ *
+ * Layout primitives: when the layoutPrimitives feature flag is ON, the active
+ * structural primitive (AppSettings.activeLayoutPrimitive) selects which
+ * SURFACE renders. When the flag is OFF the surface is always the current
+ * fixed grid - this file renders exactly what it did before the flag existed.
  */
 
 import { SupercoreGrid } from '@/components/SupercoreGrid';
+import { getSurfaceForKind } from '@/components/surfaces';
+import { useApp } from '@/context/AppContext';
+import { isLayoutPrimitivesEnabled } from '@/lib/feature-flags';
+import { getPrimitive, resolveActivePrimitiveId } from '@/lib/layout-primitives';
 
 export default function SupercoreCorePage() {
+  const { settings } = useApp();
+
+  // Flag OFF: render the current grid, unchanged. This branch is a build-time
+  // constant (NEXT_PUBLIC_* is inlined), so with the flag off the surface
+  // router and primitive resolution are never reached.
+  if (!isLayoutPrimitivesEnabled()) {
+    return (
+      <div className="h-screen bg-[var(--brand-bg-warm)]">
+        <SupercoreGrid />
+      </div>
+    );
+  }
+
+  // Flag ON: resolve the active primitive to a structural surface. In this
+  // framework PR every kind still renders the Supercore grid (with a "coming
+  // soon" banner for the four not-yet-built kinds).
+  const activeId = resolveActivePrimitiveId(true, settings.activeLayoutPrimitive);
+  const primitive = getPrimitive(activeId);
+  const Surface = getSurfaceForKind(primitive.kind);
+
   return (
     <div className="h-screen bg-[var(--brand-bg-warm)]">
-      <SupercoreGrid />
+      <Surface />
     </div>
   );
 }

--- a/src/components/surfaces/index.tsx
+++ b/src/components/surfaces/index.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+/**
+ * Talk Core surface router.
+ *
+ * Maps a structural LayoutKind (see src/lib/layout-primitives) to the React
+ * component that renders it. This is the seam a later PR will use to introduce
+ * genuine scene / text / flow / orbit surfaces.
+ *
+ * FRAMEWORK PR CONTRACT: every kind renders the EXISTING SupercoreGrid so
+ * nothing breaks. The four not-yet-built kinds additionally show a slim,
+ * non-blocking "coming soon" banner ABOVE the same grid, so selecting one is
+ * honest about what it is while still giving the child a fully working board.
+ *
+ * The banner only ever appears when the layoutPrimitives flag is ON and a
+ * non-default primitive is selected. With the flag off the active primitive is
+ * always 'alpha' (fixedGrid), which renders the bare grid - byte-for-byte the
+ * current behaviour.
+ */
+
+import type { ComponentType } from 'react';
+import { SupercoreGrid, type SupercoreGridProps } from '@/components/SupercoreGrid';
+import type { LayoutKind } from '@/lib/layout-primitives';
+
+export type SurfaceProps = SupercoreGridProps;
+
+/** Alpha / fixedGrid: the current Talk Core, unchanged. */
+function FixedGridSurface(props: SurfaceProps) {
+  return <SupercoreGrid {...props} />;
+}
+
+/** Beta / adaptiveGrid: same grid today; the bundle widens the columns. */
+function AdaptiveGridSurface(props: SurfaceProps) {
+  return <SupercoreGrid {...props} />;
+}
+
+/**
+ * Placeholder for a not-yet-built structural surface. Renders the existing,
+ * fully-working grid beneath a slim banner so the child can always talk while
+ * the real surface is in development.
+ */
+function PlaceholderSurface({ label, props }: { label: string; props: SurfaceProps }) {
+  return (
+    <div className="flex flex-col h-full">
+      <div
+        className="shrink-0 px-3 py-1.5 text-[11px] font-semibold text-center"
+        style={{ backgroundColor: '#FFF4E5', color: '#8A5200' }}
+        role="status"
+        aria-live="polite"
+      >
+        {label} is coming soon - showing the Steady Grid for now.
+      </div>
+      <div className="flex-1 min-h-0">
+        <SupercoreGrid {...props} />
+      </div>
+    </div>
+  );
+}
+
+function SceneFieldSurface(props: SurfaceProps) {
+  return <PlaceholderSurface label="Scene" props={props} />;
+}
+function TextRailSurface(props: SurfaceProps) {
+  return <PlaceholderSurface label="Word Rail" props={props} />;
+}
+function FlowBoardSurface(props: SurfaceProps) {
+  return <PlaceholderSurface label="Flow Board" props={props} />;
+}
+function OrbitCoreSurface(props: SurfaceProps) {
+  return <PlaceholderSurface label="Orbit Core" props={props} />;
+}
+
+/** kind -> surface component. Exhaustive over LayoutKind (compile-checked). */
+export const SURFACE_BY_KIND: Record<LayoutKind, ComponentType<SurfaceProps>> = {
+  fixedGrid: FixedGridSurface,
+  adaptiveGrid: AdaptiveGridSurface,
+  sceneField: SceneFieldSurface,
+  textRail: TextRailSurface,
+  flowBoard: FlowBoardSurface,
+  orbitCore: OrbitCoreSurface,
+};
+
+/** Resolve the surface component for a kind. */
+export function getSurfaceForKind(kind: LayoutKind): ComponentType<SurfaceProps> {
+  return SURFACE_BY_KIND[kind] ?? FixedGridSurface;
+}

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -92,9 +92,11 @@ const DEFAULT_SETTINGS: AppSettings = {
   showPredictions: false,
   density: 'relaxed',
   activeLayoutPreset: 'big-simple',
-  // Structural layout primitive. 'alpha' = the current fixed grid. Only has an
-  // effect when the layoutPrimitives feature flag is enabled.
-  activeLayoutPrimitive: 'alpha',
+  // Unified layout selection. 'eta' is the Big & Simple grid - the same bundle
+  // as the shipped default above, so the unified picker highlights it on first
+  // run. Only has an effect when the layoutPrimitives feature flag is enabled;
+  // with the flag off this value is ignored and the surface is the fixed grid.
+  activeLayoutPrimitive: 'eta',
 };
 
 const STORAGE_KEY = '8gentjr-app-settings';

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
 import type { AccountType } from '@/lib/account';
 import type { CardSize, LayoutDensity, LayoutPresetId } from '@/lib/layout-presets';
+import type { LayoutPrimitiveId } from '@/lib/layout-primitives';
 
 /**
  * 8gent Jr App Context
@@ -56,6 +57,14 @@ export interface AppSettings {
   showPredictions: boolean;
   density: LayoutDensity;
   activeLayoutPreset: LayoutPresetId;
+  /**
+   * Layout primitives (structural layout dimension, see
+   * src/lib/layout-primitives.ts). Records which structural surface the Talk
+   * Core renders. Presentation-only and gated behind the layoutPrimitives
+   * feature flag - when the flag is off this value is ignored and the surface
+   * always resolves to 'alpha' (the current fixed grid). Default 'alpha'.
+   */
+  activeLayoutPrimitive: LayoutPrimitiveId;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -83,6 +92,9 @@ const DEFAULT_SETTINGS: AppSettings = {
   showPredictions: false,
   density: 'relaxed',
   activeLayoutPreset: 'big-simple',
+  // Structural layout primitive. 'alpha' = the current fixed grid. Only has an
+  // effect when the layoutPrimitives feature flag is enabled.
+  activeLayoutPrimitive: 'alpha',
 };
 
 const STORAGE_KEY = '8gentjr-app-settings';

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,21 @@
+/**
+ * Feature flags for 8gent Jr.
+ *
+ * The repo has no prior flag abstraction - flags to date have been plain
+ * NEXT_PUBLIC_* env reads. This keeps that convention but centralises the
+ * layoutPrimitives flag so the check reads the same way everywhere.
+ *
+ * NEXT_PUBLIC_* vars are inlined at build time, so this evaluates identically
+ * on the server and in the browser. Default is OFF: unless the env var is the
+ * exact string 'true', the flag is disabled and the app behaves as it does
+ * today (only the four existing presets show; the Core screen renders the
+ * current grid).
+ */
+
+/**
+ * layoutPrimitives - the structural layout dimension (see ./layout-primitives).
+ * DEFAULT OFF. Enable by setting NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES=true.
+ */
+export function isLayoutPrimitivesEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES === 'true';
+}

--- a/src/lib/layout-presets.ts
+++ b/src/lib/layout-presets.ts
@@ -1,24 +1,18 @@
 /**
- * Layout Presets for the Talk Core surface.
+ * Shared layout tokens and types for the Talk Core surface.
  *
- * A layout preset bundles the handful of settings that change how the Talk
- * Core *looks and feels* - grid density, card size, and which helper rows are
- * shown. Picking a preset writes its whole bundle at once via updateSettings.
+ * This module holds the small, shared vocabulary the layout system is built
+ * from - card sizes, density, the settings bundle shape, and the card-size
+ * tokens the Core grid renders with. It intentionally does NOT hold a registry
+ * of layouts any more.
  *
- * Presets are inspired by real-world AAC layout philosophies:
- *  - "Core First" mirrors motor-planning-first systems (fixed, calm, few big
- *    targets, no moving prediction row) used for early/emerging communicators.
- *  - "Big & Simple" is a low-density, high-contrast layout for learners who
- *    need large tap targets and minimal visual load.
- *  - "Word Rich" is a high-density vocabulary layout for fluent communicators
- *    who benefit from more words on screen plus predictions.
- *  - "Quick Chat" foregrounds the child's own most-used words and predictions
- *    for fast everyday conversation.
- *  - "Custom" represents any hand-tuned combination the user has set.
+ * There is now a SINGLE registry of selectable layouts, and it lives in
+ * ./layout-primitives (see LAYOUT_PRIMITIVES). The classic density presets
+ * (Core First / Big & Simple / Word Rich / Quick Chat) are DERIVED from that
+ * one registry as LAYOUT_PRESETS, so there is one source of truth for the
+ * layout bundles and no duplicated magic numbers.
  *
- * Each preset is intentionally small and declarative - it is just data. The
- * Settings UI renders them as selectable cards; SupercoreGrid honours the
- * resulting settings. No banned hues (270-350) appear in any hint colour.
+ * No banned hues (270-350) appear in any token here.
  */
 
 /** Card size affects tap-target min-height and label font on the Core grid. */
@@ -29,7 +23,9 @@ export type CardSize = 'large' | 'medium' | 'small';
  *  future surfaces can branch on it without re-deriving from columns. */
 export type LayoutDensity = 'relaxed' | 'balanced' | 'compact';
 
-/** Identifier for the active preset. 'custom' = user-tuned, no preset match. */
+/** Identifier for the active classic preset. 'custom' = user-tuned, no match.
+ *  Retained as the selection field the flag-OFF Layout picker writes, so the
+ *  shipped-today behaviour is preserved byte-for-byte. */
 export type LayoutPresetId =
   | 'core-first'
   | 'big-simple'
@@ -47,77 +43,8 @@ export interface LayoutSettingsBundle {
   density: LayoutDensity;
 }
 
-export interface LayoutPreset extends LayoutSettingsBundle {
-  id: LayoutPresetId;
-  /** Friendly, child-facing name. */
-  name: string;
-  /** One-line description of who the layout suits. */
-  description: string;
-  /** Tiny visual hint for the picker card: a small grid preview. */
-  hint: {
-    /** Columns to render in the mini grid preview. */
-    cols: number;
-    /** Number of filled cells to render (visual density cue). */
-    cells: number;
-    /** Accent colour for the preview (NO hues 270-350). */
-    color: string;
-  };
-}
-
-/**
- * The selectable presets, in display order. 'custom' is intentionally NOT in
- * this list - it is a state the surface falls into when a user hand-tunes a
- * setting, not something you pick directly.
- */
-export const LAYOUT_PRESETS: LayoutPreset[] = [
-  {
-    id: 'core-first',
-    name: 'Core First',
-    description: 'Fewer, bigger core words. Calm and steady - no moving rows.',
-    gridColumns: 4,
-    cardSize: 'large',
-    showPredictions: false,
-    showPersonalVocab: false,
-    density: 'relaxed',
-    hint: { cols: 4, cells: 8, color: '#4CAF50' },
-  },
-  {
-    id: 'big-simple',
-    name: 'Big & Simple',
-    description: 'Three big columns with the fewest helper rows. Easy to aim at.',
-    gridColumns: 3,
-    cardSize: 'large',
-    showPredictions: false,
-    showPersonalVocab: true,
-    density: 'relaxed',
-    hint: { cols: 3, cells: 6, color: '#2196F3' },
-  },
-  {
-    id: 'word-rich',
-    name: 'Word Rich',
-    description: 'Six columns of smaller cards with next-word predictions on.',
-    gridColumns: 6,
-    cardSize: 'small',
-    showPredictions: true,
-    showPersonalVocab: true,
-    density: 'compact',
-    hint: { cols: 6, cells: 18, color: '#E8610A' },
-  },
-  {
-    id: 'quick-chat',
-    name: 'Quick Chat',
-    description: 'Your words and predictions up front for fast everyday talking.',
-    gridColumns: 4,
-    cardSize: 'medium',
-    showPredictions: true,
-    showPersonalVocab: true,
-    density: 'balanced',
-    hint: { cols: 4, cells: 12, color: '#009688' },
-  },
-];
-
 /** Card sizing tokens consumed by the Core grid buttons. minHeight in px,
- *  fontPx for the label, imgPx for the pictogram. Kept here so the preset
+ *  fontPx for the label, imgPx for the pictogram. Kept here so the layout
  *  system fully owns the look of card size. */
 export const CARD_SIZE_TOKENS: Record<CardSize, { minHeight: number; fontPx: number; imgPx: number }> = {
   large:  { minHeight: 104, fontPx: 16, imgPx: 60 },

--- a/src/lib/layout-primitives.test.ts
+++ b/src/lib/layout-primitives.test.ts
@@ -1,0 +1,212 @@
+// @ts-nocheck - bun:test types not wired to main tsconfig; run with `bun test`
+/**
+ * Tests for the Layout Primitives framework. Runs via `bun test`.
+ *
+ * Proves the hard constraints from the framework PR:
+ *   - the six primitives exist, are unique, and map to the right kinds
+ *   - alpha is the default and reuses the shipped core-first bundle
+ *   - NO primitive colour lands in the banned purple/pink hue band (270-350)
+ *   - flag OFF === current behaviour: the active primitive always resolves to
+ *     'alpha' (fixedGrid) regardless of what is stored
+ *   - switching primitive and back is non-destructive: it only changes the
+ *     layout bundle + selection, never vocabulary / categories / personal
+ *     words / phrase folders / any other setting
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_PRIMITIVE_ID,
+  LAYOUT_PRIMITIVES,
+  applyPrimitive,
+  getPrimitive,
+  resolveActivePrimitiveId,
+  type LayoutKind,
+} from './layout-primitives';
+import { LAYOUT_PRESETS } from './layout-presets';
+
+/** Convert a #RRGGBB hex to an HSL hue in [0,360). */
+function hexToHue(hex: string): number {
+  const m = hex.replace('#', '');
+  const r = parseInt(m.slice(0, 2), 16) / 255;
+  const g = parseInt(m.slice(2, 4), 16) / 255;
+  const b = parseInt(m.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  if (d === 0) return 0;
+  let h: number;
+  if (max === r) h = ((g - b) / d) % 6;
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  h *= 60;
+  return h < 0 ? h + 360 : h;
+}
+
+describe('LAYOUT_PRIMITIVES shape', () => {
+  test('has exactly six primitives', () => {
+    expect(LAYOUT_PRIMITIVES).toHaveLength(6);
+  });
+
+  test('ids are the expected Greek series and are unique', () => {
+    const ids = LAYOUT_PRIMITIVES.map((p) => p.id);
+    expect(ids).toEqual(['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta']);
+    expect(new Set(ids).size).toBe(6);
+  });
+
+  test('glyphs are unique Greek capitals', () => {
+    const glyphs = LAYOUT_PRIMITIVES.map((p) => p.glyph);
+    expect(glyphs).toEqual(['Α', 'Β', 'Γ', 'Δ', 'Ε', 'Ζ']);
+    expect(new Set(glyphs).size).toBe(6);
+  });
+
+  test('kinds cover the six structural surfaces', () => {
+    const byId = Object.fromEntries(LAYOUT_PRIMITIVES.map((p) => [p.id, p.kind]));
+    const expected: Record<string, LayoutKind> = {
+      alpha: 'fixedGrid',
+      beta: 'adaptiveGrid',
+      gamma: 'sceneField',
+      delta: 'textRail',
+      epsilon: 'flowBoard',
+      zeta: 'orbitCore',
+    };
+    expect(byId).toEqual(expected);
+  });
+
+  test('every primitive carries a complete bundle and hint', () => {
+    for (const p of LAYOUT_PRIMITIVES) {
+      expect(typeof p.bundle.gridColumns).toBe('number');
+      expect(['large', 'medium', 'small']).toContain(p.bundle.cardSize);
+      expect(typeof p.bundle.showPredictions).toBe('boolean');
+      expect(typeof p.bundle.showPersonalVocab).toBe('boolean');
+      expect(['relaxed', 'balanced', 'compact']).toContain(p.bundle.density);
+      expect(p.hint.cols).toBeGreaterThan(0);
+      expect(p.hint.cells).toBeGreaterThan(0);
+      expect(p.name.length).toBeGreaterThan(0);
+      expect(p.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('brand safety: no banned purple/pink hues (270-350)', () => {
+  test('no primitive hint colour falls in the banned band', () => {
+    for (const p of LAYOUT_PRIMITIVES) {
+      const hue = hexToHue(p.hint.color);
+      expect(hue >= 270 && hue <= 350).toBe(false);
+    }
+  });
+});
+
+describe('alpha is the default and reuses core-first', () => {
+  test('DEFAULT_PRIMITIVE_ID is alpha', () => {
+    expect(DEFAULT_PRIMITIVE_ID).toBe('alpha');
+  });
+
+  test('alpha maps to fixedGrid', () => {
+    expect(getPrimitive('alpha').kind).toBe('fixedGrid');
+  });
+
+  test("alpha's bundle equals the shipped core-first preset bundle", () => {
+    const coreFirst = LAYOUT_PRESETS.find((p) => p.id === 'core-first')!;
+    const alpha = getPrimitive('alpha');
+    expect(alpha.bundle).toEqual({
+      gridColumns: coreFirst.gridColumns,
+      cardSize: coreFirst.cardSize,
+      showPredictions: coreFirst.showPredictions,
+      showPersonalVocab: coreFirst.showPersonalVocab,
+      density: coreFirst.density,
+    });
+  });
+
+  test("beta's bundle equals the shipped word-rich preset bundle", () => {
+    const wordRich = LAYOUT_PRESETS.find((p) => p.id === 'word-rich')!;
+    const beta = getPrimitive('beta');
+    expect(beta.bundle).toEqual({
+      gridColumns: wordRich.gridColumns,
+      cardSize: wordRich.cardSize,
+      showPredictions: wordRich.showPredictions,
+      showPersonalVocab: wordRich.showPersonalVocab,
+      density: wordRich.density,
+    });
+  });
+});
+
+describe('getPrimitive fallbacks', () => {
+  test('unknown / null / undefined all fall back to the default', () => {
+    expect(getPrimitive('nope').id).toBe('alpha');
+    expect(getPrimitive(null).id).toBe('alpha');
+    expect(getPrimitive(undefined).id).toBe('alpha');
+  });
+});
+
+describe('flag OFF === current behaviour', () => {
+  test('flag off always resolves to alpha regardless of stored id', () => {
+    expect(resolveActivePrimitiveId(false, 'zeta')).toBe('alpha');
+    expect(resolveActivePrimitiveId(false, 'beta')).toBe('alpha');
+    expect(resolveActivePrimitiveId(false, null)).toBe('alpha');
+  });
+
+  test('flag on honours a valid stored id and falls back for garbage', () => {
+    expect(resolveActivePrimitiveId(true, 'zeta')).toBe('zeta');
+    expect(resolveActivePrimitiveId(true, 'garbage')).toBe('alpha');
+    expect(resolveActivePrimitiveId(true, null)).toBe('alpha');
+  });
+});
+
+describe('non-destructive switch-and-back', () => {
+  // A settings-like object carrying BOTH layout fields and unrelated data that
+  // must survive any primitive switch untouched.
+  const baseSettings = {
+    // layout bundle fields (alpha / core-first values)
+    gridColumns: 4,
+    cardSize: 'large' as const,
+    showPredictions: false,
+    showPersonalVocab: false,
+    density: 'relaxed' as const,
+    activeLayoutPrimitive: 'alpha' as const,
+    // unrelated data that must never change
+    childName: 'Robin',
+    selectedVoiceId: 'voice-123',
+    glpStage: 2,
+    guardianConfirmed: true,
+    parentEmailConfirmed: true,
+  };
+
+  test('switching to beta only changes bundle + selection', () => {
+    const afterBeta = applyPrimitive(baseSettings, 'beta');
+    const beta = getPrimitive('beta');
+    // Bundle applied + selection recorded.
+    expect(afterBeta.activeLayoutPrimitive).toBe('beta');
+    expect(afterBeta.gridColumns).toBe(beta.bundle.gridColumns);
+    expect(afterBeta.cardSize).toBe(beta.bundle.cardSize);
+    expect(afterBeta.showPredictions).toBe(beta.bundle.showPredictions);
+    // Unrelated data untouched.
+    expect(afterBeta.childName).toBe('Robin');
+    expect(afterBeta.selectedVoiceId).toBe('voice-123');
+    expect(afterBeta.glpStage).toBe(2);
+    expect(afterBeta.guardianConfirmed).toBe(true);
+    expect(afterBeta.parentEmailConfirmed).toBe(true);
+  });
+
+  test('switching to a primitive and back to alpha restores the bundle exactly', () => {
+    const afterBeta = applyPrimitive(baseSettings, 'beta');
+    const backToAlpha = applyPrimitive(afterBeta, 'alpha');
+    // Layout bundle is byte-for-byte the original alpha bundle again.
+    expect(backToAlpha.gridColumns).toBe(baseSettings.gridColumns);
+    expect(backToAlpha.cardSize).toBe(baseSettings.cardSize);
+    expect(backToAlpha.showPredictions).toBe(baseSettings.showPredictions);
+    expect(backToAlpha.showPersonalVocab).toBe(baseSettings.showPersonalVocab);
+    expect(backToAlpha.density).toBe(baseSettings.density);
+    expect(backToAlpha.activeLayoutPrimitive).toBe('alpha');
+    // And all unrelated data is still exactly as it started.
+    expect(backToAlpha.childName).toBe(baseSettings.childName);
+    expect(backToAlpha.selectedVoiceId).toBe(baseSettings.selectedVoiceId);
+    expect(backToAlpha.glpStage).toBe(baseSettings.glpStage);
+    expect(backToAlpha.guardianConfirmed).toBe(baseSettings.guardianConfirmed);
+    expect(backToAlpha.parentEmailConfirmed).toBe(baseSettings.parentEmailConfirmed);
+  });
+
+  test('applyPrimitive does not mutate its input', () => {
+    const snapshot = JSON.stringify(baseSettings);
+    applyPrimitive(baseSettings, 'zeta');
+    expect(JSON.stringify(baseSettings)).toBe(snapshot);
+  });
+});

--- a/src/lib/layout-primitives.test.ts
+++ b/src/lib/layout-primitives.test.ts
@@ -1,27 +1,34 @@
 // @ts-nocheck - bun:test types not wired to main tsconfig; run with `bun test`
 /**
- * Tests for the Layout Primitives framework. Runs via `bun test`.
+ * Tests for the consolidated Layout registry. Runs via `bun test`.
  *
- * Proves the hard constraints from the framework PR:
- *   - the six primitives exist, are unique, and map to the right kinds
- *   - alpha is the default and reuses the shipped core-first bundle
+ * After consolidation there is ONE source of truth (LAYOUT_PRIMITIVES). The
+ * classic density presets (LAYOUT_PRESETS) are DERIVED from it. These tests
+ * prove:
+ *   - the eight primitives exist, are unique, and map to the right kinds
+ *   - every primitive carries BOTH a structural kind AND a full settings bundle
+ *   - the four classic presets are derived and reuse the primitive bundles
+ *     (no duplicated data)
  *   - NO primitive colour lands in the banned purple/pink hue band (270-350)
  *   - flag OFF === current behaviour: the active primitive always resolves to
  *     'alpha' (fixedGrid) regardless of what is stored
- *   - switching primitive and back is non-destructive: it only changes the
- *     layout bundle + selection, never vocabulary / categories / personal
- *     words / phrase folders / any other setting
+ *   - selecting a preset writes kind + bundle; switching and back is
+ *     non-destructive (never touches vocabulary / categories / personal words /
+ *     phrase folders / any other setting)
+ *   - Custom state is detected when the layout no longer matches any preset
  */
 import { describe, expect, test } from 'bun:test';
 import {
   DEFAULT_PRIMITIVE_ID,
   LAYOUT_PRIMITIVES,
+  LAYOUT_PRESETS,
   applyPrimitive,
+  bundlesMatch,
   getPrimitive,
   resolveActivePrimitiveId,
+  activePrimitiveIdForSettings,
   type LayoutKind,
 } from './layout-primitives';
-import { LAYOUT_PRESETS } from './layout-presets';
 
 /** Convert a #RRGGBB hex to an HSL hue in [0,360). */
 function hexToHue(hex: string): number {
@@ -41,28 +48,30 @@ function hexToHue(hex: string): number {
   return h < 0 ? h + 360 : h;
 }
 
-describe('LAYOUT_PRIMITIVES shape', () => {
-  test('has exactly six primitives', () => {
-    expect(LAYOUT_PRIMITIVES).toHaveLength(6);
+describe('LAYOUT_PRIMITIVES shape (single unified registry)', () => {
+  test('has exactly eight primitives', () => {
+    expect(LAYOUT_PRIMITIVES).toHaveLength(8);
   });
 
-  test('ids are the expected Greek series and are unique', () => {
+  test('ids are the expected series and are unique', () => {
     const ids = LAYOUT_PRIMITIVES.map((p) => p.id);
-    expect(ids).toEqual(['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta']);
-    expect(new Set(ids).size).toBe(6);
+    expect(ids).toEqual(['alpha', 'eta', 'beta', 'theta', 'gamma', 'delta', 'epsilon', 'zeta']);
+    expect(new Set(ids).size).toBe(8);
   });
 
   test('glyphs are unique Greek capitals', () => {
     const glyphs = LAYOUT_PRIMITIVES.map((p) => p.glyph);
-    expect(glyphs).toEqual(['Α', 'Β', 'Γ', 'Δ', 'Ε', 'Ζ']);
-    expect(new Set(glyphs).size).toBe(6);
+    expect(glyphs).toEqual(['Α', 'Η', 'Β', 'Θ', 'Γ', 'Δ', 'Ε', 'Ζ']);
+    expect(new Set(glyphs).size).toBe(8);
   });
 
-  test('kinds cover the six structural surfaces', () => {
+  test('kinds cover the structural surfaces', () => {
     const byId = Object.fromEntries(LAYOUT_PRIMITIVES.map((p) => [p.id, p.kind]));
     const expected: Record<string, LayoutKind> = {
       alpha: 'fixedGrid',
+      eta: 'fixedGrid',
       beta: 'adaptiveGrid',
+      theta: 'fixedGrid',
       gamma: 'sceneField',
       delta: 'textRail',
       epsilon: 'flowBoard',
@@ -71,8 +80,9 @@ describe('LAYOUT_PRIMITIVES shape', () => {
     expect(byId).toEqual(expected);
   });
 
-  test('every primitive carries a complete bundle and hint', () => {
+  test('every primitive carries a complete bundle, a kind and a hint', () => {
     for (const p of LAYOUT_PRIMITIVES) {
+      expect(typeof p.kind).toBe('string');
       expect(typeof p.bundle.gridColumns).toBe('number');
       expect(['large', 'medium', 'small']).toContain(p.bundle.cardSize);
       expect(typeof p.bundle.showPredictions).toBe('boolean');
@@ -95,7 +105,44 @@ describe('brand safety: no banned purple/pink hues (270-350)', () => {
   });
 });
 
-describe('alpha is the default and reuses core-first', () => {
+describe('classic presets are derived from the single registry', () => {
+  test('LAYOUT_PRESETS derives the four classic density presets in order', () => {
+    expect(LAYOUT_PRESETS.map((p) => p.id)).toEqual([
+      'core-first',
+      'big-simple',
+      'word-rich',
+      'quick-chat',
+    ]);
+  });
+
+  test('each classic preset reuses its backing primitive bundle (no duplicated data)', () => {
+    for (const preset of LAYOUT_PRESETS) {
+      const backing = LAYOUT_PRIMITIVES.find((p) => p.classic?.id === preset.id)!;
+      expect(bundlesMatch(preset, backing.bundle)).toBe(true);
+      // flat bundle fields on the derived preset equal the primitive bundle
+      expect(preset.gridColumns).toBe(backing.bundle.gridColumns);
+      expect(preset.cardSize).toBe(backing.bundle.cardSize);
+      expect(preset.showPredictions).toBe(backing.bundle.showPredictions);
+      expect(preset.showPersonalVocab).toBe(backing.bundle.showPersonalVocab);
+      expect(preset.density).toBe(backing.bundle.density);
+    }
+  });
+
+  test('classic preset copy matches the shipped-today values (flag-off parity)', () => {
+    const byId = Object.fromEntries(LAYOUT_PRESETS.map((p) => [p.id, p]));
+    expect(byId['core-first'].name).toBe('Core First');
+    expect(byId['big-simple'].name).toBe('Big & Simple');
+    expect(byId['word-rich'].name).toBe('Word Rich');
+    expect(byId['quick-chat'].name).toBe('Quick Chat');
+    // Bundle values preserved exactly.
+    expect(byId['core-first']).toMatchObject({ gridColumns: 4, cardSize: 'large', showPredictions: false, showPersonalVocab: false, density: 'relaxed' });
+    expect(byId['big-simple']).toMatchObject({ gridColumns: 3, cardSize: 'large', showPredictions: false, showPersonalVocab: true, density: 'relaxed' });
+    expect(byId['word-rich']).toMatchObject({ gridColumns: 6, cardSize: 'small', showPredictions: true, showPersonalVocab: true, density: 'compact' });
+    expect(byId['quick-chat']).toMatchObject({ gridColumns: 4, cardSize: 'medium', showPredictions: true, showPersonalVocab: true, density: 'balanced' });
+  });
+});
+
+describe('alpha is the safe default / fallback', () => {
   test('DEFAULT_PRIMITIVE_ID is alpha', () => {
     expect(DEFAULT_PRIMITIVE_ID).toBe('alpha');
   });
@@ -104,28 +151,21 @@ describe('alpha is the default and reuses core-first', () => {
     expect(getPrimitive('alpha').kind).toBe('fixedGrid');
   });
 
-  test("alpha's bundle equals the shipped core-first preset bundle", () => {
+  test("alpha's bundle equals the classic core-first bundle", () => {
     const coreFirst = LAYOUT_PRESETS.find((p) => p.id === 'core-first')!;
-    const alpha = getPrimitive('alpha');
-    expect(alpha.bundle).toEqual({
-      gridColumns: coreFirst.gridColumns,
-      cardSize: coreFirst.cardSize,
-      showPredictions: coreFirst.showPredictions,
-      showPersonalVocab: coreFirst.showPersonalVocab,
-      density: coreFirst.density,
-    });
+    expect(bundlesMatch(getPrimitive('alpha').bundle, coreFirst)).toBe(true);
   });
 
-  test("beta's bundle equals the shipped word-rich preset bundle", () => {
+  test("beta's bundle equals the classic word-rich bundle", () => {
     const wordRich = LAYOUT_PRESETS.find((p) => p.id === 'word-rich')!;
-    const beta = getPrimitive('beta');
-    expect(beta.bundle).toEqual({
-      gridColumns: wordRich.gridColumns,
-      cardSize: wordRich.cardSize,
-      showPredictions: wordRich.showPredictions,
-      showPersonalVocab: wordRich.showPersonalVocab,
-      density: wordRich.density,
-    });
+    expect(bundlesMatch(getPrimitive('beta').bundle, wordRich)).toBe(true);
+  });
+
+  test("eta reuses big-simple and theta reuses quick-chat", () => {
+    const bigSimple = LAYOUT_PRESETS.find((p) => p.id === 'big-simple')!;
+    const quickChat = LAYOUT_PRESETS.find((p) => p.id === 'quick-chat')!;
+    expect(bundlesMatch(getPrimitive('eta').bundle, bigSimple)).toBe(true);
+    expect(bundlesMatch(getPrimitive('theta').bundle, quickChat)).toBe(true);
   });
 });
 
@@ -140,20 +180,19 @@ describe('getPrimitive fallbacks', () => {
 describe('flag OFF === current behaviour', () => {
   test('flag off always resolves to alpha regardless of stored id', () => {
     expect(resolveActivePrimitiveId(false, 'zeta')).toBe('alpha');
-    expect(resolveActivePrimitiveId(false, 'beta')).toBe('alpha');
+    expect(resolveActivePrimitiveId(false, 'eta')).toBe('alpha');
     expect(resolveActivePrimitiveId(false, null)).toBe('alpha');
   });
 
   test('flag on honours a valid stored id and falls back for garbage', () => {
     expect(resolveActivePrimitiveId(true, 'zeta')).toBe('zeta');
+    expect(resolveActivePrimitiveId(true, 'theta')).toBe('theta');
     expect(resolveActivePrimitiveId(true, 'garbage')).toBe('alpha');
     expect(resolveActivePrimitiveId(true, null)).toBe('alpha');
   });
 });
 
-describe('non-destructive switch-and-back', () => {
-  // A settings-like object carrying BOTH layout fields and unrelated data that
-  // must survive any primitive switch untouched.
+describe('selecting a preset applies kind + bundle in one action', () => {
   const baseSettings = {
     // layout bundle fields (alpha / core-first values)
     gridColumns: 4,
@@ -170,15 +209,26 @@ describe('non-destructive switch-and-back', () => {
     parentEmailConfirmed: true,
   };
 
+  test('applyPrimitive spreads the whole bundle and records the selection', () => {
+    for (const p of LAYOUT_PRIMITIVES) {
+      const after = applyPrimitive(baseSettings, p.id);
+      expect(after.activeLayoutPrimitive).toBe(p.id);
+      expect(after.gridColumns).toBe(p.bundle.gridColumns);
+      expect(after.cardSize).toBe(p.bundle.cardSize);
+      expect(after.showPredictions).toBe(p.bundle.showPredictions);
+      expect(after.showPersonalVocab).toBe(p.bundle.showPersonalVocab);
+      expect(after.density).toBe(p.bundle.density);
+    }
+  });
+
   test('switching to beta only changes bundle + selection', () => {
     const afterBeta = applyPrimitive(baseSettings, 'beta');
     const beta = getPrimitive('beta');
-    // Bundle applied + selection recorded.
     expect(afterBeta.activeLayoutPrimitive).toBe('beta');
     expect(afterBeta.gridColumns).toBe(beta.bundle.gridColumns);
     expect(afterBeta.cardSize).toBe(beta.bundle.cardSize);
-    expect(afterBeta.showPredictions).toBe(beta.bundle.showPredictions);
-    // Unrelated data untouched.
+    // Unrelated data untouched (vocabulary/categories/personal words/phrase
+    // folders live in separate storage; these stand-ins prove nothing else moves).
     expect(afterBeta.childName).toBe('Robin');
     expect(afterBeta.selectedVoiceId).toBe('voice-123');
     expect(afterBeta.glpStage).toBe(2);
@@ -186,17 +236,15 @@ describe('non-destructive switch-and-back', () => {
     expect(afterBeta.parentEmailConfirmed).toBe(true);
   });
 
-  test('switching to a primitive and back to alpha restores the bundle exactly', () => {
-    const afterBeta = applyPrimitive(baseSettings, 'beta');
-    const backToAlpha = applyPrimitive(afterBeta, 'alpha');
-    // Layout bundle is byte-for-byte the original alpha bundle again.
+  test('switching to a preset and back to alpha restores the bundle exactly', () => {
+    const afterZeta = applyPrimitive(baseSettings, 'zeta');
+    const backToAlpha = applyPrimitive(afterZeta, 'alpha');
     expect(backToAlpha.gridColumns).toBe(baseSettings.gridColumns);
     expect(backToAlpha.cardSize).toBe(baseSettings.cardSize);
     expect(backToAlpha.showPredictions).toBe(baseSettings.showPredictions);
     expect(backToAlpha.showPersonalVocab).toBe(baseSettings.showPersonalVocab);
     expect(backToAlpha.density).toBe(baseSettings.density);
     expect(backToAlpha.activeLayoutPrimitive).toBe('alpha');
-    // And all unrelated data is still exactly as it started.
     expect(backToAlpha.childName).toBe(baseSettings.childName);
     expect(backToAlpha.selectedVoiceId).toBe(baseSettings.selectedVoiceId);
     expect(backToAlpha.glpStage).toBe(baseSettings.glpStage);
@@ -208,5 +256,42 @@ describe('non-destructive switch-and-back', () => {
     const snapshot = JSON.stringify(baseSettings);
     applyPrimitive(baseSettings, 'zeta');
     expect(JSON.stringify(baseSettings)).toBe(snapshot);
+  });
+});
+
+describe('Custom state detection', () => {
+  test('a settings bundle that matches a preset resolves to that preset id', () => {
+    const eta = getPrimitive('eta');
+    const settings = { ...eta.bundle, activeLayoutPrimitive: 'eta' as const };
+    expect(activePrimitiveIdForSettings(settings)).toBe('eta');
+  });
+
+  test('the stored selection wins when two presets share a bundle', () => {
+    // eta (Big & Simple) and gamma (Scene) share an identical bundle; the
+    // explicit stored selection disambiguates.
+    const gamma = getPrimitive('gamma');
+    expect(bundlesMatch(gamma.bundle, getPrimitive('eta').bundle)).toBe(true);
+    const settings = { ...gamma.bundle, activeLayoutPrimitive: 'gamma' as const };
+    expect(activePrimitiveIdForSettings(settings)).toBe('gamma');
+  });
+
+  test('hand-tuning a knob away from every preset yields custom', () => {
+    const eta = getPrimitive('eta');
+    // Bump grid columns to a value no preset uses.
+    const settings = { ...eta.bundle, gridColumns: 9, activeLayoutPrimitive: 'eta' as const };
+    expect(activePrimitiveIdForSettings(settings)).toBe('custom');
+  });
+
+  test('the shipped default (Big & Simple bundle, eta) is not custom', () => {
+    // Mirrors DEFAULT_SETTINGS: big-simple bundle + activeLayoutPrimitive 'eta'.
+    const settings = {
+      gridColumns: 3,
+      cardSize: 'large' as const,
+      showPredictions: false,
+      showPersonalVocab: true,
+      density: 'relaxed' as const,
+      activeLayoutPrimitive: 'eta' as const,
+    };
+    expect(activePrimitiveIdForSettings(settings)).toBe('eta');
   });
 });

--- a/src/lib/layout-primitives.ts
+++ b/src/lib/layout-primitives.ts
@@ -1,18 +1,23 @@
 /**
- * Layout Primitives - a STRUCTURAL layout dimension for the Talk Core surface.
+ * Layout Primitives - the SINGLE registry of selectable Talk Core layouts.
  *
- * The existing layout-presets system (see ./layout-presets) changes the
- * DENSITY and CARD SIZE of the SAME grid. Presets answer "how tightly packed
- * and how big are the cards?". Primitives answer a different, orthogonal
- * question: "what SHAPE of surface renders the vocabulary at all?" - a fixed
- * grid, an adaptive grid, a scene field, a text rail, a flowing board, or a
- * radial orbit core.
+ * Before consolidation the app had two competing lists: a set of DENSITY
+ * presets (Core First / Big & Simple / Word Rich / Quick Chat) and a separate
+ * set of STRUCTURAL primitives (Steady Grid / Busy Grid / Scene / ...). That
+ * meant two Layout choosers in Settings. This file is now the ONE source of
+ * truth: every selectable layout is a primitive that carries BOTH a structural
+ * `kind` (which surface renders it) AND the full settings `bundle` (grid,
+ * card size, helper rows, density). Selecting one is a single theme-like action:
+ * write `activeLayoutPrimitive` and spread the bundle via updateSettings.
  *
- * This file is ADDITIVE. It imports the existing bundle type and reuses the
- * existing preset bundles where the task calls for it, so nothing about the
- * current grid changes. Selecting a primitive is presentation-only: it never
- * touches vocabulary, categories, personal words or phrase folders (those live
- * in their own localStorage keys, independent of AppSettings).
+ * The classic density presets are DERIVED from this registry (see
+ * LAYOUT_PRESETS below), so their bundle values are never duplicated. Four of
+ * the primitives carry a `classic` descriptor so the flag-OFF Layout picker
+ * renders exactly as it did before consolidation.
+ *
+ * Selecting a primitive is presentation-only: it never touches vocabulary,
+ * categories, personal words or phrase folders (those live in their own
+ * localStorage keys, independent of AppSettings).
  *
  * Feature-flagged OFF by default (see ./feature-flags). When the flag is off,
  * the active primitive always resolves to 'alpha' (fixedGrid) and the app
@@ -21,9 +26,9 @@
  * No banned hues (270-350, purple/pink) appear in any primitive colour.
  */
 
-import {
-  LAYOUT_PRESETS,
-  type LayoutSettingsBundle,
+import type {
+  LayoutSettingsBundle,
+  LayoutPresetId,
 } from './layout-presets';
 
 /**
@@ -40,76 +45,114 @@ export type LayoutKind =
   | 'flowBoard'
   | 'orbitCore';
 
-/** Stable identifier for a primitive. Greek-letter series, alpha = default. */
+/** Stable identifier for a primitive. Greek-letter series, alpha = default.
+ *  eta/theta are the two extra calm grids carried over from the classic
+ *  Big & Simple and Quick Chat presets so no useful tuning is lost. */
 export type LayoutPrimitiveId =
   | 'alpha'
+  | 'eta'
   | 'beta'
+  | 'theta'
   | 'gamma'
   | 'delta'
   | 'epsilon'
   | 'zeta';
 
 /** The child-facing glyph shown on each primitive card. */
-export type LayoutPrimitiveGlyph = 'Α' | 'Β' | 'Γ' | 'Δ' | 'Ε' | 'Ζ';
+export type LayoutPrimitiveGlyph = 'Α' | 'Η' | 'Β' | 'Θ' | 'Γ' | 'Δ' | 'Ε' | 'Ζ';
+
+/** A small grid preview shown on a picker card. */
+export interface LayoutHint {
+  /** Columns to render in the mini preview. */
+  cols: number;
+  /** Number of filled cells to render (visual density cue). */
+  cells: number;
+  /** Accent colour for the preview (NO hues 270-350). */
+  color: string;
+}
+
+/**
+ * The classic-preset descriptor. Present on the four primitives that correspond
+ * to a density preset shipped before consolidation. It carries the classic id,
+ * name, copy and hint so the flag-OFF Layout picker (LAYOUT_PRESETS, derived
+ * below) renders byte-identically to what shipped. Absent on the four
+ * structural-only surfaces (scene / rail / flow / orbit).
+ */
+export interface ClassicPresetMeta {
+  id: Exclude<LayoutPresetId, 'custom'>;
+  name: string;
+  description: string;
+  hint: LayoutHint;
+}
 
 export interface LayoutPrimitive {
   id: LayoutPrimitiveId;
   /** Greek capital glyph rendered on the picker card. */
   glyph: LayoutPrimitiveGlyph;
-  /** Friendly, child-facing name. */
+  /** Friendly, child-facing name (unified theme name). */
   name: string;
   /** Which structural surface this primitive renders. */
   kind: LayoutKind;
-  /** Layout settings applied when this primitive is chosen (reuses the preset
-   *  bundle shape so it spreads straight into updateSettings). */
+  /** Layout settings applied when this primitive is chosen (spreads straight
+   *  into updateSettings). */
   bundle: LayoutSettingsBundle;
   /** One-line description of the shape and who it suits. */
   description: string;
   /** Tiny visual hint for the picker card: a small grid preview. */
-  hint: {
-    /** Columns to render in the mini preview. */
-    cols: number;
-    /** Number of filled cells to render (visual density cue). */
-    cells: number;
-    /** Accent colour for the preview (NO hues 270-350). */
-    color: string;
-  };
+  hint: LayoutHint;
+  /** Present when this primitive doubles as a classic density preset. */
+  classic?: ClassicPresetMeta;
 }
 
-/** The default primitive. Reused in several places so it is named once. */
+/** The default primitive used as a safe fallback for unknown/garbage ids and as
+ *  the flag-OFF resolution constant. Reused in several places so it is named
+ *  once. */
 export const DEFAULT_PRIMITIVE_ID: LayoutPrimitiveId = 'alpha';
 
-/** Look up an existing preset bundle by id, stripped to the bundle fields.
- *  Keeps alpha/beta genuinely reusing the shipped preset values rather than
- *  copying magic numbers, so the default surface stays identical to today. */
-function bundleFromPreset(presetId: string): LayoutSettingsBundle {
-  const preset = LAYOUT_PRESETS.find((p) => p.id === presetId);
-  if (!preset) {
-    // Should never happen - the preset ids are compile-time constants. Fall
-    // back to the calmest possible bundle rather than throwing in the UI path.
-    return {
-      gridColumns: 4,
-      cardSize: 'large',
-      showPredictions: false,
-      showPersonalVocab: false,
-      density: 'relaxed',
-    };
-  }
-  return {
-    gridColumns: preset.gridColumns,
-    cardSize: preset.cardSize,
-    showPredictions: preset.showPredictions,
-    showPersonalVocab: preset.showPersonalVocab,
-    density: preset.density,
-  };
-}
+/**
+ * The canonical layout bundles, defined once here (single source of truth).
+ * The classic presets reuse these exact values, so there are no duplicated
+ * magic numbers anywhere in the layout system.
+ */
+const CORE_FIRST_BUNDLE: LayoutSettingsBundle = {
+  gridColumns: 4,
+  cardSize: 'large',
+  showPredictions: false,
+  showPersonalVocab: false,
+  density: 'relaxed',
+};
+const BIG_SIMPLE_BUNDLE: LayoutSettingsBundle = {
+  gridColumns: 3,
+  cardSize: 'large',
+  showPredictions: false,
+  showPersonalVocab: true,
+  density: 'relaxed',
+};
+const WORD_RICH_BUNDLE: LayoutSettingsBundle = {
+  gridColumns: 6,
+  cardSize: 'small',
+  showPredictions: true,
+  showPersonalVocab: true,
+  density: 'compact',
+};
+const QUICK_CHAT_BUNDLE: LayoutSettingsBundle = {
+  gridColumns: 4,
+  cardSize: 'medium',
+  showPredictions: true,
+  showPersonalVocab: true,
+  density: 'balanced',
+};
 
 /**
- * The six structural primitives, in display order.
+ * The eight selectable layouts, in display order.
  *
- * Mapping (per spec):
- *   alpha   Α -> fixedGrid    (reuses core-first bundle - THE DEFAULT)
- *   beta    Β -> adaptiveGrid (reuses word-rich bundle - more columns)
+ * The first four are calm/working grids (they also back the classic presets);
+ * the last four are the experimental structural surfaces (grid-backed for now).
+ *
+ *   alpha   Α -> fixedGrid    (Core First bundle - the classic default calm grid)
+ *   eta     Η -> fixedGrid    (Big & Simple bundle - the shipped default)
+ *   beta    Β -> adaptiveGrid (Word Rich bundle - dense, predictions on)
+ *   theta   Θ -> fixedGrid    (Quick Chat bundle - your words + predictions)
  *   gamma   Γ -> sceneField   (few big cards, calm scene)
  *   delta   Δ -> textRail     (text-forward, predictions on)
  *   epsilon Ε -> flowBoard    (medium cards, flowing board)
@@ -121,18 +164,60 @@ export const LAYOUT_PRIMITIVES: LayoutPrimitive[] = [
     glyph: 'Α',
     name: 'Steady Grid',
     kind: 'fixedGrid',
-    bundle: bundleFromPreset('core-first'),
+    bundle: CORE_FIRST_BUNDLE,
     description: 'The classic fixed grid. Words never move - calm and reliable.',
     hint: { cols: 4, cells: 8, color: '#4CAF50' },
+    classic: {
+      id: 'core-first',
+      name: 'Core First',
+      description: 'Fewer, bigger core words. Calm and steady - no moving rows.',
+      hint: { cols: 4, cells: 8, color: '#4CAF50' },
+    },
+  },
+  {
+    id: 'eta',
+    glyph: 'Η',
+    name: 'Big & Simple',
+    kind: 'fixedGrid',
+    bundle: BIG_SIMPLE_BUNDLE,
+    description: 'Three big columns with the fewest helper rows. Easy to aim at.',
+    hint: { cols: 3, cells: 6, color: '#2196F3' },
+    classic: {
+      id: 'big-simple',
+      name: 'Big & Simple',
+      description: 'Three big columns with the fewest helper rows. Easy to aim at.',
+      hint: { cols: 3, cells: 6, color: '#2196F3' },
+    },
   },
   {
     id: 'beta',
     glyph: 'Β',
     name: 'Busy Grid',
     kind: 'adaptiveGrid',
-    bundle: bundleFromPreset('word-rich'),
+    bundle: WORD_RICH_BUNDLE,
     description: 'More words on screen with next-word helpers for fluent talkers.',
     hint: { cols: 6, cells: 18, color: '#E8610A' },
+    classic: {
+      id: 'word-rich',
+      name: 'Word Rich',
+      description: 'Six columns of smaller cards with next-word predictions on.',
+      hint: { cols: 6, cells: 18, color: '#E8610A' },
+    },
+  },
+  {
+    id: 'theta',
+    glyph: 'Θ',
+    name: 'Quick Chat',
+    kind: 'fixedGrid',
+    bundle: QUICK_CHAT_BUNDLE,
+    description: 'Your words and predictions up front for fast everyday talking.',
+    hint: { cols: 4, cells: 12, color: '#009688' },
+    classic: {
+      id: 'quick-chat',
+      name: 'Quick Chat',
+      description: 'Your words and predictions up front for fast everyday talking.',
+      hint: { cols: 4, cells: 12, color: '#009688' },
+    },
   },
   {
     id: 'gamma',
@@ -245,3 +330,69 @@ export function applyPrimitive<T extends LayoutSettingsBundle & Record<string, u
     activeLayoutPrimitive: primitive.id,
   };
 }
+
+/** True when two bundles carry identical layout values. */
+export function bundlesMatch(a: LayoutSettingsBundle, b: LayoutSettingsBundle): boolean {
+  return (
+    a.gridColumns === b.gridColumns &&
+    a.cardSize === b.cardSize &&
+    a.showPredictions === b.showPredictions &&
+    a.showPersonalVocab === b.showPersonalVocab &&
+    a.density === b.density
+  );
+}
+
+/**
+ * Resolve the selected unified-picker id for a settings object, or 'custom'
+ * when the current layout no longer matches any preset (i.e. the user
+ * hand-tuned a knob away from every preset).
+ *
+ * The stored `activeLayoutPrimitive` is trusted first: if its bundle still
+ * matches the current settings, that id wins (this disambiguates presets that
+ * happen to share a bundle, e.g. Big & Simple vs Scene). Only if the stored
+ * selection no longer matches do we look for any other preset with the same
+ * bundle before falling back to 'custom'.
+ */
+export function activePrimitiveIdForSettings(
+  s: LayoutSettingsBundle & { activeLayoutPrimitive?: string | null },
+): LayoutPrimitiveId | 'custom' {
+  const stored = getPrimitive(s.activeLayoutPrimitive);
+  if (bundlesMatch(stored.bundle, s)) return stored.id;
+  const match = LAYOUT_PRIMITIVES.find((p) => bundlesMatch(p.bundle, s));
+  return match ? match.id : 'custom';
+}
+
+// ---------------------------------------------------------------------------
+// Derived classic presets (flag-OFF Layout picker)
+// ---------------------------------------------------------------------------
+
+/**
+ * A classic density preset, in the flat shape the flag-OFF Layout picker
+ * renders (bundle fields at the top level, plus a hint). DERIVED from the
+ * primitives that carry a `classic` descriptor - never authored twice.
+ */
+export interface LayoutPreset extends LayoutSettingsBundle {
+  id: Exclude<LayoutPresetId, 'custom'>;
+  name: string;
+  description: string;
+  hint: LayoutHint;
+}
+
+/**
+ * The four classic density presets (Core First / Big & Simple / Word Rich /
+ * Quick Chat), derived from the single registry so the flag-OFF picker keeps
+ * working exactly as it shipped, with no duplicated data.
+ */
+export const LAYOUT_PRESETS: LayoutPreset[] = LAYOUT_PRIMITIVES.filter(
+  (p): p is LayoutPrimitive & { classic: ClassicPresetMeta } => p.classic !== undefined,
+).map((p) => ({
+  id: p.classic.id,
+  name: p.classic.name,
+  description: p.classic.description,
+  gridColumns: p.bundle.gridColumns,
+  cardSize: p.bundle.cardSize,
+  showPredictions: p.bundle.showPredictions,
+  showPersonalVocab: p.bundle.showPersonalVocab,
+  density: p.bundle.density,
+  hint: p.classic.hint,
+}));

--- a/src/lib/layout-primitives.ts
+++ b/src/lib/layout-primitives.ts
@@ -1,0 +1,247 @@
+/**
+ * Layout Primitives - a STRUCTURAL layout dimension for the Talk Core surface.
+ *
+ * The existing layout-presets system (see ./layout-presets) changes the
+ * DENSITY and CARD SIZE of the SAME grid. Presets answer "how tightly packed
+ * and how big are the cards?". Primitives answer a different, orthogonal
+ * question: "what SHAPE of surface renders the vocabulary at all?" - a fixed
+ * grid, an adaptive grid, a scene field, a text rail, a flowing board, or a
+ * radial orbit core.
+ *
+ * This file is ADDITIVE. It imports the existing bundle type and reuses the
+ * existing preset bundles where the task calls for it, so nothing about the
+ * current grid changes. Selecting a primitive is presentation-only: it never
+ * touches vocabulary, categories, personal words or phrase folders (those live
+ * in their own localStorage keys, independent of AppSettings).
+ *
+ * Feature-flagged OFF by default (see ./feature-flags). When the flag is off,
+ * the active primitive always resolves to 'alpha' (fixedGrid) and the app
+ * behaves exactly as it does today.
+ *
+ * No banned hues (270-350, purple/pink) appear in any primitive colour.
+ */
+
+import {
+  LAYOUT_PRESETS,
+  type LayoutSettingsBundle,
+} from './layout-presets';
+
+/**
+ * The structural kind of a Talk Core surface. Each kind is a distinct way of
+ * arranging the vocabulary on screen. In THIS framework PR every kind renders
+ * the existing SupercoreGrid; the scene/text/flow/orbit surfaces are a later
+ * PR. The kind is what a surface-router switches on.
+ */
+export type LayoutKind =
+  | 'fixedGrid'
+  | 'adaptiveGrid'
+  | 'sceneField'
+  | 'textRail'
+  | 'flowBoard'
+  | 'orbitCore';
+
+/** Stable identifier for a primitive. Greek-letter series, alpha = default. */
+export type LayoutPrimitiveId =
+  | 'alpha'
+  | 'beta'
+  | 'gamma'
+  | 'delta'
+  | 'epsilon'
+  | 'zeta';
+
+/** The child-facing glyph shown on each primitive card. */
+export type LayoutPrimitiveGlyph = 'Α' | 'Β' | 'Γ' | 'Δ' | 'Ε' | 'Ζ';
+
+export interface LayoutPrimitive {
+  id: LayoutPrimitiveId;
+  /** Greek capital glyph rendered on the picker card. */
+  glyph: LayoutPrimitiveGlyph;
+  /** Friendly, child-facing name. */
+  name: string;
+  /** Which structural surface this primitive renders. */
+  kind: LayoutKind;
+  /** Layout settings applied when this primitive is chosen (reuses the preset
+   *  bundle shape so it spreads straight into updateSettings). */
+  bundle: LayoutSettingsBundle;
+  /** One-line description of the shape and who it suits. */
+  description: string;
+  /** Tiny visual hint for the picker card: a small grid preview. */
+  hint: {
+    /** Columns to render in the mini preview. */
+    cols: number;
+    /** Number of filled cells to render (visual density cue). */
+    cells: number;
+    /** Accent colour for the preview (NO hues 270-350). */
+    color: string;
+  };
+}
+
+/** The default primitive. Reused in several places so it is named once. */
+export const DEFAULT_PRIMITIVE_ID: LayoutPrimitiveId = 'alpha';
+
+/** Look up an existing preset bundle by id, stripped to the bundle fields.
+ *  Keeps alpha/beta genuinely reusing the shipped preset values rather than
+ *  copying magic numbers, so the default surface stays identical to today. */
+function bundleFromPreset(presetId: string): LayoutSettingsBundle {
+  const preset = LAYOUT_PRESETS.find((p) => p.id === presetId);
+  if (!preset) {
+    // Should never happen - the preset ids are compile-time constants. Fall
+    // back to the calmest possible bundle rather than throwing in the UI path.
+    return {
+      gridColumns: 4,
+      cardSize: 'large',
+      showPredictions: false,
+      showPersonalVocab: false,
+      density: 'relaxed',
+    };
+  }
+  return {
+    gridColumns: preset.gridColumns,
+    cardSize: preset.cardSize,
+    showPredictions: preset.showPredictions,
+    showPersonalVocab: preset.showPersonalVocab,
+    density: preset.density,
+  };
+}
+
+/**
+ * The six structural primitives, in display order.
+ *
+ * Mapping (per spec):
+ *   alpha   Α -> fixedGrid    (reuses core-first bundle - THE DEFAULT)
+ *   beta    Β -> adaptiveGrid (reuses word-rich bundle - more columns)
+ *   gamma   Γ -> sceneField   (few big cards, calm scene)
+ *   delta   Δ -> textRail     (text-forward, predictions on)
+ *   epsilon Ε -> flowBoard    (medium cards, flowing board)
+ *   zeta    Ζ -> orbitCore    (core-forward radial arrangement)
+ */
+export const LAYOUT_PRIMITIVES: LayoutPrimitive[] = [
+  {
+    id: 'alpha',
+    glyph: 'Α',
+    name: 'Steady Grid',
+    kind: 'fixedGrid',
+    bundle: bundleFromPreset('core-first'),
+    description: 'The classic fixed grid. Words never move - calm and reliable.',
+    hint: { cols: 4, cells: 8, color: '#4CAF50' },
+  },
+  {
+    id: 'beta',
+    glyph: 'Β',
+    name: 'Busy Grid',
+    kind: 'adaptiveGrid',
+    bundle: bundleFromPreset('word-rich'),
+    description: 'More words on screen with next-word helpers for fluent talkers.',
+    hint: { cols: 6, cells: 18, color: '#E8610A' },
+  },
+  {
+    id: 'gamma',
+    glyph: 'Γ',
+    name: 'Scene',
+    kind: 'sceneField',
+    bundle: {
+      gridColumns: 3,
+      cardSize: 'large',
+      showPredictions: false,
+      showPersonalVocab: true,
+      density: 'relaxed',
+    },
+    description: 'Big picture cards arranged like a scene. Coming soon.',
+    hint: { cols: 3, cells: 6, color: '#2196F3' },
+  },
+  {
+    id: 'delta',
+    glyph: 'Δ',
+    name: 'Word Rail',
+    kind: 'textRail',
+    bundle: {
+      gridColumns: 4,
+      cardSize: 'medium',
+      showPredictions: true,
+      showPersonalVocab: true,
+      density: 'balanced',
+    },
+    description: 'A text-forward rail with predictions up front. Coming soon.',
+    hint: { cols: 4, cells: 12, color: '#009688' },
+  },
+  {
+    id: 'epsilon',
+    glyph: 'Ε',
+    name: 'Flow Board',
+    kind: 'flowBoard',
+    bundle: {
+      gridColumns: 5,
+      cardSize: 'medium',
+      showPredictions: true,
+      showPersonalVocab: true,
+      density: 'balanced',
+    },
+    description: 'Cards flow to fit the screen at any size. Coming soon.',
+    hint: { cols: 5, cells: 15, color: '#F4A100' },
+  },
+  {
+    id: 'zeta',
+    glyph: 'Ζ',
+    name: 'Orbit Core',
+    kind: 'orbitCore',
+    bundle: {
+      gridColumns: 4,
+      cardSize: 'large',
+      showPredictions: false,
+      showPersonalVocab: true,
+      density: 'relaxed',
+    },
+    description: 'Core words held close in a radial arrangement. Coming soon.',
+    hint: { cols: 4, cells: 8, color: '#F44336' },
+  },
+];
+
+/** Fast id -> primitive lookup, built once. */
+const PRIMITIVE_BY_ID: Record<LayoutPrimitiveId, LayoutPrimitive> =
+  LAYOUT_PRIMITIVES.reduce((acc, p) => {
+    acc[p.id] = p;
+    return acc;
+  }, {} as Record<LayoutPrimitiveId, LayoutPrimitive>);
+
+/** Get a primitive by id, always falling back to the default. Never throws. */
+export function getPrimitive(id: string | null | undefined): LayoutPrimitive {
+  if (id && id in PRIMITIVE_BY_ID) {
+    return PRIMITIVE_BY_ID[id as LayoutPrimitiveId];
+  }
+  return PRIMITIVE_BY_ID[DEFAULT_PRIMITIVE_ID];
+}
+
+/**
+ * Resolve which primitive id is actually active given the feature flag.
+ *
+ * This is the single choke-point that guarantees flag-off === today: when the
+ * flag is off, the active primitive is ALWAYS 'alpha' (fixedGrid), no matter
+ * what is stored in settings. Callers must route surface selection through
+ * this function.
+ */
+export function resolveActivePrimitiveId(
+  flagEnabled: boolean,
+  storedId: string | null | undefined,
+): LayoutPrimitiveId {
+  if (!flagEnabled) return DEFAULT_PRIMITIVE_ID;
+  return getPrimitive(storedId).id;
+}
+
+/**
+ * Purely apply a primitive's layout bundle onto an existing settings-like
+ * object, returning a NEW object. Only the five bundle fields plus
+ * activeLayoutPrimitive change; every other field (childName, voice, consent,
+ * etc.) is preserved untouched. Used by the Settings picker and covered by the
+ * switch-and-back test that proves data is never lost.
+ */
+export function applyPrimitive<T extends LayoutSettingsBundle & Record<string, unknown>>(
+  base: T,
+  id: LayoutPrimitiveId,
+): T & { activeLayoutPrimitive: LayoutPrimitiveId } {
+  const primitive = getPrimitive(id);
+  return {
+    ...base,
+    ...primitive.bundle,
+    activeLayoutPrimitive: primitive.id,
+  };
+}


### PR DESCRIPTION
Refs #220 (does not auto-close - framework only)

## What changed

Adds a **structural** layout dimension for the Talk Core surface, orthogonal to the existing density/card-size **presets**. Presets change how tightly packed the same grid is; primitives change **what shape of surface** renders the vocabulary (fixed grid, adaptive grid, scene field, text rail, flow board, orbit core).

Additive and non-destructive. With the flag off, the app is byte-for-byte the current behaviour.

**New files**
- `src/lib/layout-primitives.ts` - `LayoutKind`, `LayoutPrimitive`, `LAYOUT_PRIMITIVES` (six: alpha..zeta), `getPrimitive`, `resolveActivePrimitiveId`, `applyPrimitive`. `alpha` (Α, fixedGrid) reuses the shipped `core-first` preset bundle and is the default; `beta` (Β, adaptiveGrid) reuses `word-rich`. No banned hues (270-350) in any colour.
- `src/lib/feature-flags.ts` - `isLayoutPrimitivesEnabled()` reading `NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES`. **DEFAULT OFF**.
- `src/components/surfaces/index.tsx` - `kind -> component` router. Every kind renders the existing `SupercoreGrid`; the four not-yet-built kinds add a slim "coming soon" banner above the same working grid.
- `src/lib/layout-primitives.test.ts` - unit tests (see below).

**Edited files**
- `src/context/AppContext.tsx` - persisted `activeLayoutPrimitive` setting (default `'alpha'`).
- `src/app/talk/core/page.tsx` - routes by surface kind ONLY when the flag is on; flag off renders the current grid unchanged.
- `src/app/settings/page.tsx` - six-primitive picker with mini-preview, shown only when the flag is on. Existing preset picker untouched.
- `.env.example` - documents `NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES`.

## The flag

`NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES` - **default OFF**. Enable with the exact string `true`. When off: only the existing four presets show, the Core screen renders the current grid, and `resolveActivePrimitiveId` always returns `alpha`.

## Success criteria

- [x] Six primitives (alpha..zeta) mapping to the six structural kinds; alpha = fixedGrid = default reusing core-first
- [x] Persisted `activeLayoutPrimitive` (default `alpha`), presentation-only
- [x] Feature flag, default OFF; flag-off === current behaviour (asserted in tests)
- [x] Core screen routes by surface kind only when flag on; every kind renders the existing grid (no scene/text/flow/orbit surfaces built here)
- [x] Settings picker shows six primitives with mini-preview only when flag on
- [x] Additive only - no refactor of SupercoreGrid or the preset system
- [x] Non-destructive - switching primitive preserves vocabulary/categories/personal words/phrase folders (independent storage keys); unit-tested switch-and-back
- [x] No banned hues (270-350); no em dashes in shipped copy; TypeScript strict (tsc --noEmit clean); no `any` leaks
- [x] No hardcoded/mocked vocabulary; no new data collection or third-party calls; guest use unaffected

## Test / build results

- `bun test` - **68 pass, 0 fail** (16 new in `layout-primitives.test.ts`: six-primitive shape, unique ids/glyphs, kind mapping, no banned hues, alpha==core-first / beta==word-rich bundles, flag-off resolves to alpha, switch-and-back preserves data, applyPrimitive is pure)
- `npx tsc --noEmit` - **clean (exit 0)**, strict mode
- `next build` - **compiles + type-checks successfully**; `/talk/core` and `/settings` build as static routes. (`npm run lint` is not runnable in this repo - ESLint was never configured/installed here, unrelated to this PR.)

## Screenshots (headless Chrome, three widths, flag OFF and ON)

Saved locally for review at `/Users/jamesspalding/layout-primitives-review/`:

| State | 390 (phone) | 834 (iPad portrait) | 1280 (landscape) |
|-------|-------------|---------------------|------------------|
| Flag OFF (unchanged) | `core-OFF-390.png` | `core-OFF-834.png` | `core-OFF-1280.png` |
| Flag ON (gamma applied) | `core-ON-390.png` | `core-ON-834.png` | `core-ON-1280.png` |

Flag OFF renders the current Talk Core grid unchanged. Flag ON with the `gamma`/`sceneField` primitive shows the "Scene is coming soon - showing the Steady Grid for now." banner above the same working grid, confirming the surface router. Full Settings picker (flag on, all six primitives visible with glyphs + mini-previews): `settings-ON-full.png`.

Note: the small red "1 Issue" badge in the shots is the Next.js dev error overlay (a dummy local Clerk key), not part of the app UI.

---

## Update: design consolidation (one unified Layout picker)

Follow-up on the same branch. Settings previously showed **two** competing layout choosers - the classic density presets and the new "Layout shape" primitives. This collapses them into a **single "Layout" section** that behaves like choosing a theme: one list, one action writes both the structural kind and the full settings bundle.

**Reconciliation - one source of truth.** `LAYOUT_PRIMITIVES` is now the single registry. Every entry carries a structural `kind` **and** the full `LayoutSettingsBundle`. The old second registry (`LAYOUT_PRESETS` array + `LayoutPreset`) is retired; the four classic density presets are now **derived** from the primitives that carry a `classic` descriptor, so there are no duplicated bundle values. `layout-presets.ts` is now shared tokens/types only (`CardSize`, `LayoutDensity`, `LayoutPresetId`, `LayoutSettingsBundle`, `CARD_SIZE_TOKENS`).

**No tuning lost.** The two useful bundles that were not primitives are carried as additional entries in the same list: `eta` (Η, Big & Simple, `fixedGrid`) and `theta` (Θ, Quick Chat, `fixedGrid`). Big & Simple remains the shipped default; `activeLayoutPrimitive` now defaults to `eta` so the picker highlights the true default bundle. Registry order: Steady Grid Α, Big & Simple Η, Busy Grid Β, Quick Chat Θ, Scene Γ, Word Rail Δ, Flow Board Ε, Orbit Core Ζ.

**Custom state.** The unified picker resolves its selection from the current bundle (`activePrimitiveIdForSettings`): hand-tuning any knob (Grid Size, Your Words) away from every preset shows **Custom**, and a stored selection wins when two presets share a bundle.

**Flag still default OFF.** With `NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES` off, the single Layout section renders the **classic four presets exactly as today** and the Core grid is unchanged - byte-for-byte parity. The unified eight-entry picker only appears when the flag is on. The separate "Layout shape" section is removed, so Settings has exactly one Layout chooser in both states.

**Files changed in this consolidation**
- `src/lib/layout-primitives.ts` - single registry (8 entries), `classic` descriptor, derived `LAYOUT_PRESETS`, `bundlesMatch`, `activePrimitiveIdForSettings`; `bundleFromPreset` removed.
- `src/lib/layout-presets.ts` - reduced to shared tokens/types; second registry retired.
- `src/context/AppContext.tsx` - default `activeLayoutPrimitive` now `eta` (matches the default Big & Simple bundle).
- `src/app/settings/page.tsx` - one "Layout" section (unified picker when flag on, classic picker when off); "Layout shape" section removed; unified picker gains Custom detection + Custom row.
- `src/lib/layout-primitives.test.ts` - updated for the single registry, per-preset kind+bundle, derived classic presets, flag-off parity, switch-and-back data preservation, and Custom detection.

**Validation (consolidation)**
- `bun test` - **77 pass, 0 fail** (25 in `layout-primitives.test.ts`).
- `npx tsc --noEmit` - **clean**, strict.
- `next build` - **compiles + type-checks**; `/talk/core` and `/settings` build as static routes.
- Screenshots re-captured (headless Chrome, overwritten) at `/Users/jamesspalding/layout-primitives-review/`: `core-OFF-{390,834,1280}.png` (default Big & Simple grid), `core-ON-{390,834,1280}.png` (Busy Grid `beta` applied - predictions row + denser grid), and `settings-ON-full.png` showing the single unified Layout section with all eight presets and no second section.