### PR TITLE
feat(layout): the four real Layout Primitive surfaces (Scene, Word Rail, Flow Board, Orbit Core)

### DIFF
--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -25,7 +25,15 @@
  */
 
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
-import { FITZGERALD_COLORS, type WordCategory } from '@/lib/fitzgerald-key';
+import {
+  SUPERCORE_50,
+  ARASAAC_IMG,
+  FITZGERALD_CLASSES,
+  getGridCategoryColor,
+  performCoreTap,
+  type SupercoreWord as CoreWord,
+  type FitzgeraldCategory,
+} from '@/lib/core-vocab';
 import { logWord } from '@/lib/session-logger';
 import { speak as elevenLabsSpeak, preloadAudio } from '@/lib/tts';
 import { SharedSentenceBar } from '@/components/SharedSentenceBar';
@@ -39,133 +47,11 @@ import { getPersonalVocab } from '@/lib/personal-vocab';
 import { predictNext, PREDICTIVE_CARD_COUNT } from '@/lib/predictive';
 import { CARD_SIZE_TOKENS, type CardSize } from '@/lib/layout-presets';
 
-// =============================================================================
-// Fitzgerald Key Color Definitions (mapped from shared vocabulary system)
-// =============================================================================
-
-type FitzgeraldCategory =
-  | 'people'
-  | 'verbs'
-  | 'descriptors'
-  | 'prepositions'
-  | 'social'
-  | 'questions'
-  | 'determiners'
-  | 'negation';
-
-/** Map grid categories to canonical Fitzgerald Key word categories */
-const CATEGORY_TO_WORD_TYPE: Record<FitzgeraldCategory, WordCategory> = {
-  people: 'pronoun',
-  verbs: 'verb',
-  descriptors: 'adjective',
-  prepositions: 'preposition',
-  social: 'social',
-  questions: 'question',
-  determiners: 'determiner',
-  negation: 'negation',
-};
-
-/**
- * Maps each Fitzgerald category to Tailwind class strings using CSS variables.
- * bg = background, text = text color, border = border color, chip = sentence strip chip
- */
-const FITZGERALD_CLASSES: Record<FitzgeraldCategory, { bg: string; text: string; border: string }> = {
-  people:       { bg: 'bg-fitzgerald-yellow', text: 'text-fitzgerald-yellow-text', border: 'border-fitzgerald-yellow-border' },
-  verbs:        { bg: 'bg-fitzgerald-green',  text: 'text-fitzgerald-green-text',  border: 'border-fitzgerald-green-border' },
-  descriptors:  { bg: 'bg-fitzgerald-blue',   text: 'text-fitzgerald-blue-text',   border: 'border-fitzgerald-blue-border' },
-  prepositions: { bg: 'bg-fitzgerald-purple', text: 'text-fitzgerald-purple-text', border: 'border-fitzgerald-purple-border' },
-  social:       { bg: 'bg-fitzgerald-pink',   text: 'text-fitzgerald-pink-text',   border: 'border-fitzgerald-pink-border' },
-  questions:    { bg: 'bg-fitzgerald-orange',  text: 'text-fitzgerald-orange-text', border: 'border-fitzgerald-orange-border' },
-  determiners:  { bg: 'bg-fitzgerald-white',   text: 'text-fitzgerald-white-text',  border: 'border-fitzgerald-white-border' },
-  negation:     { bg: 'bg-fitzgerald-red',    text: 'text-fitzgerald-red-text',    border: 'border-fitzgerald-red-border' },
-};
-
-/** Get inline Fitzgerald Key color for a grid category (used by non-Tailwind contexts) */
-export function getGridCategoryColor(category: FitzgeraldCategory) {
-  return FITZGERALD_COLORS[CATEGORY_TO_WORD_TYPE[category]];
-}
-
-// =============================================================================
-// Core Word Data - FIXED positions, NEVER reorder
-// =============================================================================
-
-interface CoreWord {
-  id: string;
-  label: string;
-  category: FitzgeraldCategory;
-  arasaacId?: number;
-}
-
-const ARASAAC_IMG = (id: number) => `https://static.arasaac.org/pictograms/${id}/${id}_500.png`;
-
-/**
- * THE SUPERCORE 50 GRID
- *
- * Layout: 10 columns x 5 rows = 50 cells
- * Words are ordered LEFT-TO-RIGHT, TOP-TO-BOTTOM.
- * THIS ORDER IS PERMANENT. NEVER CHANGE IT.
- */
-const SUPERCORE_50: CoreWord[] = [
-  // Row 1
-  { id: 'w01', label: 'I',         category: 'people',      arasaacId: 6632 },
-  { id: 'w02', label: 'you',       category: 'people',      arasaacId: 6625 },
-  { id: 'w03', label: 'want',      category: 'verbs',       arasaacId: 5441 },
-  { id: 'w04', label: 'need',      category: 'verbs',       arasaacId: 37160 },
-  { id: 'w05', label: 'like',      category: 'verbs',       arasaacId: 37826 },
-  { id: 'w06', label: "don't",     category: 'negation',    arasaacId: 5525 },
-  { id: 'w07', label: 'help',      category: 'social',      arasaacId: 32648 },
-  { id: 'w08', label: 'more',      category: 'determiners', arasaacId: 5508 },
-  { id: 'w09', label: 'stop',      category: 'negation',    arasaacId: 7196 },
-  { id: 'w10', label: 'go',        category: 'verbs',       arasaacId: 8142 },
-
-  // Row 2
-  { id: 'w11', label: 'come',      category: 'verbs',       arasaacId: 32669 },
-  { id: 'w12', label: 'look',      category: 'verbs',       arasaacId: 6564 },
-  { id: 'w13', label: 'eat',       category: 'verbs',       arasaacId: 6456 },
-  { id: 'w14', label: 'drink',     category: 'verbs',       arasaacId: 6061 },
-  { id: 'w15', label: 'play',      category: 'verbs',       arasaacId: 23392 },
-  { id: 'w16', label: 'yes',       category: 'social',      arasaacId: 5584 },
-  { id: 'w17', label: 'no',        category: 'negation',    arasaacId: 5526 },
-  { id: 'w18', label: 'please',    category: 'social',      arasaacId: 8195 },
-  { id: 'w19', label: 'thank you', category: 'social',      arasaacId: 8129 },
-  { id: 'w20', label: 'sorry',     category: 'social',      arasaacId: 11625 },
-
-  // Row 3
-  { id: 'w21', label: 'happy',     category: 'descriptors', arasaacId: 35533 },
-  { id: 'w22', label: 'sad',       category: 'descriptors', arasaacId: 35545 },
-  { id: 'w23', label: 'angry',     category: 'descriptors', arasaacId: 35539 },
-  { id: 'w24', label: 'tired',     category: 'descriptors', arasaacId: 35537 },
-  { id: 'w25', label: 'hot',       category: 'descriptors', arasaacId: 2300 },
-  { id: 'w26', label: 'cold',      category: 'descriptors', arasaacId: 4652 },
-  { id: 'w27', label: 'big',       category: 'descriptors', arasaacId: 4658 },
-  { id: 'w28', label: 'small',     category: 'descriptors', arasaacId: 4716 },
-  { id: 'w29', label: 'up',        category: 'prepositions', arasaacId: 5388 },
-  { id: 'w30', label: 'down',      category: 'prepositions', arasaacId: 37428 },
-
-  // Row 4
-  { id: 'w31', label: 'in',        category: 'prepositions', arasaacId: 7034 },
-  { id: 'w32', label: 'out',       category: 'prepositions', arasaacId: 6606 },
-  { id: 'w33', label: 'on',        category: 'prepositions', arasaacId: 7814 },
-  { id: 'w34', label: 'off',       category: 'prepositions', arasaacId: 27518 },
-  { id: 'w35', label: 'open',      category: 'verbs',       arasaacId: 24825 },
-  { id: 'w36', label: 'close',     category: 'verbs',       arasaacId: 30383 },
-  { id: 'w37', label: 'give',      category: 'verbs',       arasaacId: 28431 },
-  { id: 'w38', label: 'take',      category: 'verbs',       arasaacId: 10148 },
-  { id: 'w39', label: 'put',       category: 'verbs',       arasaacId: 32757 },
-  { id: 'w40', label: 'make',      category: 'verbs',       arasaacId: 32751 },
-
-  // Row 5
-  { id: 'w41', label: 'do',        category: 'verbs',       arasaacId: 6624 },
-  { id: 'w42', label: 'have',      category: 'verbs',       arasaacId: 32761 },
-  { id: 'w43', label: 'is',        category: 'verbs',       arasaacId: 8115 },
-  { id: 'w44', label: 'it',        category: 'determiners', arasaacId: 31670 },
-  { id: 'w45', label: 'that',      category: 'determiners', arasaacId: 6906 },
-  { id: 'w46', label: 'this',      category: 'determiners', arasaacId: 7095 },
-  { id: 'w47', label: 'what',      category: 'questions',   arasaacId: 22620 },
-  { id: 'w48', label: 'where',     category: 'questions',   arasaacId: 7764 },
-  { id: 'w49', label: 'who',       category: 'questions',   arasaacId: 9853 },
-  { id: 'w50', label: 'why',       category: 'questions',   arasaacId: 36719 },
-];
+// Core vocabulary, Fitzgerald Key colours, the pictogram URL helper and the
+// shared "tap a core word" action now live in @/lib/core-vocab so every Layout
+// Primitive surface reads the SAME data and writes through the SAME pipeline.
+// getGridCategoryColor is re-exported for backward compatibility.
+export { getGridCategoryColor };
 
 // =============================================================================
 // TTS Helper - ElevenLabs via tts.ts
@@ -361,13 +247,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   }, [onSpeak, settings.selectedVoiceId, settings.ttsRate]);
 
   const handleWordTap = useCallback((word: CoreWord) => {
-    speakText(word.label);
-    addWord({
-      label: word.label,
-      imageUrl: word.arasaacId ? ARASAAC_IMG(word.arasaacId) : undefined,
-      className: `${FITZGERALD_CLASSES[word.category].bg} ${FITZGERALD_CLASSES[word.category].text} ${FITZGERALD_CLASSES[word.category].border}`,
-    });
-    logWord(word.label);
+    performCoreTap(word, { speak: speakText, add: addWord, log: logWord });
   }, [speakText, addWord]);
 
   const handleSpeakAll = useCallback(() => {

--- a/src/components/surfaces/FlowBoard.tsx
+++ b/src/components/surfaces/FlowBoard.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+/**
+ * FlowBoard (Ε Flow Board) - a fluid, auto-reflowing board of word cards with a
+ * category filter. The filter is a vertical side-rail on wide screens and
+ * collapses to a horizontal bottom bar on narrow phones, so the same board
+ * works from phone to desktop. The card area uses an auto-fill grid, so cards
+ * flow to fit whatever width is available - no fixed column count.
+ *
+ * Same vocabulary (Supercore 50, grouped by the existing Fitzgerald categories)
+ * and the same speak/sentence pipeline (useCoreSurface). Filtering is
+ * presentation-only: it never reorders or mutates the underlying vocabulary.
+ */
+
+import { useMemo, useState } from 'react';
+import { SharedSentenceBar } from '@/components/SharedSentenceBar';
+import { TapCard } from '@/components/TapCard';
+import {
+  SUPERCORE_50,
+  CORE_CATEGORY_ORDER,
+  FITZGERALD_CLASSES,
+  wordsInCategory,
+  type FitzgeraldCategory,
+} from '@/lib/core-vocab';
+import { SurfaceWordCard } from './SurfaceWordCard';
+import { useCoreSurface } from './useCoreSurface';
+import type { SurfaceProps } from './index';
+
+type Filter = 'all' | FitzgeraldCategory;
+
+export function FlowBoard(props: SurfaceProps) {
+  const {
+    sentence,
+    removeWord,
+    engineFallback,
+    isMagicLoading,
+    tapWord,
+    handleSpeakAll,
+    handleClear,
+    handleMagic,
+  } = useCoreSurface(props);
+
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const words = useMemo(
+    () => (filter === 'all' ? [...SUPERCORE_50] : wordsInCategory(filter)),
+    [filter],
+  );
+
+  const railItems: { key: Filter; label: string; category?: FitzgeraldCategory }[] = [
+    { key: 'all', label: 'All' },
+    ...CORE_CATEGORY_ORDER.map((c) => ({ key: c.category as Filter, label: c.label, category: c.category })),
+  ];
+
+  const railButton = (item: { key: Filter; label: string; category?: FitzgeraldCategory }) => {
+    const active = filter === item.key;
+    const cls = item.category ? FITZGERALD_CLASSES[item.category] : null;
+    return (
+      <TapCard
+        key={item.key}
+        onTap={() => setFilter(item.key)}
+        ariaLabel={`Show ${item.label}`}
+        className={`shrink-0 min-h-[44px] px-3 rounded-xl border-[3px] font-bold text-[13px] flex items-center justify-center ${
+          cls ? `${cls.bg} ${cls.text} ${cls.border}` : 'bg-gray-100 text-gray-800 border-gray-400'
+        } ${active ? 'ring-2 ring-offset-1 ring-emerald-500' : ''}`}
+      >
+        {item.label}
+      </TapCard>
+    );
+  };
+
+  return (
+    <div
+      className="flex flex-col font-sans bg-gray-50"
+      style={{ height: 'calc(100dvh - 72px - env(safe-area-inset-bottom, 0px))' }}
+    >
+      <SharedSentenceBar
+        words={sentence}
+        onSpeak={handleSpeakAll}
+        onMagic={handleMagic}
+        isMagicLoading={isMagicLoading}
+        onClear={handleClear}
+        onRemoveWord={removeWord}
+        engineFallback={engineFallback}
+      />
+
+      <div className="flex-1 min-h-0 flex flex-row">
+        {/* Side-rail (wide screens) */}
+        <nav
+          className="hidden md:flex md:flex-col gap-2 w-40 shrink-0 overflow-y-auto p-2 border-r border-gray-200"
+          aria-label="Word categories"
+        >
+          {railItems.map(railButton)}
+        </nav>
+
+        {/* Flowing card area */}
+        <div className="flex-1 min-h-0 overflow-y-auto touch-pan-y p-2">
+          <div
+            className="grid gap-2"
+            style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(84px, 1fr))' }}
+          >
+            {words.map((w) => (
+              <SurfaceWordCard key={w.id} word={w} onTap={tapWord} size="medium" />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom bar (narrow screens) */}
+      <nav
+        className="flex md:hidden gap-2 overflow-x-auto no-scrollbar p-2 border-t border-gray-200 bg-white shrink-0"
+        aria-label="Word categories"
+      >
+        {railItems.map(railButton)}
+      </nav>
+    </div>
+  );
+}
+
+export default FlowBoard;

--- a/src/components/surfaces/OrbitCore.tsx
+++ b/src/components/surfaces/OrbitCore.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+/**
+ * OrbitCore (Ζ Orbit Core) - the 8gent jr signature shape. A central speak orb
+ * sits at the middle of a ring of category satellites. Tapping a satellite
+ * reveals that category's words held close to the centre, in a compact cluster
+ * over the orb. Tapping the orb (with words in the strip) speaks the sentence.
+ *
+ * Same vocabulary (Supercore 50 grouped by the existing Fitzgerald categories)
+ * and the same speak/sentence pipeline (useCoreSurface). Selecting a satellite
+ * is presentation-only - it never mutates vocabulary, categories, personal words
+ * or phrase folders.
+ *
+ * Chrome (ring guide, centre orb) uses emerald/teal/slate - clear of the banned
+ * 270-350 hue band. Satellites and word cards keep the exempt Fitzgerald colours.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { SharedSentenceBar } from '@/components/SharedSentenceBar';
+import { TapCard } from '@/components/TapCard';
+import {
+  CORE_CATEGORY_ORDER,
+  FITZGERALD_CLASSES,
+  wordsInCategory,
+  type FitzgeraldCategory,
+} from '@/lib/core-vocab';
+import { SurfaceWordCard } from './SurfaceWordCard';
+import { useCoreSurface } from './useCoreSurface';
+import type { SurfaceProps } from './index';
+
+export function OrbitCore(props: SurfaceProps) {
+  const {
+    sentence,
+    removeWord,
+    engineFallback,
+    isMagicLoading,
+    tapWord,
+    handleSpeakAll,
+    handleClear,
+    handleMagic,
+  } = useCoreSurface(props);
+
+  const [selected, setSelected] = useState<FitzgeraldCategory | null>(null);
+  const fieldRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+
+  useEffect(() => {
+    const el = fieldRef.current;
+    if (!el) return;
+    const measure = () => setSize({ w: el.clientWidth, h: el.clientHeight });
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const satellites = CORE_CATEGORY_ORDER;
+  const cx = size.w / 2;
+  const cy = size.h / 2;
+  const ringRadius = Math.max(0, Math.min(size.w, size.h) / 2 - 52);
+
+  const selectedWords = useMemo(
+    () => (selected ? wordsInCategory(selected) : []),
+    [selected],
+  );
+
+  return (
+    <div
+      className="flex flex-col font-sans bg-slate-50"
+      style={{ height: 'calc(100dvh - 72px - env(safe-area-inset-bottom, 0px))' }}
+    >
+      <SharedSentenceBar
+        words={sentence}
+        onSpeak={handleSpeakAll}
+        onMagic={handleMagic}
+        isMagicLoading={isMagicLoading}
+        onClear={handleClear}
+        onRemoveWord={removeWord}
+        engineFallback={engineFallback}
+      />
+
+      <div
+        ref={fieldRef}
+        className="relative flex-1 min-h-0 overflow-hidden"
+        role="group"
+        aria-label="Orbit word core"
+      >
+        {/* Ring guide - decorative. */}
+        {ringRadius > 0 && (
+          <div
+            className="absolute rounded-full border-2 border-dashed pointer-events-none"
+            style={{
+              width: ringRadius * 2,
+              height: ringRadius * 2,
+              left: cx,
+              top: cy,
+              transform: 'translate(-50%, -50%)',
+              borderColor: 'rgba(15,118,110,0.25)',
+            }}
+            aria-hidden="true"
+          />
+        )}
+
+        {/* Category satellites on the ring. */}
+        {size.w > 0 &&
+          satellites.map((s, i) => {
+            const angle = (-90 + (360 / satellites.length) * i) * (Math.PI / 180);
+            const x = cx + ringRadius * Math.cos(angle);
+            const y = cy + ringRadius * Math.sin(angle);
+            const cls = FITZGERALD_CLASSES[s.category];
+            const active = selected === s.category;
+            return (
+              <div
+                key={s.category}
+                className="absolute"
+                style={{ left: x, top: y, transform: 'translate(-50%, -50%)' }}
+              >
+                <TapCard
+                  onTap={() => setSelected(active ? null : s.category)}
+                  ariaLabel={`${active ? 'Hide' : 'Show'} ${s.label} words`}
+                  className={`flex items-center justify-center rounded-full border-[3px] font-bold text-[12px] text-center leading-tight shadow-md px-1 ${cls.bg} ${cls.text} ${cls.border} ${
+                    active ? 'ring-2 ring-offset-2 ring-emerald-500' : ''
+                  }`}
+                  style={{ width: 72, height: 72 }}
+                >
+                  <span className="line-clamp-2">{s.label}</span>
+                </TapCard>
+              </div>
+            );
+          })}
+
+        {/* Centre: speak orb when nothing selected, else the word cluster. */}
+        <div
+          className="absolute"
+          style={{ left: cx, top: cy, transform: 'translate(-50%, -50%)' }}
+        >
+          {selected === null ? (
+            <TapCard
+              onTap={handleSpeakAll}
+              ariaLabel="Speak sentence"
+              className="flex flex-col items-center justify-center rounded-full bg-emerald-500 text-white border-4 border-emerald-600 shadow-lg"
+              style={{ width: 108, height: 108 }}
+            >
+              <span className="text-3xl leading-none">&#9654;</span>
+              <span className="text-[12px] font-bold mt-1">Speak</span>
+            </TapCard>
+          ) : (
+            <div
+              className="bg-white/95 backdrop-blur rounded-2xl shadow-xl border border-slate-200 p-2 w-[min(78vw,320px)] max-h-[60vh] overflow-y-auto"
+              role="group"
+              aria-label={`${satellites.find((s) => s.category === selected)?.label} words`}
+            >
+              <div className="flex items-center justify-between mb-1.5 px-1">
+                <span className="text-[12px] font-bold text-slate-600 uppercase tracking-wide">
+                  {satellites.find((s) => s.category === selected)?.label}
+                </span>
+                <button
+                  onClick={() => setSelected(null)}
+                  aria-label="Close category"
+                  className="w-9 h-9 shrink-0 rounded-full bg-slate-100 text-slate-600 font-bold flex items-center justify-center cursor-pointer active:scale-90"
+                >
+                  &#10005;
+                </button>
+              </div>
+              <div
+                className="grid gap-1.5"
+                style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(72px, 1fr))' }}
+              >
+                {selectedWords.map((w) => (
+                  <SurfaceWordCard key={w.id} word={w} onTap={tapWord} size="small" />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default OrbitCore;

--- a/src/components/surfaces/SceneField.tsx
+++ b/src/components/surfaces/SceneField.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+/**
+ * SceneField (Γ Scene) - a calm, familiar backdrop with a handful of big,
+ * tappable word hotspots floating over it. Few, large targets: the opposite of
+ * a dense grid, for children who scan a picture rather than a table.
+ *
+ * The hotspots are real Supercore words (SCENE_HOTSPOTS -> sceneHotspotWords),
+ * positioned as percentages so they reflow with the container at any size. Every
+ * tap routes through the shared pipeline (useCoreSurface.tapWord): speak, append
+ * to the shared sentence strip, log. Nothing here mutates vocabulary.
+ *
+ * Chrome (the scene gradient) uses sky-blue -> meadow-green, well clear of the
+ * banned 270-350 hue band. The word cards keep their Fitzgerald Key colours,
+ * which are the exempt AAC standard.
+ */
+
+import { SharedSentenceBar } from '@/components/SharedSentenceBar';
+import { TapCard } from '@/components/TapCard';
+import {
+  ARASAAC_IMG,
+  FITZGERALD_CLASSES,
+  sceneHotspotWords,
+} from '@/lib/core-vocab';
+import { useCoreSurface } from './useCoreSurface';
+import type { SurfaceProps } from './index';
+
+export function SceneField(props: SurfaceProps) {
+  const {
+    sentence,
+    removeWord,
+    engineFallback,
+    isMagicLoading,
+    tapWord,
+    handleSpeakAll,
+    handleClear,
+    handleMagic,
+  } = useCoreSurface(props);
+
+  const hotspots = sceneHotspotWords();
+
+  return (
+    <div
+      className="flex flex-col font-sans"
+      style={{ height: 'calc(100dvh - 72px - env(safe-area-inset-bottom, 0px))' }}
+    >
+      <SharedSentenceBar
+        words={sentence}
+        onSpeak={handleSpeakAll}
+        onMagic={handleMagic}
+        isMagicLoading={isMagicLoading}
+        onClear={handleClear}
+        onRemoveWord={removeWord}
+        engineFallback={engineFallback}
+      />
+
+      {/* Scene backdrop - sky to meadow. Hotspots float over it. */}
+      <div
+        className="relative flex-1 min-h-0 overflow-hidden mx-2 my-2 rounded-2xl"
+        style={{
+          background:
+            'linear-gradient(180deg, #BEE3F8 0%, #DCF0FF 42%, #CDEFD3 70%, #A7DDB0 100%)',
+        }}
+        role="group"
+        aria-label="Scene word board"
+      >
+        {/* Soft sun + horizon accents - decorative only. */}
+        <div
+          className="absolute rounded-full pointer-events-none"
+          style={{ width: 84, height: 84, top: '8%', left: '78%', background: '#FFE29A', opacity: 0.85 }}
+          aria-hidden="true"
+        />
+        <div
+          className="absolute left-0 right-0 pointer-events-none"
+          style={{ top: '66%', height: 2, background: 'rgba(56,142,60,0.25)' }}
+          aria-hidden="true"
+        />
+
+        {hotspots.map(({ word, x, y }) => {
+          const cls = FITZGERALD_CLASSES[word.category];
+          return (
+            <div
+              key={word.id}
+              className="absolute"
+              style={{ left: `${x}%`, top: `${y}%`, transform: 'translate(-50%, -50%)' }}
+            >
+              <TapCard
+                onTap={() => tapWord(word)}
+                ariaLabel={word.label}
+                className={`flex flex-col items-center justify-center rounded-2xl border-[3px] shadow-md px-1.5 py-1 ${cls.bg} ${cls.text} ${cls.border}`}
+                style={{ width: 84, minHeight: 84 }}
+              >
+                {word.arasaacId && (
+                  /* eslint-disable-next-line @next/next/no-img-element */
+                  <img
+                    src={ARASAAC_IMG(word.arasaacId)}
+                    alt=""
+                    width={44}
+                    height={44}
+                    style={{ width: 44, height: 44 }}
+                    className="object-contain pointer-events-none"
+                    loading="lazy"
+                  />
+                )}
+                <span className="font-bold text-[13px] leading-none mt-0.5 line-clamp-1">
+                  {word.label}
+                </span>
+              </TapCard>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default SceneField;

--- a/src/components/surfaces/SurfaceWordCard.tsx
+++ b/src/components/surfaces/SurfaceWordCard.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+/**
+ * SurfaceWordCard - the standard tappable Fitzgerald word card, shared by the
+ * Flow Board and Orbit Core surfaces (and any future surface that shows a plain
+ * picto + label card). Visually matches the Supercore grid card so a child sees
+ * the same word the same way on every surface.
+ *
+ * Built on TapCard, so it is a real <button>: focusable, aria-labelled, and it
+ * carries the app's rapid-tap throttle + press animation.
+ */
+
+import React, { useCallback } from 'react';
+import { TapCard } from '@/components/TapCard';
+import {
+  ARASAAC_IMG,
+  FITZGERALD_CLASSES,
+  type SupercoreWord,
+} from '@/lib/core-vocab';
+
+export const SurfaceWordCard = React.memo(function SurfaceWordCard({
+  word,
+  onTap,
+  size = 'medium',
+}: {
+  word: SupercoreWord;
+  onTap: (word: SupercoreWord) => void;
+  size?: 'small' | 'medium' | 'large';
+}) {
+  const cls = FITZGERALD_CLASSES[word.category];
+  const handleTap = useCallback(() => onTap(word), [onTap, word]);
+  const tok =
+    size === 'large'
+      ? { minHeight: 96, img: 52, font: 16 }
+      : size === 'small'
+        ? { minHeight: 60, img: 34, font: 12 }
+        : { minHeight: 76, img: 44, font: 14 };
+  return (
+    <TapCard
+      onTap={handleTap}
+      ariaLabel={word.label}
+      className={`flex flex-col items-center justify-center rounded-xl border-[3px] py-1.5 px-0.5 text-center leading-tight ${cls.bg} ${cls.text} ${cls.border}`}
+      style={{ minHeight: tok.minHeight }}
+    >
+      {word.arasaacId && (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          src={ARASAAC_IMG(word.arasaacId)}
+          alt=""
+          width={tok.img}
+          height={tok.img}
+          style={{ width: tok.img, height: tok.img }}
+          className="object-contain pointer-events-none"
+          loading="lazy"
+        />
+      )}
+      <span
+        className="font-bold leading-none mt-0.5 w-full line-clamp-2 px-0.5"
+        style={{ fontSize: tok.font }}
+      >
+        {word.label}
+      </span>
+    </TapCard>
+  );
+});

--- a/src/components/surfaces/TextRail.tsx
+++ b/src/components/surfaces/TextRail.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+/**
+ * TextRail (Δ Word Rail) - a keyboard-forward surface for children (and
+ * partners) who are faster typing than scanning a grid. A text compose box
+ * feeds straight into the shared sentence strip; a next-word prediction rail and
+ * a row of quick social words sit above it for one-tap building.
+ *
+ * Everything writes to the SAME sentence pipeline (useCoreSurface) and reads the
+ * SAME vocabulary (Supercore 50 + the existing predictive engine). No surface
+ * state mutates vocabulary, categories, personal words or phrase folders.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { SharedSentenceBar } from '@/components/SharedSentenceBar';
+import { predictNext, PREDICTIVE_CARD_COUNT } from '@/lib/predictive';
+import {
+  SUPERCORE_BY_LABEL,
+  FITZGERALD_CLASSES,
+  wordsInCategory,
+} from '@/lib/core-vocab';
+import { useCoreSurface } from './useCoreSurface';
+import type { SurfaceProps } from './index';
+
+const SKY_CHIP = 'bg-sky-100 text-sky-900 border-sky-300';
+
+export function TextRail(props: SurfaceProps) {
+  const {
+    settings,
+    sentence,
+    removeWord,
+    engineFallback,
+    isMagicLoading,
+    tapWord,
+    tapText,
+    handleSpeakAll,
+    handleClear,
+    handleMagic,
+  } = useCoreSurface(props);
+
+  const [draft, setDraft] = useState('');
+
+  const stage = settings.glpStage ?? 3;
+  const lastWord = sentence.length > 0 ? sentence[sentence.length - 1].label : null;
+
+  const predictions = useMemo(
+    () => predictNext(lastWord, stage, PREDICTIVE_CARD_COUNT),
+    [lastWord, stage],
+  );
+
+  // Quick words: the real social-category Supercore words (help, yes, please...).
+  const quickWords = useMemo(() => wordsInCategory('social'), []);
+
+  // A prediction that maps to a locked-grid word routes through the identical
+  // grid tap (Fitzgerald chip + log); otherwise it is a plain sky chip.
+  const handlePrediction = useCallback(
+    (text: string) => {
+      const match = SUPERCORE_BY_LABEL.get(text.toLowerCase());
+      if (match) tapWord(match);
+      else tapText(text, { className: SKY_CHIP, log: true });
+    },
+    [tapWord, tapText],
+  );
+
+  const commitDraft = useCallback(() => {
+    const text = draft.trim();
+    if (!text) return;
+    const match = SUPERCORE_BY_LABEL.get(text.toLowerCase());
+    if (match) tapWord(match);
+    else tapText(text);
+    setDraft('');
+  }, [draft, tapWord, tapText]);
+
+  return (
+    <div
+      className="flex flex-col font-sans bg-gray-50"
+      style={{ height: 'calc(100dvh - 72px - env(safe-area-inset-bottom, 0px))' }}
+    >
+      <SharedSentenceBar
+        words={sentence}
+        onSpeak={handleSpeakAll}
+        onMagic={handleMagic}
+        isMagicLoading={isMagicLoading}
+        onClear={handleClear}
+        onRemoveWord={removeWord}
+        engineFallback={engineFallback}
+      />
+
+      <div className="flex-1 min-h-0 overflow-y-auto touch-pan-y px-2 py-3 flex flex-col gap-4">
+        {/* Prediction rail */}
+        <section aria-label="Next word suggestions">
+          <p className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+            Next word
+          </p>
+          <div className="flex gap-2 overflow-x-auto no-scrollbar pb-1">
+            {predictions.length === 0 && (
+              <span className="text-sm text-gray-400 py-2">Start typing to see suggestions</span>
+            )}
+            {predictions.map((c) => {
+              const match = SUPERCORE_BY_LABEL.get(c.text.toLowerCase());
+              const cls = match ? FITZGERALD_CLASSES[match.category] : null;
+              return (
+                <button
+                  key={`${c.source}-${c.text}`}
+                  onClick={() => handlePrediction(c.text)}
+                  className={`shrink-0 min-h-[44px] px-4 rounded-xl border-[3px] font-bold text-[15px] cursor-pointer active:scale-95 transition-transform ${
+                    cls ? `${cls.bg} ${cls.text} ${cls.border}` : `${SKY_CHIP}`
+                  }`}
+                  aria-label={`Add word ${c.text}`}
+                >
+                  {match ? match.label : c.text}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Quick words */}
+        <section aria-label="Quick words">
+          <p className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+            Quick words
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {quickWords.map((w) => {
+              const cls = FITZGERALD_CLASSES[w.category];
+              return (
+                <button
+                  key={w.id}
+                  onClick={() => tapWord(w)}
+                  className={`min-h-[44px] px-4 rounded-xl border-[3px] font-bold text-[15px] cursor-pointer active:scale-95 transition-transform ${cls.bg} ${cls.text} ${cls.border}`}
+                  aria-label={`Add word ${w.label}`}
+                >
+                  {w.label}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+
+      {/* Compose box - the keyboard-forward core of this surface. */}
+      <form
+        className="shrink-0 flex items-center gap-2 px-2 py-2 border-t border-gray-200 bg-white"
+        onSubmit={(e) => {
+          e.preventDefault();
+          commitDraft();
+        }}
+      >
+        <label htmlFor="word-rail-input" className="sr-only">
+          Type a word
+        </label>
+        <input
+          id="word-rail-input"
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Type a word, then Add"
+          autoComplete="off"
+          className="flex-1 min-h-[48px] px-3 rounded-xl border-2 border-gray-300 text-[16px] focus:outline-none focus:border-emerald-500"
+        />
+        <button
+          type="submit"
+          disabled={draft.trim().length === 0}
+          className={`shrink-0 min-h-[48px] px-5 rounded-xl font-bold text-white text-[15px] transition-colors ${
+            draft.trim().length > 0
+              ? 'bg-emerald-500 hover:bg-emerald-400 cursor-pointer'
+              : 'bg-gray-300 cursor-not-allowed'
+          }`}
+          aria-label="Add typed word to sentence"
+        >
+          Add
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default TextRail;

--- a/src/components/surfaces/index.tsx
+++ b/src/components/surfaces/index.tsx
@@ -7,20 +7,24 @@
  * component that renders it. This is the seam a later PR will use to introduce
  * genuine scene / text / flow / orbit surfaces.
  *
- * FRAMEWORK PR CONTRACT: every kind renders the EXISTING SupercoreGrid so
- * nothing breaks. The four not-yet-built kinds additionally show a slim,
- * non-blocking "coming soon" banner ABOVE the same grid, so selecting one is
- * honest about what it is while still giving the child a fully working board.
+ * FRAMEWORK CONTRACT: the two grid kinds (fixedGrid / adaptiveGrid) render the
+ * EXISTING SupercoreGrid, unchanged. The four structural kinds now render their
+ * REAL surfaces (Scene / Word Rail / Flow Board / Orbit Core). Every surface
+ * reads the same Supercore 50 vocabulary and writes to the same speak +
+ * sentence-strip pipeline as the grid (see ./useCoreSurface + @/lib/core-vocab).
  *
- * The banner only ever appears when the layoutPrimitives flag is ON and a
- * non-default primitive is selected. With the flag off the active primitive is
- * always 'alpha' (fixedGrid), which renders the bare grid - byte-for-byte the
- * current behaviour.
+ * With the layoutPrimitives flag OFF the active primitive is always 'alpha'
+ * (fixedGrid), which renders the bare grid - byte-for-byte the current
+ * behaviour. The four surfaces are only ever reachable with the flag ON.
  */
 
 import type { ComponentType } from 'react';
 import { SupercoreGrid, type SupercoreGridProps } from '@/components/SupercoreGrid';
 import type { LayoutKind } from '@/lib/layout-primitives';
+import { SceneField } from './SceneField';
+import { TextRail } from './TextRail';
+import { FlowBoard } from './FlowBoard';
+import { OrbitCore } from './OrbitCore';
 
 export type SurfaceProps = SupercoreGridProps;
 
@@ -34,50 +38,14 @@ function AdaptiveGridSurface(props: SurfaceProps) {
   return <SupercoreGrid {...props} />;
 }
 
-/**
- * Placeholder for a not-yet-built structural surface. Renders the existing,
- * fully-working grid beneath a slim banner so the child can always talk while
- * the real surface is in development.
- */
-function PlaceholderSurface({ label, props }: { label: string; props: SurfaceProps }) {
-  return (
-    <div className="flex flex-col h-full">
-      <div
-        className="shrink-0 px-3 py-1.5 text-[11px] font-semibold text-center"
-        style={{ backgroundColor: '#FFF4E5', color: '#8A5200' }}
-        role="status"
-        aria-live="polite"
-      >
-        {label} is coming soon - showing the Steady Grid for now.
-      </div>
-      <div className="flex-1 min-h-0">
-        <SupercoreGrid {...props} />
-      </div>
-    </div>
-  );
-}
-
-function SceneFieldSurface(props: SurfaceProps) {
-  return <PlaceholderSurface label="Scene" props={props} />;
-}
-function TextRailSurface(props: SurfaceProps) {
-  return <PlaceholderSurface label="Word Rail" props={props} />;
-}
-function FlowBoardSurface(props: SurfaceProps) {
-  return <PlaceholderSurface label="Flow Board" props={props} />;
-}
-function OrbitCoreSurface(props: SurfaceProps) {
-  return <PlaceholderSurface label="Orbit Core" props={props} />;
-}
-
 /** kind -> surface component. Exhaustive over LayoutKind (compile-checked). */
 export const SURFACE_BY_KIND: Record<LayoutKind, ComponentType<SurfaceProps>> = {
   fixedGrid: FixedGridSurface,
   adaptiveGrid: AdaptiveGridSurface,
-  sceneField: SceneFieldSurface,
-  textRail: TextRailSurface,
-  flowBoard: FlowBoardSurface,
-  orbitCore: OrbitCoreSurface,
+  sceneField: SceneField,
+  textRail: TextRail,
+  flowBoard: FlowBoard,
+  orbitCore: OrbitCore,
 };
 
 /** Resolve the surface component for a kind. */

--- a/src/components/surfaces/surfaces.test.ts
+++ b/src/components/surfaces/surfaces.test.ts
@@ -1,0 +1,178 @@
+// @ts-nocheck - bun:test types not wired to main tsconfig; run with `bun test`
+/**
+ * Tests for the Layout Primitive SURFACES (Scene / Word Rail / Flow Board /
+ * Orbit Core). Runs via `bun test`.
+ *
+ * The app has no DOM test renderer (all existing suites are pure-logic), so
+ * these tests target the shared contract that guarantees every surface behaves
+ * like the grid, rather than pixel output (pixels are covered by `next build`
+ * + the headless screenshots in the PR):
+ *
+ *   - VOCABULARY SOURCE: all surfaces read the single Supercore 50 list, which
+ *     is frozen (immutable) and internally consistent.
+ *   - SHARED PIPELINE: the one tap action every surface uses (performCoreTap)
+ *     speaks the word, appends a chip to the SHARED sentence store, and logs -
+ *     in that order.
+ *   - SCENE HOTSPOTS resolve to real Supercore words (never invented vocab).
+ *   - NON-DESTRUCTIVE: tapping through a surface never mutates vocabulary,
+ *     categories, personal words or phrase folders.
+ *   - EXPORTS: the four surface kinds map to four distinct real components (no
+ *     longer the placeholder / grid).
+ */
+import { describe, expect, test, beforeEach } from 'bun:test';
+import {
+  SUPERCORE_50,
+  SUPERCORE_BY_LABEL,
+  CORE_CATEGORY_ORDER,
+  FITZGERALD_CLASSES,
+  coreWordChip,
+  performCoreTap,
+  sceneHotspotWords,
+  wordsInCategory,
+  SCENE_HOTSPOTS,
+} from '@/lib/core-vocab';
+import { sentenceStore } from '@/lib/sentence-store';
+import { loadFolders } from '@/lib/phrase-folders';
+
+const CATEGORIES = CORE_CATEGORY_ORDER.map((c) => c.category);
+
+describe('core vocabulary source', () => {
+  test('is the Supercore 50 and never fewer', () => {
+    expect(SUPERCORE_50.length).toBe(50);
+  });
+
+  test('every word has a valid category and unique id', () => {
+    const ids = new Set<string>();
+    for (const w of SUPERCORE_50) {
+      expect(CATEGORIES).toContain(w.category);
+      expect(ids.has(w.id)).toBe(false);
+      ids.add(w.id);
+      expect(w.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('is frozen - a surface cannot reorder or mutate the vocabulary', () => {
+    expect(Object.isFrozen(SUPERCORE_50)).toBe(true);
+    expect(() => {
+      // @ts-expect-error - deliberate illegal mutation
+      SUPERCORE_50.push({ id: 'x', label: 'x', category: 'people' });
+    }).toThrow();
+    expect(SUPERCORE_50.length).toBe(50);
+  });
+
+  test('label lookup covers every word', () => {
+    for (const w of SUPERCORE_50) {
+      expect(SUPERCORE_BY_LABEL.get(w.label.toLowerCase())?.id).toBe(w.id);
+    }
+  });
+
+  test('wordsInCategory returns a fresh array of only that category', () => {
+    for (const { category } of CORE_CATEGORY_ORDER) {
+      const words = wordsInCategory(category);
+      expect(words.length).toBeGreaterThan(0);
+      expect(words.every((w) => w.category === category)).toBe(true);
+    }
+    // Every word belongs to exactly one category bucket.
+    const total = CORE_CATEGORY_ORDER.reduce((n, c) => n + wordsInCategory(c.category).length, 0);
+    expect(total).toBe(50);
+  });
+});
+
+describe('scene hotspots (Gamma / SceneField)', () => {
+  test('are a handful of large targets (8-12)', () => {
+    expect(SCENE_HOTSPOTS.length).toBeGreaterThanOrEqual(8);
+    expect(SCENE_HOTSPOTS.length).toBeLessThanOrEqual(12);
+  });
+
+  test('every hotspot resolves to a real Supercore word within bounds', () => {
+    const resolved = sceneHotspotWords();
+    expect(resolved.length).toBe(SCENE_HOTSPOTS.length);
+    for (const { word, x, y } of resolved) {
+      expect(SUPERCORE_50.some((w) => w.id === word.id)).toBe(true);
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThanOrEqual(100);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
+describe('shared chip + tap pipeline', () => {
+  test('coreWordChip carries the Fitzgerald class + label + pictogram', () => {
+    const want = SUPERCORE_50.find((w) => w.label === 'want')!;
+    const chip = coreWordChip(want);
+    const cls = FITZGERALD_CLASSES[want.category];
+    expect(chip.label).toBe('want');
+    expect(chip.className).toBe(`${cls.bg} ${cls.text} ${cls.border}`);
+    expect(chip.imageUrl).toContain(String(want.arasaacId));
+  });
+
+  test('performCoreTap speaks, then adds the chip, then logs - in order', () => {
+    const calls: string[] = [];
+    const word = SUPERCORE_50[2];
+    performCoreTap(word, {
+      speak: (t) => calls.push(`speak:${t}`),
+      add: (chip) => calls.push(`add:${chip.label}`),
+      log: (w) => calls.push(`log:${w}`),
+    });
+    expect(calls).toEqual([`speak:${word.label}`, `add:${word.label}`, `log:${word.label}`]);
+  });
+});
+
+describe('writes to the SAME shared sentence store', () => {
+  beforeEach(() => sentenceStore.clear());
+
+  test('a surface tap appends a chip to the shared sentence strip', () => {
+    const word = SUPERCORE_50.find((w) => w.label === 'help')!;
+    let spoken = '';
+    performCoreTap(word, {
+      speak: (t) => (spoken = t), // speak pipeline exercised, TTS stubbed
+      add: (chip) => sentenceStore.addWord(chip),
+      log: () => {},
+    });
+    const words = sentenceStore.getWords();
+    expect(spoken).toBe('help');
+    expect(words.length).toBe(1);
+    expect(words[0].label).toBe('help');
+    expect(words[0].className).toContain('fitzgerald');
+  });
+});
+
+describe('non-destructive contract', () => {
+  beforeEach(() => sentenceStore.clear());
+
+  test('tapping never mutates vocabulary or phrase folders', () => {
+    const vocabBefore = JSON.stringify(SUPERCORE_50);
+    const foldersBefore = JSON.stringify(loadFolders());
+
+    // Tap a handful of words through the shared pipeline.
+    for (const label of ['I', 'want', 'more']) {
+      const w = SUPERCORE_50.find((x) => x.label === label)!;
+      performCoreTap(w, {
+        speak: () => {},
+        add: (chip) => sentenceStore.addWord(chip),
+        log: () => {},
+      });
+    }
+
+    expect(JSON.stringify(SUPERCORE_50)).toBe(vocabBefore);
+    expect(JSON.stringify(loadFolders())).toBe(foldersBefore);
+    // The only thing that changed is the shared sentence strip.
+    expect(sentenceStore.getWords().length).toBe(3);
+  });
+});
+
+describe('surface router exports real surfaces', () => {
+  test('the four structural kinds map to four distinct components', async () => {
+    const { SURFACE_BY_KIND } = await import('./index');
+    const { SupercoreGrid } = await import('@/components/SupercoreGrid');
+    const kinds = ['sceneField', 'textRail', 'flowBoard', 'orbitCore'] as const;
+    const comps = kinds.map((k) => SURFACE_BY_KIND[k]);
+    // Each is a defined function component...
+    for (const c of comps) expect(typeof c).toBe('function');
+    // ...distinct from each other...
+    expect(new Set(comps).size).toBe(4);
+    // ...and none is the raw grid (they are the real surfaces now).
+    for (const c of comps) expect(c).not.toBe(SupercoreGrid);
+  });
+});

--- a/src/components/surfaces/useCoreSurface.ts
+++ b/src/components/surfaces/useCoreSurface.ts
@@ -1,0 +1,121 @@
+'use client';
+
+/**
+ * useCoreSurface - the shared behaviour every Layout Primitive surface runs on.
+ *
+ * The Scene, Word Rail, Flow Board and Orbit Core surfaces differ ONLY in how
+ * they arrange the vocabulary on screen. Their behaviour - speaking, appending
+ * to the sentence strip, clearing, the optional analytic "magic" rewrite - is
+ * identical to the Supercore grid and is centralised here so no surface can
+ * drift from the shared pipeline.
+ *
+ * Contract:
+ *   - Reads the shared sentence store via useSentence (same store the grid uses).
+ *   - Speaks via the same ElevenLabs-with-browser-fallback path (or the parent's
+ *     onSpeak override, exactly like the grid).
+ *   - tapWord() routes through performCoreTap: speak -> add chip -> log. It
+ *     never mutates vocabulary, personal words or phrase folders.
+ */
+
+import { useCallback, useState } from 'react';
+import { useSentence } from '@/hooks/useSentence';
+import { useApp } from '@/context/AppContext';
+import { speak as elevenLabsSpeak } from '@/lib/tts';
+import { logWord } from '@/lib/session-logger';
+import { performCoreTap, type SupercoreWord } from '@/lib/core-vocab';
+import type { SurfaceProps } from './index';
+
+export function useCoreSurface({ onSpeak }: SurfaceProps) {
+  const { words: sentence, addWord, removeWord, clear } = useSentence();
+  const { settings } = useApp();
+  const [engineFallback, setEngineFallback] = useState(false);
+  const [isMagicLoading, setIsMagicLoading] = useState(false);
+
+  const speakText = useCallback(
+    async (text: string) => {
+      if (onSpeak) {
+        onSpeak(text);
+        return;
+      }
+      const engine = await elevenLabsSpeak({
+        text,
+        voiceId: settings.selectedVoiceId ?? undefined,
+        rate: settings.ttsRate,
+      });
+      setEngineFallback(engine === 'browser');
+    },
+    [onSpeak, settings.selectedVoiceId, settings.ttsRate],
+  );
+
+  const tapWord = useCallback(
+    (word: SupercoreWord) => {
+      performCoreTap(word, { speak: speakText, add: addWord, log: logWord });
+    },
+    [speakText, addWord],
+  );
+
+  /**
+   * Speak an arbitrary text token and append it to the shared sentence strip.
+   * Used by the Word Rail for typed text and free-text predictions. `log`
+   * defaults to false so hand-typed strings never pollute the personal-vocab
+   * analytics (core-word taps still log, exactly like the grid).
+   */
+  const tapText = useCallback(
+    (text: string, opts?: { className?: string; imageUrl?: string; log?: boolean }) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      speakText(trimmed);
+      addWord({ label: trimmed, className: opts?.className, imageUrl: opts?.imageUrl });
+      if (opts?.log) logWord(trimmed);
+    },
+    [speakText, addWord],
+  );
+
+  const handleSpeakAll = useCallback(() => {
+    if (sentence.length === 0) return;
+    speakText(sentence.map((w) => w.label).join(' '));
+  }, [sentence, speakText]);
+
+  const handleClear = useCallback(() => {
+    clear();
+    if (typeof window !== 'undefined') window.speechSynthesis?.cancel();
+  }, [clear]);
+
+  // Analytic "magic" rewrite - same endpoint and fallback the grid uses.
+  const handleMagic = useCallback(async () => {
+    if (sentence.length < 2) return;
+    setIsMagicLoading(true);
+    try {
+      const words = sentence.map((w) => w.label);
+      const res = await fetch('/api/improve-sentence', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cards: words }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        speakText(data.improved || data.sentence || words.join(' '));
+      } else {
+        speakText(words.join(' '));
+      }
+    } catch {
+      speakText(sentence.map((w) => w.label).join(' '));
+    } finally {
+      setIsMagicLoading(false);
+    }
+  }, [sentence, speakText]);
+
+  return {
+    settings,
+    sentence,
+    removeWord,
+    engineFallback,
+    isMagicLoading,
+    speakText,
+    tapWord,
+    tapText,
+    handleSpeakAll,
+    handleClear,
+    handleMagic,
+  };
+}

--- a/src/lib/core-vocab.ts
+++ b/src/lib/core-vocab.ts
@@ -1,0 +1,269 @@
+/**
+ * Core vocabulary - the SINGLE source of truth for the Supercore 50 word set.
+ *
+ * Before the Layout Primitives surfaces existed, this data lived privately
+ * inside `SupercoreGrid.tsx`. Every alternative surface (Scene, Word Rail,
+ * Flow Board, Orbit Core) must render the EXACT SAME vocabulary and route
+ * through the EXACT SAME speech + sentence-strip pipeline as the grid. To make
+ * that guarantee real (and testable) the word list, the Fitzgerald Key colour
+ * classes, the pictogram URL helper and the "tap a core word" action are all
+ * defined here, once, and imported by the grid and every surface.
+ *
+ * NON-DESTRUCTIVE CONTRACT: nothing in this module mutates vocabulary,
+ * categories, personal words or phrase folders. `SUPERCORE_50` is frozen. The
+ * tap helper only speaks, appends a chip to the shared sentence store, and logs
+ * the tap for analytics - identical to a grid tap.
+ *
+ * CRITICAL AAC RULES (unchanged from the grid):
+ *   1. Words NEVER move once positioned (motor-planning consistency).
+ *   2. This order is PERMANENT. Never reorder SUPERCORE_50.
+ *   3. Each word has: text label + Fitzgerald Key colour category.
+ *   4. Tapping a word speaks it and adds it to the sentence strip.
+ *
+ * Colour coding: Modified Fitzgerald Key. The category colours on word cards
+ * are the industry-standard AAC key and are exempt from the app-wide banned-hue
+ * rule; surface CHROME (backdrops, rails, rings) must stay clear of hues
+ * 270-350.
+ */
+
+import type { WordCategory } from '@/lib/fitzgerald-key';
+import { FITZGERALD_COLORS } from '@/lib/fitzgerald-key';
+import type { SentenceWord } from '@/lib/sentence-store';
+
+// ---------------------------------------------------------------------------
+// Categories
+// ---------------------------------------------------------------------------
+
+export type FitzgeraldCategory =
+  | 'people'
+  | 'verbs'
+  | 'descriptors'
+  | 'prepositions'
+  | 'social'
+  | 'questions'
+  | 'determiners'
+  | 'negation';
+
+/** Map grid categories to canonical Fitzgerald Key word categories. */
+export const CATEGORY_TO_WORD_TYPE: Record<FitzgeraldCategory, WordCategory> = {
+  people: 'pronoun',
+  verbs: 'verb',
+  descriptors: 'adjective',
+  prepositions: 'preposition',
+  social: 'social',
+  questions: 'question',
+  determiners: 'determiner',
+  negation: 'negation',
+};
+
+/**
+ * Tailwind class strings (backed by CSS variables) for each Fitzgerald
+ * category. bg = background, text = text colour, border = border colour.
+ * Shared by the grid and every surface so a chip built anywhere looks the same
+ * in the sentence strip.
+ */
+export const FITZGERALD_CLASSES: Record<
+  FitzgeraldCategory,
+  { bg: string; text: string; border: string }
+> = {
+  people:       { bg: 'bg-fitzgerald-yellow', text: 'text-fitzgerald-yellow-text', border: 'border-fitzgerald-yellow-border' },
+  verbs:        { bg: 'bg-fitzgerald-green',  text: 'text-fitzgerald-green-text',  border: 'border-fitzgerald-green-border' },
+  descriptors:  { bg: 'bg-fitzgerald-blue',   text: 'text-fitzgerald-blue-text',   border: 'border-fitzgerald-blue-border' },
+  prepositions: { bg: 'bg-fitzgerald-purple', text: 'text-fitzgerald-purple-text', border: 'border-fitzgerald-purple-border' },
+  social:       { bg: 'bg-fitzgerald-pink',   text: 'text-fitzgerald-pink-text',   border: 'border-fitzgerald-pink-border' },
+  questions:    { bg: 'bg-fitzgerald-orange', text: 'text-fitzgerald-orange-text', border: 'border-fitzgerald-orange-border' },
+  determiners:  { bg: 'bg-fitzgerald-white',  text: 'text-fitzgerald-white-text',  border: 'border-fitzgerald-white-border' },
+  negation:     { bg: 'bg-fitzgerald-red',    text: 'text-fitzgerald-red-text',    border: 'border-fitzgerald-red-border' },
+};
+
+/** Display order + friendly labels for category-organised surfaces. */
+export const CORE_CATEGORY_ORDER: { category: FitzgeraldCategory; label: string }[] = [
+  { category: 'people',       label: 'People' },
+  { category: 'verbs',        label: 'Doing' },
+  { category: 'descriptors',  label: 'Feelings' },
+  { category: 'social',       label: 'Social' },
+  { category: 'questions',    label: 'Questions' },
+  { category: 'prepositions', label: 'Places' },
+  { category: 'determiners',  label: 'Little words' },
+  { category: 'negation',     label: 'No & stop' },
+];
+
+/** Inline Fitzgerald Key colour object for a grid category. */
+export function getGridCategoryColor(category: FitzgeraldCategory) {
+  return FITZGERALD_COLORS[CATEGORY_TO_WORD_TYPE[category]];
+}
+
+// ---------------------------------------------------------------------------
+// Word data
+// ---------------------------------------------------------------------------
+
+export interface SupercoreWord {
+  id: string;
+  label: string;
+  category: FitzgeraldCategory;
+  arasaacId?: number;
+}
+
+/** ARASAAC pictogram URL for a numeric pictogram id. */
+export const ARASAAC_IMG = (id: number) =>
+  `https://static.arasaac.org/pictograms/${id}/${id}_500.png`;
+
+/**
+ * THE SUPERCORE 50 GRID
+ *
+ * Layout: 10 columns x 5 rows = 50 cells, left-to-right, top-to-bottom.
+ * THIS ORDER IS PERMANENT. NEVER CHANGE IT. Frozen to make the
+ * non-destructive contract enforceable at runtime.
+ */
+export const SUPERCORE_50: readonly SupercoreWord[] = Object.freeze([
+  // Row 1
+  { id: 'w01', label: 'I',         category: 'people',      arasaacId: 6632 },
+  { id: 'w02', label: 'you',       category: 'people',      arasaacId: 6625 },
+  { id: 'w03', label: 'want',      category: 'verbs',       arasaacId: 5441 },
+  { id: 'w04', label: 'need',      category: 'verbs',       arasaacId: 37160 },
+  { id: 'w05', label: 'like',      category: 'verbs',       arasaacId: 37826 },
+  { id: 'w06', label: "don't",     category: 'negation',    arasaacId: 5525 },
+  { id: 'w07', label: 'help',      category: 'social',      arasaacId: 32648 },
+  { id: 'w08', label: 'more',      category: 'determiners', arasaacId: 5508 },
+  { id: 'w09', label: 'stop',      category: 'negation',    arasaacId: 7196 },
+  { id: 'w10', label: 'go',        category: 'verbs',       arasaacId: 8142 },
+
+  // Row 2
+  { id: 'w11', label: 'come',      category: 'verbs',       arasaacId: 32669 },
+  { id: 'w12', label: 'look',      category: 'verbs',       arasaacId: 6564 },
+  { id: 'w13', label: 'eat',       category: 'verbs',       arasaacId: 6456 },
+  { id: 'w14', label: 'drink',     category: 'verbs',       arasaacId: 6061 },
+  { id: 'w15', label: 'play',      category: 'verbs',       arasaacId: 23392 },
+  { id: 'w16', label: 'yes',       category: 'social',      arasaacId: 5584 },
+  { id: 'w17', label: 'no',        category: 'negation',    arasaacId: 5526 },
+  { id: 'w18', label: 'please',    category: 'social',      arasaacId: 8195 },
+  { id: 'w19', label: 'thank you', category: 'social',      arasaacId: 8129 },
+  { id: 'w20', label: 'sorry',     category: 'social',      arasaacId: 11625 },
+
+  // Row 3
+  { id: 'w21', label: 'happy',     category: 'descriptors', arasaacId: 35533 },
+  { id: 'w22', label: 'sad',       category: 'descriptors', arasaacId: 35545 },
+  { id: 'w23', label: 'angry',     category: 'descriptors', arasaacId: 35539 },
+  { id: 'w24', label: 'tired',     category: 'descriptors', arasaacId: 35537 },
+  { id: 'w25', label: 'hot',       category: 'descriptors', arasaacId: 2300 },
+  { id: 'w26', label: 'cold',      category: 'descriptors', arasaacId: 4652 },
+  { id: 'w27', label: 'big',       category: 'descriptors', arasaacId: 4658 },
+  { id: 'w28', label: 'small',     category: 'descriptors', arasaacId: 4716 },
+  { id: 'w29', label: 'up',        category: 'prepositions', arasaacId: 5388 },
+  { id: 'w30', label: 'down',      category: 'prepositions', arasaacId: 37428 },
+
+  // Row 4
+  { id: 'w31', label: 'in',        category: 'prepositions', arasaacId: 7034 },
+  { id: 'w32', label: 'out',       category: 'prepositions', arasaacId: 6606 },
+  { id: 'w33', label: 'on',        category: 'prepositions', arasaacId: 7814 },
+  { id: 'w34', label: 'off',       category: 'prepositions', arasaacId: 27518 },
+  { id: 'w35', label: 'open',      category: 'verbs',       arasaacId: 24825 },
+  { id: 'w36', label: 'close',     category: 'verbs',       arasaacId: 30383 },
+  { id: 'w37', label: 'give',      category: 'verbs',       arasaacId: 28431 },
+  { id: 'w38', label: 'take',      category: 'verbs',       arasaacId: 10148 },
+  { id: 'w39', label: 'put',       category: 'verbs',       arasaacId: 32757 },
+  { id: 'w40', label: 'make',      category: 'verbs',       arasaacId: 32751 },
+
+  // Row 5
+  { id: 'w41', label: 'do',        category: 'verbs',       arasaacId: 6624 },
+  { id: 'w42', label: 'have',      category: 'verbs',       arasaacId: 32761 },
+  { id: 'w43', label: 'is',        category: 'verbs',       arasaacId: 8115 },
+  { id: 'w44', label: 'it',        category: 'determiners', arasaacId: 31670 },
+  { id: 'w45', label: 'that',      category: 'determiners', arasaacId: 6906 },
+  { id: 'w46', label: 'this',      category: 'determiners', arasaacId: 7095 },
+  { id: 'w47', label: 'what',      category: 'questions',   arasaacId: 22620 },
+  { id: 'w48', label: 'where',     category: 'questions',   arasaacId: 7764 },
+  { id: 'w49', label: 'who',       category: 'questions',   arasaacId: 9853 },
+  { id: 'w50', label: 'why',       category: 'questions',   arasaacId: 36719 },
+] as const);
+
+/** Lowercase label -> Supercore word, built once. */
+export const SUPERCORE_BY_LABEL: ReadonlyMap<string, SupercoreWord> = (() => {
+  const map = new Map<string, SupercoreWord>();
+  for (const w of SUPERCORE_50) map.set(w.label.toLowerCase(), w);
+  return map;
+})();
+
+/** All words in a category, in their permanent grid order. */
+export function wordsInCategory(category: FitzgeraldCategory): SupercoreWord[] {
+  return SUPERCORE_50.filter((w) => w.category === category);
+}
+
+// ---------------------------------------------------------------------------
+// Scene hotspots (Gamma / SceneField)
+// ---------------------------------------------------------------------------
+
+/**
+ * A curated set of large, high-value core words positioned over the Scene
+ * backdrop as percentages (x/y are the hotspot CENTRE, 0-100). Few, big
+ * targets - the whole point of the Scene surface. Every entry is a real
+ * Supercore word (looked up by id) so the Scene never invents vocabulary.
+ */
+export interface SceneHotspot {
+  id: string;
+  /** Centre X as a percentage of the scene width. */
+  x: number;
+  /** Centre Y as a percentage of the scene height. */
+  y: number;
+}
+
+export const SCENE_HOTSPOTS: readonly SceneHotspot[] = Object.freeze([
+  { id: 'w01', x: 16, y: 22 }, // I
+  { id: 'w02', x: 50, y: 16 }, // you
+  { id: 'w03', x: 82, y: 24 }, // want
+  { id: 'w13', x: 24, y: 46 }, // eat
+  { id: 'w14', x: 50, y: 42 }, // drink
+  { id: 'w15', x: 76, y: 48 }, // play
+  { id: 'w07', x: 14, y: 70 }, // help
+  { id: 'w08', x: 38, y: 74 }, // more
+  { id: 'w16', x: 62, y: 72 }, // yes
+  { id: 'w09', x: 86, y: 70 }, // stop
+  { id: 'w21', x: 32, y: 90 }, // happy
+  { id: 'w10', x: 68, y: 90 }, // go
+]);
+
+/** Resolve the curated Scene hotspots to their Supercore words + positions. */
+export function sceneHotspotWords(): { word: SupercoreWord; x: number; y: number }[] {
+  return SCENE_HOTSPOTS.map((h) => {
+    const word = SUPERCORE_50.find((w) => w.id === h.id);
+    if (!word) throw new Error(`Scene hotspot references unknown word id: ${h.id}`);
+    return { word, x: h.x, y: h.y };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared tap action (the ONE way any surface writes a core word)
+// ---------------------------------------------------------------------------
+
+/** Build the sentence-strip chip for a core word (Fitzgerald-coloured). */
+export function coreWordChip(word: SupercoreWord): SentenceWord {
+  const cls = FITZGERALD_CLASSES[word.category];
+  return {
+    label: word.label,
+    imageUrl: word.arasaacId ? ARASAAC_IMG(word.arasaacId) : undefined,
+    className: `${cls.bg} ${cls.text} ${cls.border}`,
+  };
+}
+
+/** Callback bundle for {@link performCoreTap}. Pure and injectable for tests. */
+export interface CoreTapHandlers {
+  /** Speak the word (shared TTS pipeline). */
+  speak: (text: string) => void;
+  /** Append a chip to the shared sentence store. */
+  add: (chip: SentenceWord) => void;
+  /** Log the tap for analytics/personalisation. */
+  log: (word: string) => void;
+}
+
+/**
+ * The single "tap a core word" action, shared by the grid and every surface.
+ * Speaks the word, appends its chip to the shared sentence strip, and logs the
+ * tap - in that order, exactly as the grid does. Purely delegates to the
+ * injected handlers so it is trivially testable and provably non-destructive
+ * (it never touches vocabulary, personal words or phrase folders).
+ */
+export function performCoreTap(word: SupercoreWord, handlers: CoreTapHandlers): void {
+  handlers.speak(word.label);
+  handlers.add(coreWordChip(word));
+  handlers.log(word.label);
+}


### PR DESCRIPTION
Stacked on #221 (base: `feat/layout-primitives-core`). Replaces the four "coming soon" placeholders in `src/components/surfaces/index.tsx` with real, functional Talk Core surfaces, behind the existing `layoutPrimitives` flag (`NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES`, default OFF).

## The four surfaces

- **SceneField (Γ Scene)** - a calm sky-to-meadow gradient backdrop with 12 large word hotspots positioned over it (percent-based, reflow at any size). Few, big targets sourced from the active vocabulary.
- **TextRail (Δ Word Rail)** - keyboard-forward: a text compose box that types straight into the shared sentence strip, a next-word prediction rail (reuses the existing `predictNext` engine) and a row of quick social words.
- **FlowBoard (Ε Flow Board)** - an auto-fill card grid that flows to fit any width, with a category filter that is a vertical side-rail on wide screens and collapses to a horizontal bottom bar on phones.
- **OrbitCore (Ζ Orbit Core)** - the signature radial shape: a central speak orb ringed by eight category satellites; tapping a satellite reveals that category's words held close to the centre.

## Same vocabulary, same pipeline (non-destructive)

The Supercore 50 word list, the Fitzgerald Key colour classes, the pictogram URL helper and the single "tap a core word" action moved to one source of truth, `src/lib/core-vocab.ts`, now consumed by both `SupercoreGrid` and every surface via the shared `useCoreSurface` hook. Every surface:

- reads the **same** Supercore 50 vocabulary, and
- writes through the **same** speak + shared sentence store as the grid.

Selecting a surface is presentation only - it never mutates vocabulary, categories, personal words or phrase folders. `SUPERCORE_50` is frozen; tests assert the non-destructive contract at runtime.

## Guardrails

- Behind the same flag. Flag OFF is byte-for-byte today (always resolves to the fixed grid). The grid and the Settings picker are untouched functionally.
- No hues 270-350 in surface chrome (backdrops, rails, rings). Fitzgerald category colours on word cards are the exempt AAC standard.
- No em dashes in shipped copy. TS strict, no `any`.
- a11y: tap targets >= 44px, aria-labels on interactive elements, keyboard-focusable buttons.

## Validation

- `bun test`: 89 pass (incl. 12 new surface tests - vocabulary source, shared chip/tap pipeline order, scene hotspots resolve to real words, non-destructive contract, router exports four distinct real components).
- `npx tsc --noEmit`: clean.
- `next build`: compiles (`/talk/core` builds).
- Eight headless Chrome screenshots captured and verified by eye - phone (390px) and desktop (1280px) for each surface, with the flag ON and `activeLayoutPrimitive` set per surface. Paths in `/Users/jamesspalding/layout-primitives-review/web-surfaces/`.

## Files

- `src/lib/core-vocab.ts` (new) - single source of truth for vocabulary + shared tap action.
- `src/components/surfaces/useCoreSurface.ts` (new) - shared speak/sentence pipeline hook.
- `src/components/surfaces/{SceneField,TextRail,FlowBoard,OrbitCore,SurfaceWordCard}.tsx` (new).
- `src/components/surfaces/surfaces.test.ts` (new).
- `src/components/surfaces/index.tsx` - router now maps the four kinds to the real surfaces.
- `src/components/SupercoreGrid.tsx` - consumes the extracted vocabulary (behaviour unchanged).