### PR TITLE
fix(layout): drop stale Coming-soon copy from the four built surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,10 @@ AGENTMAIL_FROM_INBOX=privacy@8gentjr.com
 # Dashboard: https://dashboard.clerk.com
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=
+
+# Feature flags
+# layoutPrimitives — structural Talk Core layouts (fixed/adaptive/scene/text/
+# flow/orbit). DEFAULT OFF. Set to the exact string 'true' to show the six
+# primitives picker in Settings and route the Core screen by structural kind.
+# When unset/anything-else, the app behaves exactly as today.
+NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES=

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -19,6 +19,8 @@ import {
   type InstallPlatform,
 } from '@/lib/pwa-install';
 import { LAYOUT_PRESETS, type LayoutPreset } from '@/lib/layout-presets';
+import { LAYOUT_PRIMITIVES, type LayoutPrimitive } from '@/lib/layout-primitives';
+import { isLayoutPrimitivesEnabled } from '@/lib/feature-flags';
 
 /**
  * 8gent Jr Settings Page
@@ -61,6 +63,10 @@ export default function SettingsPage() {
   const { settings, updateSettings } = useApp();
 
   const accent = settings.primaryColor || '#4CAF50';
+
+  // Layout primitives are gated behind a build-time feature flag (default off).
+  // When off, this section never renders and Settings looks exactly as today.
+  const primitivesEnabled = isLayoutPrimitivesEnabled();
 
   // Read-only stage estimate from on-device session-logger events (T3.7).
   // Computed client-side after mount so SSR stays deterministic.
@@ -203,6 +209,17 @@ export default function SettingsPage() {
           </p>
           <LayoutPresetPicker accent={accent} />
         </Section>
+
+        {/* ── Layout Primitives (feature-flagged, structural surfaces) ── */}
+        {primitivesEnabled && (
+          <Section title="Layout shape" icon={<IconLayout />}>
+            <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
+              Choose the shape of the Talk screen. Each shape arranges the same
+              words a different way. Steady Grid is the classic board.
+            </p>
+            <LayoutPrimitivePicker accent={accent} />
+          </Section>
+        )}
 
         {/* ── Grid Columns ── */}
         <Section title="Grid Size" icon={<IconGrid />}>
@@ -706,6 +723,99 @@ function PresetHint({ preset }: { preset: LayoutPreset }) {
           key={i}
           className="rounded-[2px]"
           style={{ backgroundColor: preset.hint.color, opacity: 0.85 }}
+        />
+      ))}
+    </span>
+  );
+}
+
+/* ── Layout primitive picker (radiogroup, feature-flagged) ── */
+function LayoutPrimitivePicker({ accent }: { accent: string }) {
+  const { settings, updateSettings } = useApp();
+  const activeId = settings.activeLayoutPrimitive ?? 'alpha';
+
+  const applyPrimitive = (primitive: LayoutPrimitive) => {
+    // Presentation-only: apply the primitive's layout bundle and record the
+    // selection. Vocabulary, categories, personal words and phrase folders
+    // live in their own storage keys and are never touched here.
+    updateSettings({
+      gridColumns: primitive.bundle.gridColumns,
+      cardSize: primitive.bundle.cardSize,
+      showPredictions: primitive.bundle.showPredictions,
+      showPersonalVocab: primitive.bundle.showPersonalVocab,
+      density: primitive.bundle.density,
+      activeLayoutPrimitive: primitive.id,
+    });
+  };
+
+  return (
+    <div className="space-y-2" role="radiogroup" aria-label="Talk screen shape">
+      {LAYOUT_PRIMITIVES.map((primitive) => {
+        const active = activeId === primitive.id;
+        return (
+          <button
+            key={primitive.id}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => applyPrimitive(primitive)}
+            className="w-full flex items-center gap-3 text-left px-3 py-3 rounded-xl border-2 transition-all active:scale-[0.98]"
+            style={{
+              borderColor: active ? accent : 'var(--warm-border, #E8E0D6)',
+              backgroundColor: active ? `${accent}12` : 'white',
+            }}
+          >
+            <PrimitiveHint primitive={primitive} />
+            <span className="flex-1 min-w-0">
+              <span className="flex items-center gap-2">
+                <span
+                  className="text-lg font-bold leading-none"
+                  style={{ color: primitive.hint.color }}
+                  aria-hidden="true"
+                >
+                  {primitive.glyph}
+                </span>
+                <span className="font-bold" style={{ color: active ? accent : 'var(--warm-text, #1A1614)' }}>
+                  {primitive.name}
+                </span>
+                {active && (
+                  <span
+                    className="w-5 h-5 rounded-full flex items-center justify-center text-white text-xs font-bold flex-shrink-0"
+                    style={{ backgroundColor: accent }}
+                    aria-hidden="true"
+                  >
+                    ✓
+                  </span>
+                )}
+              </span>
+              <span className="block text-sm mt-0.5" style={{ color: 'var(--warm-text-muted, #9A9088)' }}>
+                {primitive.description}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/* Tiny visual hint for a primitive: a mini grid preview mirroring its shape. */
+function PrimitiveHint({ primitive }: { primitive: LayoutPrimitive }) {
+  const cells = Array.from({ length: primitive.hint.cells });
+  return (
+    <span
+      className="grid gap-0.5 w-12 h-12 p-1 rounded-lg flex-shrink-0 self-start"
+      style={{
+        gridTemplateColumns: `repeat(${primitive.hint.cols}, 1fr)`,
+        backgroundColor: 'var(--warm-border-light, #F0EAE3)',
+      }}
+      aria-hidden="true"
+    >
+      {cells.map((_, i) => (
+        <span
+          key={i}
+          className="rounded-[2px]"
+          style={{ backgroundColor: primitive.hint.color, opacity: 0.85 }}
         />
       ))}
     </span>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -18,8 +18,13 @@ import {
   detectPlatform,
   type InstallPlatform,
 } from '@/lib/pwa-install';
-import { LAYOUT_PRESETS, type LayoutPreset } from '@/lib/layout-presets';
-import { LAYOUT_PRIMITIVES, type LayoutPrimitive } from '@/lib/layout-primitives';
+import {
+  LAYOUT_PRESETS,
+  LAYOUT_PRIMITIVES,
+  activePrimitiveIdForSettings,
+  type LayoutPreset,
+  type LayoutPrimitive,
+} from '@/lib/layout-primitives';
 import { isLayoutPrimitivesEnabled } from '@/lib/feature-flags';
 
 /**
@@ -56,6 +61,8 @@ const DEFAULTS: Partial<AppSettings> = {
   showPersonalVocab: true,
   density: 'relaxed',
   activeLayoutPreset: 'big-simple',
+  // Unified layout selection matching the default Big & Simple bundle.
+  activeLayoutPrimitive: 'eta',
 };
 
 export default function SettingsPage() {
@@ -200,26 +207,29 @@ export default function SettingsPage() {
           </div>
         </Section>
 
-        {/* ── Layout Presets ── */}
+        {/* ── Layout (single unified chooser) ── */}
         <Section title="Layout" icon={<IconLayout />}>
-          <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
-            Pick a ready-made layout for the Talk screen. Choosing one sets the
-            grid size, card size and helper rows together. Tweak any of those
-            below and the layout becomes &ldquo;Custom&rdquo;.
-          </p>
-          <LayoutPresetPicker accent={accent} />
+          {primitivesEnabled ? (
+            <>
+              <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
+                Pick a layout for the Talk screen. Each one arranges the same
+                words a different way and sets the grid size, card size and
+                helper rows together. Tweak any of those below and the layout
+                becomes &ldquo;Custom&rdquo;.
+              </p>
+              <LayoutPrimitivePicker accent={accent} />
+            </>
+          ) : (
+            <>
+              <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
+                Pick a ready-made layout for the Talk screen. Choosing one sets the
+                grid size, card size and helper rows together. Tweak any of those
+                below and the layout becomes &ldquo;Custom&rdquo;.
+              </p>
+              <LayoutPresetPicker accent={accent} />
+            </>
+          )}
         </Section>
-
-        {/* ── Layout Primitives (feature-flagged, structural surfaces) ── */}
-        {primitivesEnabled && (
-          <Section title="Layout shape" icon={<IconLayout />}>
-            <p className="text-sm mb-3" style={{ color: 'var(--warm-text-secondary, #5C544A)' }}>
-              Choose the shape of the Talk screen. Each shape arranges the same
-              words a different way. Steady Grid is the classic board.
-            </p>
-            <LayoutPrimitivePicker accent={accent} />
-          </Section>
-        )}
 
         {/* ── Grid Columns ── */}
         <Section title="Grid Size" icon={<IconGrid />}>
@@ -732,12 +742,16 @@ function PresetHint({ preset }: { preset: LayoutPreset }) {
 /* ── Layout primitive picker (radiogroup, feature-flagged) ── */
 function LayoutPrimitivePicker({ accent }: { accent: string }) {
   const { settings, updateSettings } = useApp();
-  const activeId = settings.activeLayoutPrimitive ?? 'alpha';
+  // Selection is bundle-derived: a preset is "active" only while the current
+  // layout still matches its bundle. Hand-tuning any knob (Grid Size, Your
+  // Words) below makes the layout fall into "Custom" automatically.
+  const activeId = activePrimitiveIdForSettings(settings);
 
   const applyPrimitive = (primitive: LayoutPrimitive) => {
     // Presentation-only: apply the primitive's layout bundle and record the
-    // selection. Vocabulary, categories, personal words and phrase folders
-    // live in their own storage keys and are never touched here.
+    // selection in ONE action, exactly like a theme switch. Vocabulary,
+    // categories, personal words and phrase folders live in their own storage
+    // keys and are never touched here.
     updateSettings({
       gridColumns: primitive.bundle.gridColumns,
       cardSize: primitive.bundle.cardSize,
@@ -745,11 +759,15 @@ function LayoutPrimitivePicker({ accent }: { accent: string }) {
       showPersonalVocab: primitive.bundle.showPersonalVocab,
       density: primitive.bundle.density,
       activeLayoutPrimitive: primitive.id,
+      // Keep the classic selection field in sync so both pickers agree if the
+      // flag is ever toggled: a classic-backed primitive maps to its preset id,
+      // anything structural counts as a hand-tuned "custom" density.
+      activeLayoutPreset: primitive.classic ? primitive.classic.id : 'custom',
     });
   };
 
   return (
-    <div className="space-y-2" role="radiogroup" aria-label="Talk screen shape">
+    <div className="space-y-2" role="radiogroup" aria-label="Talk screen layout">
       {LAYOUT_PRIMITIVES.map((primitive) => {
         const active = activeId === primitive.id;
         return (
@@ -795,6 +813,41 @@ function LayoutPrimitivePicker({ accent }: { accent: string }) {
           </button>
         );
       })}
+
+      {/* Custom state row: not selectable, only reflects hand-tuned settings. */}
+      {activeId === 'custom' && (
+        <div
+          className="w-full flex items-center gap-3 px-3 py-3 rounded-xl border-2"
+          style={{ borderColor: accent, backgroundColor: `${accent}12` }}
+          aria-live="polite"
+        >
+          <span
+            className="w-12 h-12 rounded-lg flex items-center justify-center flex-shrink-0 border-2 border-dashed"
+            style={{ borderColor: accent, color: accent }}
+            aria-hidden="true"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 20h9" />
+              <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+            </svg>
+          </span>
+          <span className="flex-1 min-w-0">
+            <span className="flex items-center gap-2">
+              <span className="font-bold" style={{ color: accent }}>Custom</span>
+              <span
+                className="w-5 h-5 rounded-full flex items-center justify-center text-white text-xs font-bold flex-shrink-0"
+                style={{ backgroundColor: accent }}
+                aria-hidden="true"
+              >
+                ✓
+              </span>
+            </span>
+            <span className="block text-sm mt-0.5" style={{ color: 'var(--warm-text-muted, #9A9088)' }}>
+              Your own mix. Pick a layout above to start over.
+            </span>
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/talk/core/page.tsx
+++ b/src/app/talk/core/page.tsx
@@ -8,14 +8,43 @@
  *
  * Route: /talk/core
  * Issue: #20
+ *
+ * Layout primitives: when the layoutPrimitives feature flag is ON, the active
+ * structural primitive (AppSettings.activeLayoutPrimitive) selects which
+ * SURFACE renders. When the flag is OFF the surface is always the current
+ * fixed grid - this file renders exactly what it did before the flag existed.
  */
 
 import { SupercoreGrid } from '@/components/SupercoreGrid';
+import { getSurfaceForKind } from '@/components/surfaces';
+import { useApp } from '@/context/AppContext';
+import { isLayoutPrimitivesEnabled } from '@/lib/feature-flags';
+import { getPrimitive, resolveActivePrimitiveId } from '@/lib/layout-primitives';
 
 export default function SupercoreCorePage() {
+  const { settings } = useApp();
+
+  // Flag OFF: render the current grid, unchanged. This branch is a build-time
+  // constant (NEXT_PUBLIC_* is inlined), so with the flag off the surface
+  // router and primitive resolution are never reached.
+  if (!isLayoutPrimitivesEnabled()) {
+    return (
+      <div className="h-screen bg-[var(--brand-bg-warm)]">
+        <SupercoreGrid />
+      </div>
+    );
+  }
+
+  // Flag ON: resolve the active primitive to a structural surface. In this
+  // framework PR every kind still renders the Supercore grid (with a "coming
+  // soon" banner for the four not-yet-built kinds).
+  const activeId = resolveActivePrimitiveId(true, settings.activeLayoutPrimitive);
+  const primitive = getPrimitive(activeId);
+  const Surface = getSurfaceForKind(primitive.kind);
+
   return (
     <div className="h-screen bg-[var(--brand-bg-warm)]">
-      <SupercoreGrid />
+      <Surface />
     </div>
   );
 }

--- a/src/components/SupercoreGrid.tsx
+++ b/src/components/SupercoreGrid.tsx
@@ -25,7 +25,15 @@
  */
 
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
-import { FITZGERALD_COLORS, type WordCategory } from '@/lib/fitzgerald-key';
+import {
+  SUPERCORE_50,
+  ARASAAC_IMG,
+  FITZGERALD_CLASSES,
+  getGridCategoryColor,
+  performCoreTap,
+  type SupercoreWord as CoreWord,
+  type FitzgeraldCategory,
+} from '@/lib/core-vocab';
 import { logWord } from '@/lib/session-logger';
 import { speak as elevenLabsSpeak, preloadAudio } from '@/lib/tts';
 import { SharedSentenceBar } from '@/components/SharedSentenceBar';
@@ -39,133 +47,11 @@ import { getPersonalVocab } from '@/lib/personal-vocab';
 import { predictNext, PREDICTIVE_CARD_COUNT } from '@/lib/predictive';
 import { CARD_SIZE_TOKENS, type CardSize } from '@/lib/layout-presets';
 
-// =============================================================================
-// Fitzgerald Key Color Definitions (mapped from shared vocabulary system)
-// =============================================================================
-
-type FitzgeraldCategory =
-  | 'people'
-  | 'verbs'
-  | 'descriptors'
-  | 'prepositions'
-  | 'social'
-  | 'questions'
-  | 'determiners'
-  | 'negation';
-
-/** Map grid categories to canonical Fitzgerald Key word categories */
-const CATEGORY_TO_WORD_TYPE: Record<FitzgeraldCategory, WordCategory> = {
-  people: 'pronoun',
-  verbs: 'verb',
-  descriptors: 'adjective',
-  prepositions: 'preposition',
-  social: 'social',
-  questions: 'question',
-  determiners: 'determiner',
-  negation: 'negation',
-};
-
-/**
- * Maps each Fitzgerald category to Tailwind class strings using CSS variables.
- * bg = background, text = text color, border = border color, chip = sentence strip chip
- */
-const FITZGERALD_CLASSES: Record<FitzgeraldCategory, { bg: string; text: string; border: string }> = {
-  people:       { bg: 'bg-fitzgerald-yellow', text: 'text-fitzgerald-yellow-text', border: 'border-fitzgerald-yellow-border' },
-  verbs:        { bg: 'bg-fitzgerald-green',  text: 'text-fitzgerald-green-text',  border: 'border-fitzgerald-green-border' },
-  descriptors:  { bg: 'bg-fitzgerald-blue',   text: 'text-fitzgerald-blue-text',   border: 'border-fitzgerald-blue-border' },
-  prepositions: { bg: 'bg-fitzgerald-purple', text: 'text-fitzgerald-purple-text', border: 'border-fitzgerald-purple-border' },
-  social:       { bg: 'bg-fitzgerald-pink',   text: 'text-fitzgerald-pink-text',   border: 'border-fitzgerald-pink-border' },
-  questions:    { bg: 'bg-fitzgerald-orange',  text: 'text-fitzgerald-orange-text', border: 'border-fitzgerald-orange-border' },
-  determiners:  { bg: 'bg-fitzgerald-white',   text: 'text-fitzgerald-white-text',  border: 'border-fitzgerald-white-border' },
-  negation:     { bg: 'bg-fitzgerald-red',    text: 'text-fitzgerald-red-text',    border: 'border-fitzgerald-red-border' },
-};
-
-/** Get inline Fitzgerald Key color for a grid category (used by non-Tailwind contexts) */
-export function getGridCategoryColor(category: FitzgeraldCategory) {
-  return FITZGERALD_COLORS[CATEGORY_TO_WORD_TYPE[category]];
-}
-
-// =============================================================================
-// Core Word Data - FIXED positions, NEVER reorder
-// =============================================================================
-
-interface CoreWord {
-  id: string;
-  label: string;
-  category: FitzgeraldCategory;
-  arasaacId?: number;
-}
-
-const ARASAAC_IMG = (id: number) => `https://static.arasaac.org/pictograms/${id}/${id}_500.png`;
-
-/**
- * THE SUPERCORE 50 GRID
- *
- * Layout: 10 columns x 5 rows = 50 cells
- * Words are ordered LEFT-TO-RIGHT, TOP-TO-BOTTOM.
- * THIS ORDER IS PERMANENT. NEVER CHANGE IT.
- */
-const SUPERCORE_50: CoreWord[] = [
-  // Row 1
-  { id: 'w01', label: 'I',         category: 'people',      arasaacId: 6632 },
-  { id: 'w02', label: 'you',       category: 'people',      arasaacId: 6625 },
-  { id: 'w03', label: 'want',      category: 'verbs',       arasaacId: 5441 },
-  { id: 'w04', label: 'need',      category: 'verbs',       arasaacId: 37160 },
-  { id: 'w05', label: 'like',      category: 'verbs',       arasaacId: 37826 },
-  { id: 'w06', label: "don't",     category: 'negation',    arasaacId: 5525 },
-  { id: 'w07', label: 'help',      category: 'social',      arasaacId: 32648 },
-  { id: 'w08', label: 'more',      category: 'determiners', arasaacId: 5508 },
-  { id: 'w09', label: 'stop',      category: 'negation',    arasaacId: 7196 },
-  { id: 'w10', label: 'go',        category: 'verbs',       arasaacId: 8142 },
-
-  // Row 2
-  { id: 'w11', label: 'come',      category: 'verbs',       arasaacId: 32669 },
-  { id: 'w12', label: 'look',      category: 'verbs',       arasaacId: 6564 },
-  { id: 'w13', label: 'eat',       category: 'verbs',       arasaacId: 6456 },
-  { id: 'w14', label: 'drink',     category: 'verbs',       arasaacId: 6061 },
-  { id: 'w15', label: 'play',      category: 'verbs',       arasaacId: 23392 },
-  { id: 'w16', label: 'yes',       category: 'social',      arasaacId: 5584 },
-  { id: 'w17', label: 'no',        category: 'negation',    arasaacId: 5526 },
-  { id: 'w18', label: 'please',    category: 'social',      arasaacId: 8195 },
-  { id: 'w19', label: 'thank you', category: 'social',      arasaacId: 8129 },
-  { id: 'w20', label: 'sorry',     category: 'social',      arasaacId: 11625 },
-
-  // Row 3
-  { id: 'w21', label: 'happy',     category: 'descriptors', arasaacId: 35533 },
-  { id: 'w22', label: 'sad',       category: 'descriptors', arasaacId: 35545 },
-  { id: 'w23', label: 'angry',     category: 'descriptors', arasaacId: 35539 },
-  { id: 'w24', label: 'tired',     category: 'descriptors', arasaacId: 35537 },
-  { id: 'w25', label: 'hot',       category: 'descriptors', arasaacId: 2300 },
-  { id: 'w26', label: 'cold',      category: 'descriptors', arasaacId: 4652 },
-  { id: 'w27', label: 'big',       category: 'descriptors', arasaacId: 4658 },
-  { id: 'w28', label: 'small',     category: 'descriptors', arasaacId: 4716 },
-  { id: 'w29', label: 'up',        category: 'prepositions', arasaacId: 5388 },
-  { id: 'w30', label: 'down',      category: 'prepositions', arasaacId: 37428 },
-
-  // Row 4
-  { id: 'w31', label: 'in',        category: 'prepositions', arasaacId: 7034 },
-  { id: 'w32', label: 'out',       category: 'prepositions', arasaacId: 6606 },
-  { id: 'w33', label: 'on',        category: 'prepositions', arasaacId: 7814 },
-  { id: 'w34', label: 'off',       category: 'prepositions', arasaacId: 27518 },
-  { id: 'w35', label: 'open',      category: 'verbs',       arasaacId: 24825 },
-  { id: 'w36', label: 'close',     category: 'verbs',       arasaacId: 30383 },
-  { id: 'w37', label: 'give',      category: 'verbs',       arasaacId: 28431 },
-  { id: 'w38', label: 'take',      category: 'verbs',       arasaacId: 10148 },
-  { id: 'w39', label: 'put',       category: 'verbs',       arasaacId: 32757 },
-  { id: 'w40', label: 'make',      category: 'verbs',       arasaacId: 32751 },
-
-  // Row 5
-  { id: 'w41', label: 'do',        category: 'verbs',       arasaacId: 6624 },
-  { id: 'w42', label: 'have',      category: 'verbs',       arasaacId: 32761 },
-  { id: 'w43', label: 'is',        category: 'verbs',       arasaacId: 8115 },
-  { id: 'w44', label: 'it',        category: 'determiners', arasaacId: 31670 },
-  { id: 'w45', label: 'that',      category: 'determiners', arasaacId: 6906 },
-  { id: 'w46', label: 'this',      category: 'determiners', arasaacId: 7095 },
-  { id: 'w47', label: 'what',      category: 'questions',   arasaacId: 22620 },
-  { id: 'w48', label: 'where',     category: 'questions',   arasaacId: 7764 },
-  { id: 'w49', label: 'who',       category: 'questions',   arasaacId: 9853 },
-  { id: 'w50', label: 'why',       category: 'questions',   arasaacId: 36719 },
-];
+// Core vocabulary, Fitzgerald Key colours, the pictogram URL helper and the
+// shared "tap a core word" action now live in @/lib/core-vocab so every Layout
+// Primitive surface reads the SAME data and writes through the SAME pipeline.
+// getGridCategoryColor is re-exported for backward compatibility.
+export { getGridCategoryColor };
 
 // =============================================================================
 // TTS Helper - ElevenLabs via tts.ts
@@ -361,13 +247,7 @@ export function SupercoreGrid({ onSpeak }: SupercoreGridProps) {
   }, [onSpeak, settings.selectedVoiceId, settings.ttsRate]);
 
   const handleWordTap = useCallback((word: CoreWord) => {
-    speakText(word.label);
-    addWord({
-      label: word.label,
-      imageUrl: word.arasaacId ? ARASAAC_IMG(word.arasaacId) : undefined,
-      className: `${FITZGERALD_CLASSES[word.category].bg} ${FITZGERALD_CLASSES[word.category].text} ${FITZGERALD_CLASSES[word.category].border}`,
-    });
-    logWord(word.label);
+    performCoreTap(word, { speak: speakText, add: addWord, log: logWord });
   }, [speakText, addWord]);
 
   const handleSpeakAll = useCallback(() => {

--- a/src/components/surfaces/FlowBoard.tsx
+++ b/src/components/surfaces/FlowBoard.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+/**
+ * FlowBoard (Ε Flow Board) - a fluid, auto-reflowing board of word cards with a
+ * category filter. The filter is a vertical side-rail on wide screens and
+ * collapses to a horizontal bottom bar on narrow phones, so the same board
+ * works from phone to desktop. The card area uses an auto-fill grid, so cards
+ * flow to fit whatever width is available - no fixed column count.
+ *
+ * Same vocabulary (Supercore 50, grouped by the existing Fitzgerald categories)
+ * and the same speak/sentence pipeline (useCoreSurface). Filtering is
+ * presentation-only: it never reorders or mutates the underlying vocabulary.
+ */
+
+import { useMemo, useState } from 'react';
+import { SharedSentenceBar } from '@/components/SharedSentenceBar';
+import { TapCard } from '@/components/TapCard';
+import {
+  SUPERCORE_50,
+  CORE_CATEGORY_ORDER,
+  FITZGERALD_CLASSES,
+  wordsInCategory,
+  type FitzgeraldCategory,
+} from '@/lib/core-vocab';
+import { SurfaceWordCard } from './SurfaceWordCard';
+import { useCoreSurface } from './useCoreSurface';
+import type { SurfaceProps } from './index';
+
+type Filter = 'all' | FitzgeraldCategory;
+
+export function FlowBoard(props: SurfaceProps) {
+  const {
+    sentence,
+    removeWord,
+    engineFallback,
+    isMagicLoading,
+    tapWord,
+    handleSpeakAll,
+    handleClear,
+    handleMagic,
+  } = useCoreSurface(props);
+
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const words = useMemo(
+    () => (filter === 'all' ? [...SUPERCORE_50] : wordsInCategory(filter)),
+    [filter],
+  );
+
+  const railItems: { key: Filter; label: string; category?: FitzgeraldCategory }[] = [
+    { key: 'all', label: 'All' },
+    ...CORE_CATEGORY_ORDER.map((c) => ({ key: c.category as Filter, label: c.label, category: c.category })),
+  ];
+
+  const railButton = (item: { key: Filter; label: string; category?: FitzgeraldCategory }) => {
+    const active = filter === item.key;
+    const cls = item.category ? FITZGERALD_CLASSES[item.category] : null;
+    return (
+      <TapCard
+        key={item.key}
+        onTap={() => setFilter(item.key)}
+        ariaLabel={`Show ${item.label}`}
+        className={`shrink-0 min-h-[44px] px-3 rounded-xl border-[3px] font-bold text-[13px] flex items-center justify-center ${
+          cls ? `${cls.bg} ${cls.text} ${cls.border}` : 'bg-gray-100 text-gray-800 border-gray-400'
+        } ${active ? 'ring-2 ring-offset-1 ring-emerald-500' : ''}`}
+      >
+        {item.label}
+      </TapCard>
+    );
+  };
+
+  return (
+    <div
+      className="flex flex-col font-sans bg-gray-50"
+      style={{ height: 'calc(100dvh - 72px - env(safe-area-inset-bottom, 0px))' }}
+    >
+      <SharedSentenceBar
+        words={sentence}
+        onSpeak={handleSpeakAll}
+        onMagic={handleMagic}
+        isMagicLoading={isMagicLoading}
+        onClear={handleClear}
+        onRemoveWord={removeWord}
+        engineFallback={engineFallback}
+      />
+
+      <div className="flex-1 min-h-0 flex flex-row">
+        {/* Side-rail (wide screens) */}
+        <nav
+          className="hidden md:flex md:flex-col gap-2 w-40 shrink-0 overflow-y-auto p-2 border-r border-gray-200"
+          aria-label="Word categories"
+        >
+          {railItems.map(railButton)}
+        </nav>
+
+        {/* Flowing card area */}
+        <div className="flex-1 min-h-0 overflow-y-auto touch-pan-y p-2">
+          <div
+            className="grid gap-2"
+            style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(84px, 1fr))' }}
+          >
+            {words.map((w) => (
+              <SurfaceWordCard key={w.id} word={w} onTap={tapWord} size="medium" />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom bar (narrow screens) */}
+      <nav
+        className="flex md:hidden gap-2 overflow-x-auto no-scrollbar p-2 border-t border-gray-200 bg-white shrink-0"
+        aria-label="Word categories"
+      >
+        {railItems.map(railButton)}
+      </nav>
+    </div>
+  );
+}
+
+export default FlowBoard;

--- a/src/components/surfaces/OrbitCore.tsx
+++ b/src/components/surfaces/OrbitCore.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+/**
+ * OrbitCore (Ζ Orbit Core) - the 8gent jr signature shape. A central speak orb
+ * sits at the middle of a ring of category satellites. Tapping a satellite
+ * reveals that category's words held close to the centre, in a compact cluster
+ * over the orb. Tapping the orb (with words in the strip) speaks the sentence.
+ *
+ * Same vocabulary (Supercore 50 grouped by the existing Fitzgerald categories)
+ * and the same speak/sentence pipeline (useCoreSurface). Selecting a satellite
+ * is presentation-only - it never mutates vocabulary, categories, personal words
+ * or phrase folders.
+ *
+ * Chrome (ring guide, centre orb) uses emerald/teal/slate - clear of the banned
+ * 270-350 hue band. Satellites and word cards keep the exempt Fitzgerald colours.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { SharedSentenceBar } from '@/components/SharedSentenceBar';
+import { TapCard } from '@/components/TapCard';
+import {
+  CORE_CATEGORY_ORDER,
+  FITZGERALD_CLASSES,
+  wordsInCategory,
+  type FitzgeraldCategory,
+} from '@/lib/core-vocab';
+import { SurfaceWordCard } from './SurfaceWordCard';
+import { useCoreSurface } from './useCoreSurface';
+import type { SurfaceProps } from './index';
+
+export function OrbitCore(props: SurfaceProps) {
+  const {
+    sentence,
+    removeWord,
+    engineFallback,
+    isMagicLoading,
+    tapWord,
+    handleSpeakAll,
+    handleClear,
+    handleMagic,
+  } = useCoreSurface(props);
+
+  const [selected, setSelected] = useState<FitzgeraldCategory | null>(null);
+  const fieldRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+
+  useEffect(() => {
+    const el = fieldRef.current;
+    if (!el) return;
+    const measure = () => setSize({ w: el.clientWidth, h: el.clientHeight });
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const satellites = CORE_CATEGORY_ORDER;
+  const cx = size.w / 2;
+  const cy = size.h / 2;
+  const ringRadius = Math.max(0, Math.min(size.w, size.h) / 2 - 52);
+
+  const selectedWords = useMemo(
+    () => (selected ? wordsInCategory(selected) : []),
+    [selected],
+  );
+
+  return (
+    <div
+      className="flex flex-col font-sans bg-slate-50"
+      style={{ height: 'calc(100dvh - 72px - env(safe-area-inset-bottom, 0px))' }}
+    >
+      <SharedSentenceBar
+        words={sentence}
+        onSpeak={handleSpeakAll}
+        onMagic={handleMagic}
+        isMagicLoading={isMagicLoading}
+        onClear={handleClear}
+        onRemoveWord={removeWord}
+        engineFallback={engineFallback}
+      />
+
+      <div
+        ref={fieldRef}
+        className="relative flex-1 min-h-0 overflow-hidden"
+        role="group"
+        aria-label="Orbit word core"
+      >
+        {/* Ring guide - decorative. */}
+        {ringRadius > 0 && (
+          <div
+            className="absolute rounded-full border-2 border-dashed pointer-events-none"
+            style={{
+              width: ringRadius * 2,
+              height: ringRadius * 2,
+              left: cx,
+              top: cy,
+              transform: 'translate(-50%, -50%)',
+              borderColor: 'rgba(15,118,110,0.25)',
+            }}
+            aria-hidden="true"
+          />
+        )}
+
+        {/* Category satellites on the ring. */}
+        {size.w > 0 &&
+          satellites.map((s, i) => {
+            const angle = (-90 + (360 / satellites.length) * i) * (Math.PI / 180);
+            const x = cx + ringRadius * Math.cos(angle);
+            const y = cy + ringRadius * Math.sin(angle);
+            const cls = FITZGERALD_CLASSES[s.category];
+            const active = selected === s.category;
+            return (
+              <div
+                key={s.category}
+                className="absolute"
+                style={{ left: x, top: y, transform: 'translate(-50%, -50%)' }}
+              >
+                <TapCard
+                  onTap={() => setSelected(active ? null : s.category)}
+                  ariaLabel={`${active ? 'Hide' : 'Show'} ${s.label} words`}
+                  className={`flex items-center justify-center rounded-full border-[3px] font-bold text-[12px] text-center leading-tight shadow-md px-1 ${cls.bg} ${cls.text} ${cls.border} ${
+                    active ? 'ring-2 ring-offset-2 ring-emerald-500' : ''
+                  }`}
+                  style={{ width: 72, height: 72 }}
+                >
+                  <span className="line-clamp-2">{s.label}</span>
+                </TapCard>
+              </div>
+            );
+          })}
+
+        {/* Centre: speak orb when nothing selected, else the word cluster. */}
+        <div
+          className="absolute"
+          style={{ left: cx, top: cy, transform: 'translate(-50%, -50%)' }}
+        >
+          {selected === null ? (
+            <TapCard
+              onTap={handleSpeakAll}
+              ariaLabel="Speak sentence"
+              className="flex flex-col items-center justify-center rounded-full bg-emerald-500 text-white border-4 border-emerald-600 shadow-lg"
+              style={{ width: 108, height: 108 }}
+            >
+              <span className="text-3xl leading-none">&#9654;</span>
+              <span className="text-[12px] font-bold mt-1">Speak</span>
+            </TapCard>
+          ) : (
+            <div
+              className="bg-white/95 backdrop-blur rounded-2xl shadow-xl border border-slate-200 p-2 w-[min(78vw,320px)] max-h-[60vh] overflow-y-auto"
+              role="group"
+              aria-label={`${satellites.find((s) => s.category === selected)?.label} words`}
+            >
+              <div className="flex items-center justify-between mb-1.5 px-1">
+                <span className="text-[12px] font-bold text-slate-600 uppercase tracking-wide">
+                  {satellites.find((s) => s.category === selected)?.label}
+                </span>
+                <button
+                  onClick={() => setSelected(null)}
+                  aria-label="Close category"
+                  className="w-9 h-9 shrink-0 rounded-full bg-slate-100 text-slate-600 font-bold flex items-center justify-center cursor-pointer active:scale-90"
+                >
+                  &#10005;
+                </button>
+              </div>
+              <div
+                className="grid gap-1.5"
+                style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(72px, 1fr))' }}
+              >
+                {selectedWords.map((w) => (
+                  <SurfaceWordCard key={w.id} word={w} onTap={tapWord} size="small" />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default OrbitCore;

--- a/src/components/surfaces/SceneField.tsx
+++ b/src/components/surfaces/SceneField.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+/**
+ * SceneField (Γ Scene) - a calm, familiar backdrop with a handful of big,
+ * tappable word hotspots floating over it. Few, large targets: the opposite of
+ * a dense grid, for children who scan a picture rather than a table.
+ *
+ * The hotspots are real Supercore words (SCENE_HOTSPOTS -> sceneHotspotWords),
+ * positioned as percentages so they reflow with the container at any size. Every
+ * tap routes through the shared pipeline (useCoreSurface.tapWord): speak, append
+ * to the shared sentence strip, log. Nothing here mutates vocabulary.
+ *
+ * Chrome (the scene gradient) uses sky-blue -> meadow-green, well clear of the
+ * banned 270-350 hue band. The word cards keep their Fitzgerald Key colours,
+ * which are the exempt AAC standard.
+ */
+
+import { SharedSentenceBar } from '@/components/SharedSentenceBar';
+import { TapCard } from '@/components/TapCard';
+import {
+  ARASAAC_IMG,
+  FITZGERALD_CLASSES,
+  sceneHotspotWords,
+} from '@/lib/core-vocab';
+import { useCoreSurface } from './useCoreSurface';
+import type { SurfaceProps } from './index';
+
+export function SceneField(props: SurfaceProps) {
+  const {
+    sentence,
+    removeWord,
+    engineFallback,
+    isMagicLoading,
+    tapWord,
+    handleSpeakAll,
+    handleClear,
+    handleMagic,
+  } = useCoreSurface(props);
+
+  const hotspots = sceneHotspotWords();
+
+  return (
+    <div
+      className="flex flex-col font-sans"
+      style={{ height: 'calc(100dvh - 72px - env(safe-area-inset-bottom, 0px))' }}
+    >
+      <SharedSentenceBar
+        words={sentence}
+        onSpeak={handleSpeakAll}
+        onMagic={handleMagic}
+        isMagicLoading={isMagicLoading}
+        onClear={handleClear}
+        onRemoveWord={removeWord}
+        engineFallback={engineFallback}
+      />
+
+      {/* Scene backdrop - sky to meadow. Hotspots float over it. */}
+      <div
+        className="relative flex-1 min-h-0 overflow-hidden mx-2 my-2 rounded-2xl"
+        style={{
+          background:
+            'linear-gradient(180deg, #BEE3F8 0%, #DCF0FF 42%, #CDEFD3 70%, #A7DDB0 100%)',
+        }}
+        role="group"
+        aria-label="Scene word board"
+      >
+        {/* Soft sun + horizon accents - decorative only. */}
+        <div
+          className="absolute rounded-full pointer-events-none"
+          style={{ width: 84, height: 84, top: '8%', left: '78%', background: '#FFE29A', opacity: 0.85 }}
+          aria-hidden="true"
+        />
+        <div
+          className="absolute left-0 right-0 pointer-events-none"
+          style={{ top: '66%', height: 2, background: 'rgba(56,142,60,0.25)' }}
+          aria-hidden="true"
+        />
+
+        {hotspots.map(({ word, x, y }) => {
+          const cls = FITZGERALD_CLASSES[word.category];
+          return (
+            <div
+              key={word.id}
+              className="absolute"
+              style={{ left: `${x}%`, top: `${y}%`, transform: 'translate(-50%, -50%)' }}
+            >
+              <TapCard
+                onTap={() => tapWord(word)}
+                ariaLabel={word.label}
+                className={`flex flex-col items-center justify-center rounded-2xl border-[3px] shadow-md px-1.5 py-1 ${cls.bg} ${cls.text} ${cls.border}`}
+                style={{ width: 84, minHeight: 84 }}
+              >
+                {word.arasaacId && (
+                  /* eslint-disable-next-line @next/next/no-img-element */
+                  <img
+                    src={ARASAAC_IMG(word.arasaacId)}
+                    alt=""
+                    width={44}
+                    height={44}
+                    style={{ width: 44, height: 44 }}
+                    className="object-contain pointer-events-none"
+                    loading="lazy"
+                  />
+                )}
+                <span className="font-bold text-[13px] leading-none mt-0.5 line-clamp-1">
+                  {word.label}
+                </span>
+              </TapCard>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default SceneField;

--- a/src/components/surfaces/SurfaceWordCard.tsx
+++ b/src/components/surfaces/SurfaceWordCard.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+/**
+ * SurfaceWordCard - the standard tappable Fitzgerald word card, shared by the
+ * Flow Board and Orbit Core surfaces (and any future surface that shows a plain
+ * picto + label card). Visually matches the Supercore grid card so a child sees
+ * the same word the same way on every surface.
+ *
+ * Built on TapCard, so it is a real <button>: focusable, aria-labelled, and it
+ * carries the app's rapid-tap throttle + press animation.
+ */
+
+import React, { useCallback } from 'react';
+import { TapCard } from '@/components/TapCard';
+import {
+  ARASAAC_IMG,
+  FITZGERALD_CLASSES,
+  type SupercoreWord,
+} from '@/lib/core-vocab';
+
+export const SurfaceWordCard = React.memo(function SurfaceWordCard({
+  word,
+  onTap,
+  size = 'medium',
+}: {
+  word: SupercoreWord;
+  onTap: (word: SupercoreWord) => void;
+  size?: 'small' | 'medium' | 'large';
+}) {
+  const cls = FITZGERALD_CLASSES[word.category];
+  const handleTap = useCallback(() => onTap(word), [onTap, word]);
+  const tok =
+    size === 'large'
+      ? { minHeight: 96, img: 52, font: 16 }
+      : size === 'small'
+        ? { minHeight: 60, img: 34, font: 12 }
+        : { minHeight: 76, img: 44, font: 14 };
+  return (
+    <TapCard
+      onTap={handleTap}
+      ariaLabel={word.label}
+      className={`flex flex-col items-center justify-center rounded-xl border-[3px] py-1.5 px-0.5 text-center leading-tight ${cls.bg} ${cls.text} ${cls.border}`}
+      style={{ minHeight: tok.minHeight }}
+    >
+      {word.arasaacId && (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          src={ARASAAC_IMG(word.arasaacId)}
+          alt=""
+          width={tok.img}
+          height={tok.img}
+          style={{ width: tok.img, height: tok.img }}
+          className="object-contain pointer-events-none"
+          loading="lazy"
+        />
+      )}
+      <span
+        className="font-bold leading-none mt-0.5 w-full line-clamp-2 px-0.5"
+        style={{ fontSize: tok.font }}
+      >
+        {word.label}
+      </span>
+    </TapCard>
+  );
+});

--- a/src/components/surfaces/TextRail.tsx
+++ b/src/components/surfaces/TextRail.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+/**
+ * TextRail (Δ Word Rail) - a keyboard-forward surface for children (and
+ * partners) who are faster typing than scanning a grid. A text compose box
+ * feeds straight into the shared sentence strip; a next-word prediction rail and
+ * a row of quick social words sit above it for one-tap building.
+ *
+ * Everything writes to the SAME sentence pipeline (useCoreSurface) and reads the
+ * SAME vocabulary (Supercore 50 + the existing predictive engine). No surface
+ * state mutates vocabulary, categories, personal words or phrase folders.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { SharedSentenceBar } from '@/components/SharedSentenceBar';
+import { predictNext, PREDICTIVE_CARD_COUNT } from '@/lib/predictive';
+import {
+  SUPERCORE_BY_LABEL,
+  FITZGERALD_CLASSES,
+  wordsInCategory,
+} from '@/lib/core-vocab';
+import { useCoreSurface } from './useCoreSurface';
+import type { SurfaceProps } from './index';
+
+const SKY_CHIP = 'bg-sky-100 text-sky-900 border-sky-300';
+
+export function TextRail(props: SurfaceProps) {
+  const {
+    settings,
+    sentence,
+    removeWord,
+    engineFallback,
+    isMagicLoading,
+    tapWord,
+    tapText,
+    handleSpeakAll,
+    handleClear,
+    handleMagic,
+  } = useCoreSurface(props);
+
+  const [draft, setDraft] = useState('');
+
+  const stage = settings.glpStage ?? 3;
+  const lastWord = sentence.length > 0 ? sentence[sentence.length - 1].label : null;
+
+  const predictions = useMemo(
+    () => predictNext(lastWord, stage, PREDICTIVE_CARD_COUNT),
+    [lastWord, stage],
+  );
+
+  // Quick words: the real social-category Supercore words (help, yes, please...).
+  const quickWords = useMemo(() => wordsInCategory('social'), []);
+
+  // A prediction that maps to a locked-grid word routes through the identical
+  // grid tap (Fitzgerald chip + log); otherwise it is a plain sky chip.
+  const handlePrediction = useCallback(
+    (text: string) => {
+      const match = SUPERCORE_BY_LABEL.get(text.toLowerCase());
+      if (match) tapWord(match);
+      else tapText(text, { className: SKY_CHIP, log: true });
+    },
+    [tapWord, tapText],
+  );
+
+  const commitDraft = useCallback(() => {
+    const text = draft.trim();
+    if (!text) return;
+    const match = SUPERCORE_BY_LABEL.get(text.toLowerCase());
+    if (match) tapWord(match);
+    else tapText(text);
+    setDraft('');
+  }, [draft, tapWord, tapText]);
+
+  return (
+    <div
+      className="flex flex-col font-sans bg-gray-50"
+      style={{ height: 'calc(100dvh - 72px - env(safe-area-inset-bottom, 0px))' }}
+    >
+      <SharedSentenceBar
+        words={sentence}
+        onSpeak={handleSpeakAll}
+        onMagic={handleMagic}
+        isMagicLoading={isMagicLoading}
+        onClear={handleClear}
+        onRemoveWord={removeWord}
+        engineFallback={engineFallback}
+      />
+
+      <div className="flex-1 min-h-0 overflow-y-auto touch-pan-y px-2 py-3 flex flex-col gap-4">
+        {/* Prediction rail */}
+        <section aria-label="Next word suggestions">
+          <p className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+            Next word
+          </p>
+          <div className="flex gap-2 overflow-x-auto no-scrollbar pb-1">
+            {predictions.length === 0 && (
+              <span className="text-sm text-gray-400 py-2">Start typing to see suggestions</span>
+            )}
+            {predictions.map((c) => {
+              const match = SUPERCORE_BY_LABEL.get(c.text.toLowerCase());
+              const cls = match ? FITZGERALD_CLASSES[match.category] : null;
+              return (
+                <button
+                  key={`${c.source}-${c.text}`}
+                  onClick={() => handlePrediction(c.text)}
+                  className={`shrink-0 min-h-[44px] px-4 rounded-xl border-[3px] font-bold text-[15px] cursor-pointer active:scale-95 transition-transform ${
+                    cls ? `${cls.bg} ${cls.text} ${cls.border}` : `${SKY_CHIP}`
+                  }`}
+                  aria-label={`Add word ${c.text}`}
+                >
+                  {match ? match.label : c.text}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Quick words */}
+        <section aria-label="Quick words">
+          <p className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+            Quick words
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {quickWords.map((w) => {
+              const cls = FITZGERALD_CLASSES[w.category];
+              return (
+                <button
+                  key={w.id}
+                  onClick={() => tapWord(w)}
+                  className={`min-h-[44px] px-4 rounded-xl border-[3px] font-bold text-[15px] cursor-pointer active:scale-95 transition-transform ${cls.bg} ${cls.text} ${cls.border}`}
+                  aria-label={`Add word ${w.label}`}
+                >
+                  {w.label}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+
+      {/* Compose box - the keyboard-forward core of this surface. */}
+      <form
+        className="shrink-0 flex items-center gap-2 px-2 py-2 border-t border-gray-200 bg-white"
+        onSubmit={(e) => {
+          e.preventDefault();
+          commitDraft();
+        }}
+      >
+        <label htmlFor="word-rail-input" className="sr-only">
+          Type a word
+        </label>
+        <input
+          id="word-rail-input"
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Type a word, then Add"
+          autoComplete="off"
+          className="flex-1 min-h-[48px] px-3 rounded-xl border-2 border-gray-300 text-[16px] focus:outline-none focus:border-emerald-500"
+        />
+        <button
+          type="submit"
+          disabled={draft.trim().length === 0}
+          className={`shrink-0 min-h-[48px] px-5 rounded-xl font-bold text-white text-[15px] transition-colors ${
+            draft.trim().length > 0
+              ? 'bg-emerald-500 hover:bg-emerald-400 cursor-pointer'
+              : 'bg-gray-300 cursor-not-allowed'
+          }`}
+          aria-label="Add typed word to sentence"
+        >
+          Add
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default TextRail;

--- a/src/components/surfaces/index.tsx
+++ b/src/components/surfaces/index.tsx
@@ -7,20 +7,24 @@
  * component that renders it. This is the seam a later PR will use to introduce
  * genuine scene / text / flow / orbit surfaces.
  *
- * FRAMEWORK PR CONTRACT: every kind renders the EXISTING SupercoreGrid so
- * nothing breaks. The four not-yet-built kinds additionally show a slim,
- * non-blocking "coming soon" banner ABOVE the same grid, so selecting one is
- * honest about what it is while still giving the child a fully working board.
+ * FRAMEWORK CONTRACT: the two grid kinds (fixedGrid / adaptiveGrid) render the
+ * EXISTING SupercoreGrid, unchanged. The four structural kinds now render their
+ * REAL surfaces (Scene / Word Rail / Flow Board / Orbit Core). Every surface
+ * reads the same Supercore 50 vocabulary and writes to the same speak +
+ * sentence-strip pipeline as the grid (see ./useCoreSurface + @/lib/core-vocab).
  *
- * The banner only ever appears when the layoutPrimitives flag is ON and a
- * non-default primitive is selected. With the flag off the active primitive is
- * always 'alpha' (fixedGrid), which renders the bare grid - byte-for-byte the
- * current behaviour.
+ * With the layoutPrimitives flag OFF the active primitive is always 'alpha'
+ * (fixedGrid), which renders the bare grid - byte-for-byte the current
+ * behaviour. The four surfaces are only ever reachable with the flag ON.
  */
 
 import type { ComponentType } from 'react';
 import { SupercoreGrid, type SupercoreGridProps } from '@/components/SupercoreGrid';
 import type { LayoutKind } from '@/lib/layout-primitives';
+import { SceneField } from './SceneField';
+import { TextRail } from './TextRail';
+import { FlowBoard } from './FlowBoard';
+import { OrbitCore } from './OrbitCore';
 
 export type SurfaceProps = SupercoreGridProps;
 
@@ -34,50 +38,14 @@ function AdaptiveGridSurface(props: SurfaceProps) {
   return <SupercoreGrid {...props} />;
 }
 
-/**
- * Placeholder for a not-yet-built structural surface. Renders the existing,
- * fully-working grid beneath a slim banner so the child can always talk while
- * the real surface is in development.
- */
-function PlaceholderSurface({ label, props }: { label: string; props: SurfaceProps }) {
-  return (
-    <div className="flex flex-col h-full">
-      <div
-        className="shrink-0 px-3 py-1.5 text-[11px] font-semibold text-center"
-        style={{ backgroundColor: '#FFF4E5', color: '#8A5200' }}
-        role="status"
-        aria-live="polite"
-      >
-        {label} is coming soon - showing the Steady Grid for now.
-      </div>
-      <div className="flex-1 min-h-0">
-        <SupercoreGrid {...props} />
-      </div>
-    </div>
-  );
-}
-
-function SceneFieldSurface(props: SurfaceProps) {
-  return <PlaceholderSurface label="Scene" props={props} />;
-}
-function TextRailSurface(props: SurfaceProps) {
-  return <PlaceholderSurface label="Word Rail" props={props} />;
-}
-function FlowBoardSurface(props: SurfaceProps) {
-  return <PlaceholderSurface label="Flow Board" props={props} />;
-}
-function OrbitCoreSurface(props: SurfaceProps) {
-  return <PlaceholderSurface label="Orbit Core" props={props} />;
-}
-
 /** kind -> surface component. Exhaustive over LayoutKind (compile-checked). */
 export const SURFACE_BY_KIND: Record<LayoutKind, ComponentType<SurfaceProps>> = {
   fixedGrid: FixedGridSurface,
   adaptiveGrid: AdaptiveGridSurface,
-  sceneField: SceneFieldSurface,
-  textRail: TextRailSurface,
-  flowBoard: FlowBoardSurface,
-  orbitCore: OrbitCoreSurface,
+  sceneField: SceneField,
+  textRail: TextRail,
+  flowBoard: FlowBoard,
+  orbitCore: OrbitCore,
 };
 
 /** Resolve the surface component for a kind. */

--- a/src/components/surfaces/index.tsx
+++ b/src/components/surfaces/index.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+/**
+ * Talk Core surface router.
+ *
+ * Maps a structural LayoutKind (see src/lib/layout-primitives) to the React
+ * component that renders it. This is the seam a later PR will use to introduce
+ * genuine scene / text / flow / orbit surfaces.
+ *
+ * FRAMEWORK PR CONTRACT: every kind renders the EXISTING SupercoreGrid so
+ * nothing breaks. The four not-yet-built kinds additionally show a slim,
+ * non-blocking "coming soon" banner ABOVE the same grid, so selecting one is
+ * honest about what it is while still giving the child a fully working board.
+ *
+ * The banner only ever appears when the layoutPrimitives flag is ON and a
+ * non-default primitive is selected. With the flag off the active primitive is
+ * always 'alpha' (fixedGrid), which renders the bare grid - byte-for-byte the
+ * current behaviour.
+ */
+
+import type { ComponentType } from 'react';
+import { SupercoreGrid, type SupercoreGridProps } from '@/components/SupercoreGrid';
+import type { LayoutKind } from '@/lib/layout-primitives';
+
+export type SurfaceProps = SupercoreGridProps;
+
+/** Alpha / fixedGrid: the current Talk Core, unchanged. */
+function FixedGridSurface(props: SurfaceProps) {
+  return <SupercoreGrid {...props} />;
+}
+
+/** Beta / adaptiveGrid: same grid today; the bundle widens the columns. */
+function AdaptiveGridSurface(props: SurfaceProps) {
+  return <SupercoreGrid {...props} />;
+}
+
+/**
+ * Placeholder for a not-yet-built structural surface. Renders the existing,
+ * fully-working grid beneath a slim banner so the child can always talk while
+ * the real surface is in development.
+ */
+function PlaceholderSurface({ label, props }: { label: string; props: SurfaceProps }) {
+  return (
+    <div className="flex flex-col h-full">
+      <div
+        className="shrink-0 px-3 py-1.5 text-[11px] font-semibold text-center"
+        style={{ backgroundColor: '#FFF4E5', color: '#8A5200' }}
+        role="status"
+        aria-live="polite"
+      >
+        {label} is coming soon - showing the Steady Grid for now.
+      </div>
+      <div className="flex-1 min-h-0">
+        <SupercoreGrid {...props} />
+      </div>
+    </div>
+  );
+}
+
+function SceneFieldSurface(props: SurfaceProps) {
+  return <PlaceholderSurface label="Scene" props={props} />;
+}
+function TextRailSurface(props: SurfaceProps) {
+  return <PlaceholderSurface label="Word Rail" props={props} />;
+}
+function FlowBoardSurface(props: SurfaceProps) {
+  return <PlaceholderSurface label="Flow Board" props={props} />;
+}
+function OrbitCoreSurface(props: SurfaceProps) {
+  return <PlaceholderSurface label="Orbit Core" props={props} />;
+}
+
+/** kind -> surface component. Exhaustive over LayoutKind (compile-checked). */
+export const SURFACE_BY_KIND: Record<LayoutKind, ComponentType<SurfaceProps>> = {
+  fixedGrid: FixedGridSurface,
+  adaptiveGrid: AdaptiveGridSurface,
+  sceneField: SceneFieldSurface,
+  textRail: TextRailSurface,
+  flowBoard: FlowBoardSurface,
+  orbitCore: OrbitCoreSurface,
+};
+
+/** Resolve the surface component for a kind. */
+export function getSurfaceForKind(kind: LayoutKind): ComponentType<SurfaceProps> {
+  return SURFACE_BY_KIND[kind] ?? FixedGridSurface;
+}

--- a/src/components/surfaces/surfaces.test.ts
+++ b/src/components/surfaces/surfaces.test.ts
@@ -1,0 +1,178 @@
+// @ts-nocheck - bun:test types not wired to main tsconfig; run with `bun test`
+/**
+ * Tests for the Layout Primitive SURFACES (Scene / Word Rail / Flow Board /
+ * Orbit Core). Runs via `bun test`.
+ *
+ * The app has no DOM test renderer (all existing suites are pure-logic), so
+ * these tests target the shared contract that guarantees every surface behaves
+ * like the grid, rather than pixel output (pixels are covered by `next build`
+ * + the headless screenshots in the PR):
+ *
+ *   - VOCABULARY SOURCE: all surfaces read the single Supercore 50 list, which
+ *     is frozen (immutable) and internally consistent.
+ *   - SHARED PIPELINE: the one tap action every surface uses (performCoreTap)
+ *     speaks the word, appends a chip to the SHARED sentence store, and logs -
+ *     in that order.
+ *   - SCENE HOTSPOTS resolve to real Supercore words (never invented vocab).
+ *   - NON-DESTRUCTIVE: tapping through a surface never mutates vocabulary,
+ *     categories, personal words or phrase folders.
+ *   - EXPORTS: the four surface kinds map to four distinct real components (no
+ *     longer the placeholder / grid).
+ */
+import { describe, expect, test, beforeEach } from 'bun:test';
+import {
+  SUPERCORE_50,
+  SUPERCORE_BY_LABEL,
+  CORE_CATEGORY_ORDER,
+  FITZGERALD_CLASSES,
+  coreWordChip,
+  performCoreTap,
+  sceneHotspotWords,
+  wordsInCategory,
+  SCENE_HOTSPOTS,
+} from '@/lib/core-vocab';
+import { sentenceStore } from '@/lib/sentence-store';
+import { loadFolders } from '@/lib/phrase-folders';
+
+const CATEGORIES = CORE_CATEGORY_ORDER.map((c) => c.category);
+
+describe('core vocabulary source', () => {
+  test('is the Supercore 50 and never fewer', () => {
+    expect(SUPERCORE_50.length).toBe(50);
+  });
+
+  test('every word has a valid category and unique id', () => {
+    const ids = new Set<string>();
+    for (const w of SUPERCORE_50) {
+      expect(CATEGORIES).toContain(w.category);
+      expect(ids.has(w.id)).toBe(false);
+      ids.add(w.id);
+      expect(w.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('is frozen - a surface cannot reorder or mutate the vocabulary', () => {
+    expect(Object.isFrozen(SUPERCORE_50)).toBe(true);
+    expect(() => {
+      // @ts-expect-error - deliberate illegal mutation
+      SUPERCORE_50.push({ id: 'x', label: 'x', category: 'people' });
+    }).toThrow();
+    expect(SUPERCORE_50.length).toBe(50);
+  });
+
+  test('label lookup covers every word', () => {
+    for (const w of SUPERCORE_50) {
+      expect(SUPERCORE_BY_LABEL.get(w.label.toLowerCase())?.id).toBe(w.id);
+    }
+  });
+
+  test('wordsInCategory returns a fresh array of only that category', () => {
+    for (const { category } of CORE_CATEGORY_ORDER) {
+      const words = wordsInCategory(category);
+      expect(words.length).toBeGreaterThan(0);
+      expect(words.every((w) => w.category === category)).toBe(true);
+    }
+    // Every word belongs to exactly one category bucket.
+    const total = CORE_CATEGORY_ORDER.reduce((n, c) => n + wordsInCategory(c.category).length, 0);
+    expect(total).toBe(50);
+  });
+});
+
+describe('scene hotspots (Gamma / SceneField)', () => {
+  test('are a handful of large targets (8-12)', () => {
+    expect(SCENE_HOTSPOTS.length).toBeGreaterThanOrEqual(8);
+    expect(SCENE_HOTSPOTS.length).toBeLessThanOrEqual(12);
+  });
+
+  test('every hotspot resolves to a real Supercore word within bounds', () => {
+    const resolved = sceneHotspotWords();
+    expect(resolved.length).toBe(SCENE_HOTSPOTS.length);
+    for (const { word, x, y } of resolved) {
+      expect(SUPERCORE_50.some((w) => w.id === word.id)).toBe(true);
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThanOrEqual(100);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
+describe('shared chip + tap pipeline', () => {
+  test('coreWordChip carries the Fitzgerald class + label + pictogram', () => {
+    const want = SUPERCORE_50.find((w) => w.label === 'want')!;
+    const chip = coreWordChip(want);
+    const cls = FITZGERALD_CLASSES[want.category];
+    expect(chip.label).toBe('want');
+    expect(chip.className).toBe(`${cls.bg} ${cls.text} ${cls.border}`);
+    expect(chip.imageUrl).toContain(String(want.arasaacId));
+  });
+
+  test('performCoreTap speaks, then adds the chip, then logs - in order', () => {
+    const calls: string[] = [];
+    const word = SUPERCORE_50[2];
+    performCoreTap(word, {
+      speak: (t) => calls.push(`speak:${t}`),
+      add: (chip) => calls.push(`add:${chip.label}`),
+      log: (w) => calls.push(`log:${w}`),
+    });
+    expect(calls).toEqual([`speak:${word.label}`, `add:${word.label}`, `log:${word.label}`]);
+  });
+});
+
+describe('writes to the SAME shared sentence store', () => {
+  beforeEach(() => sentenceStore.clear());
+
+  test('a surface tap appends a chip to the shared sentence strip', () => {
+    const word = SUPERCORE_50.find((w) => w.label === 'help')!;
+    let spoken = '';
+    performCoreTap(word, {
+      speak: (t) => (spoken = t), // speak pipeline exercised, TTS stubbed
+      add: (chip) => sentenceStore.addWord(chip),
+      log: () => {},
+    });
+    const words = sentenceStore.getWords();
+    expect(spoken).toBe('help');
+    expect(words.length).toBe(1);
+    expect(words[0].label).toBe('help');
+    expect(words[0].className).toContain('fitzgerald');
+  });
+});
+
+describe('non-destructive contract', () => {
+  beforeEach(() => sentenceStore.clear());
+
+  test('tapping never mutates vocabulary or phrase folders', () => {
+    const vocabBefore = JSON.stringify(SUPERCORE_50);
+    const foldersBefore = JSON.stringify(loadFolders());
+
+    // Tap a handful of words through the shared pipeline.
+    for (const label of ['I', 'want', 'more']) {
+      const w = SUPERCORE_50.find((x) => x.label === label)!;
+      performCoreTap(w, {
+        speak: () => {},
+        add: (chip) => sentenceStore.addWord(chip),
+        log: () => {},
+      });
+    }
+
+    expect(JSON.stringify(SUPERCORE_50)).toBe(vocabBefore);
+    expect(JSON.stringify(loadFolders())).toBe(foldersBefore);
+    // The only thing that changed is the shared sentence strip.
+    expect(sentenceStore.getWords().length).toBe(3);
+  });
+});
+
+describe('surface router exports real surfaces', () => {
+  test('the four structural kinds map to four distinct components', async () => {
+    const { SURFACE_BY_KIND } = await import('./index');
+    const { SupercoreGrid } = await import('@/components/SupercoreGrid');
+    const kinds = ['sceneField', 'textRail', 'flowBoard', 'orbitCore'] as const;
+    const comps = kinds.map((k) => SURFACE_BY_KIND[k]);
+    // Each is a defined function component...
+    for (const c of comps) expect(typeof c).toBe('function');
+    // ...distinct from each other...
+    expect(new Set(comps).size).toBe(4);
+    // ...and none is the raw grid (they are the real surfaces now).
+    for (const c of comps) expect(c).not.toBe(SupercoreGrid);
+  });
+});

--- a/src/components/surfaces/useCoreSurface.ts
+++ b/src/components/surfaces/useCoreSurface.ts
@@ -1,0 +1,121 @@
+'use client';
+
+/**
+ * useCoreSurface - the shared behaviour every Layout Primitive surface runs on.
+ *
+ * The Scene, Word Rail, Flow Board and Orbit Core surfaces differ ONLY in how
+ * they arrange the vocabulary on screen. Their behaviour - speaking, appending
+ * to the sentence strip, clearing, the optional analytic "magic" rewrite - is
+ * identical to the Supercore grid and is centralised here so no surface can
+ * drift from the shared pipeline.
+ *
+ * Contract:
+ *   - Reads the shared sentence store via useSentence (same store the grid uses).
+ *   - Speaks via the same ElevenLabs-with-browser-fallback path (or the parent's
+ *     onSpeak override, exactly like the grid).
+ *   - tapWord() routes through performCoreTap: speak -> add chip -> log. It
+ *     never mutates vocabulary, personal words or phrase folders.
+ */
+
+import { useCallback, useState } from 'react';
+import { useSentence } from '@/hooks/useSentence';
+import { useApp } from '@/context/AppContext';
+import { speak as elevenLabsSpeak } from '@/lib/tts';
+import { logWord } from '@/lib/session-logger';
+import { performCoreTap, type SupercoreWord } from '@/lib/core-vocab';
+import type { SurfaceProps } from './index';
+
+export function useCoreSurface({ onSpeak }: SurfaceProps) {
+  const { words: sentence, addWord, removeWord, clear } = useSentence();
+  const { settings } = useApp();
+  const [engineFallback, setEngineFallback] = useState(false);
+  const [isMagicLoading, setIsMagicLoading] = useState(false);
+
+  const speakText = useCallback(
+    async (text: string) => {
+      if (onSpeak) {
+        onSpeak(text);
+        return;
+      }
+      const engine = await elevenLabsSpeak({
+        text,
+        voiceId: settings.selectedVoiceId ?? undefined,
+        rate: settings.ttsRate,
+      });
+      setEngineFallback(engine === 'browser');
+    },
+    [onSpeak, settings.selectedVoiceId, settings.ttsRate],
+  );
+
+  const tapWord = useCallback(
+    (word: SupercoreWord) => {
+      performCoreTap(word, { speak: speakText, add: addWord, log: logWord });
+    },
+    [speakText, addWord],
+  );
+
+  /**
+   * Speak an arbitrary text token and append it to the shared sentence strip.
+   * Used by the Word Rail for typed text and free-text predictions. `log`
+   * defaults to false so hand-typed strings never pollute the personal-vocab
+   * analytics (core-word taps still log, exactly like the grid).
+   */
+  const tapText = useCallback(
+    (text: string, opts?: { className?: string; imageUrl?: string; log?: boolean }) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      speakText(trimmed);
+      addWord({ label: trimmed, className: opts?.className, imageUrl: opts?.imageUrl });
+      if (opts?.log) logWord(trimmed);
+    },
+    [speakText, addWord],
+  );
+
+  const handleSpeakAll = useCallback(() => {
+    if (sentence.length === 0) return;
+    speakText(sentence.map((w) => w.label).join(' '));
+  }, [sentence, speakText]);
+
+  const handleClear = useCallback(() => {
+    clear();
+    if (typeof window !== 'undefined') window.speechSynthesis?.cancel();
+  }, [clear]);
+
+  // Analytic "magic" rewrite - same endpoint and fallback the grid uses.
+  const handleMagic = useCallback(async () => {
+    if (sentence.length < 2) return;
+    setIsMagicLoading(true);
+    try {
+      const words = sentence.map((w) => w.label);
+      const res = await fetch('/api/improve-sentence', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cards: words }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        speakText(data.improved || data.sentence || words.join(' '));
+      } else {
+        speakText(words.join(' '));
+      }
+    } catch {
+      speakText(sentence.map((w) => w.label).join(' '));
+    } finally {
+      setIsMagicLoading(false);
+    }
+  }, [sentence, speakText]);
+
+  return {
+    settings,
+    sentence,
+    removeWord,
+    engineFallback,
+    isMagicLoading,
+    speakText,
+    tapWord,
+    tapText,
+    handleSpeakAll,
+    handleClear,
+    handleMagic,
+  };
+}

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -92,9 +92,11 @@ const DEFAULT_SETTINGS: AppSettings = {
   showPredictions: false,
   density: 'relaxed',
   activeLayoutPreset: 'big-simple',
-  // Structural layout primitive. 'alpha' = the current fixed grid. Only has an
-  // effect when the layoutPrimitives feature flag is enabled.
-  activeLayoutPrimitive: 'alpha',
+  // Unified layout selection. 'eta' is the Big & Simple grid - the same bundle
+  // as the shipped default above, so the unified picker highlights it on first
+  // run. Only has an effect when the layoutPrimitives feature flag is enabled;
+  // with the flag off this value is ignored and the surface is the fixed grid.
+  activeLayoutPrimitive: 'eta',
 };
 
 const STORAGE_KEY = '8gentjr-app-settings';

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
 import type { AccountType } from '@/lib/account';
 import type { CardSize, LayoutDensity, LayoutPresetId } from '@/lib/layout-presets';
+import type { LayoutPrimitiveId } from '@/lib/layout-primitives';
 
 /**
  * 8gent Jr App Context
@@ -56,6 +57,14 @@ export interface AppSettings {
   showPredictions: boolean;
   density: LayoutDensity;
   activeLayoutPreset: LayoutPresetId;
+  /**
+   * Layout primitives (structural layout dimension, see
+   * src/lib/layout-primitives.ts). Records which structural surface the Talk
+   * Core renders. Presentation-only and gated behind the layoutPrimitives
+   * feature flag - when the flag is off this value is ignored and the surface
+   * always resolves to 'alpha' (the current fixed grid). Default 'alpha'.
+   */
+  activeLayoutPrimitive: LayoutPrimitiveId;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -83,6 +92,9 @@ const DEFAULT_SETTINGS: AppSettings = {
   showPredictions: false,
   density: 'relaxed',
   activeLayoutPreset: 'big-simple',
+  // Structural layout primitive. 'alpha' = the current fixed grid. Only has an
+  // effect when the layoutPrimitives feature flag is enabled.
+  activeLayoutPrimitive: 'alpha',
 };
 
 const STORAGE_KEY = '8gentjr-app-settings';

--- a/src/lib/core-vocab.ts
+++ b/src/lib/core-vocab.ts
@@ -1,0 +1,269 @@
+/**
+ * Core vocabulary - the SINGLE source of truth for the Supercore 50 word set.
+ *
+ * Before the Layout Primitives surfaces existed, this data lived privately
+ * inside `SupercoreGrid.tsx`. Every alternative surface (Scene, Word Rail,
+ * Flow Board, Orbit Core) must render the EXACT SAME vocabulary and route
+ * through the EXACT SAME speech + sentence-strip pipeline as the grid. To make
+ * that guarantee real (and testable) the word list, the Fitzgerald Key colour
+ * classes, the pictogram URL helper and the "tap a core word" action are all
+ * defined here, once, and imported by the grid and every surface.
+ *
+ * NON-DESTRUCTIVE CONTRACT: nothing in this module mutates vocabulary,
+ * categories, personal words or phrase folders. `SUPERCORE_50` is frozen. The
+ * tap helper only speaks, appends a chip to the shared sentence store, and logs
+ * the tap for analytics - identical to a grid tap.
+ *
+ * CRITICAL AAC RULES (unchanged from the grid):
+ *   1. Words NEVER move once positioned (motor-planning consistency).
+ *   2. This order is PERMANENT. Never reorder SUPERCORE_50.
+ *   3. Each word has: text label + Fitzgerald Key colour category.
+ *   4. Tapping a word speaks it and adds it to the sentence strip.
+ *
+ * Colour coding: Modified Fitzgerald Key. The category colours on word cards
+ * are the industry-standard AAC key and are exempt from the app-wide banned-hue
+ * rule; surface CHROME (backdrops, rails, rings) must stay clear of hues
+ * 270-350.
+ */
+
+import type { WordCategory } from '@/lib/fitzgerald-key';
+import { FITZGERALD_COLORS } from '@/lib/fitzgerald-key';
+import type { SentenceWord } from '@/lib/sentence-store';
+
+// ---------------------------------------------------------------------------
+// Categories
+// ---------------------------------------------------------------------------
+
+export type FitzgeraldCategory =
+  | 'people'
+  | 'verbs'
+  | 'descriptors'
+  | 'prepositions'
+  | 'social'
+  | 'questions'
+  | 'determiners'
+  | 'negation';
+
+/** Map grid categories to canonical Fitzgerald Key word categories. */
+export const CATEGORY_TO_WORD_TYPE: Record<FitzgeraldCategory, WordCategory> = {
+  people: 'pronoun',
+  verbs: 'verb',
+  descriptors: 'adjective',
+  prepositions: 'preposition',
+  social: 'social',
+  questions: 'question',
+  determiners: 'determiner',
+  negation: 'negation',
+};
+
+/**
+ * Tailwind class strings (backed by CSS variables) for each Fitzgerald
+ * category. bg = background, text = text colour, border = border colour.
+ * Shared by the grid and every surface so a chip built anywhere looks the same
+ * in the sentence strip.
+ */
+export const FITZGERALD_CLASSES: Record<
+  FitzgeraldCategory,
+  { bg: string; text: string; border: string }
+> = {
+  people:       { bg: 'bg-fitzgerald-yellow', text: 'text-fitzgerald-yellow-text', border: 'border-fitzgerald-yellow-border' },
+  verbs:        { bg: 'bg-fitzgerald-green',  text: 'text-fitzgerald-green-text',  border: 'border-fitzgerald-green-border' },
+  descriptors:  { bg: 'bg-fitzgerald-blue',   text: 'text-fitzgerald-blue-text',   border: 'border-fitzgerald-blue-border' },
+  prepositions: { bg: 'bg-fitzgerald-purple', text: 'text-fitzgerald-purple-text', border: 'border-fitzgerald-purple-border' },
+  social:       { bg: 'bg-fitzgerald-pink',   text: 'text-fitzgerald-pink-text',   border: 'border-fitzgerald-pink-border' },
+  questions:    { bg: 'bg-fitzgerald-orange', text: 'text-fitzgerald-orange-text', border: 'border-fitzgerald-orange-border' },
+  determiners:  { bg: 'bg-fitzgerald-white',  text: 'text-fitzgerald-white-text',  border: 'border-fitzgerald-white-border' },
+  negation:     { bg: 'bg-fitzgerald-red',    text: 'text-fitzgerald-red-text',    border: 'border-fitzgerald-red-border' },
+};
+
+/** Display order + friendly labels for category-organised surfaces. */
+export const CORE_CATEGORY_ORDER: { category: FitzgeraldCategory; label: string }[] = [
+  { category: 'people',       label: 'People' },
+  { category: 'verbs',        label: 'Doing' },
+  { category: 'descriptors',  label: 'Feelings' },
+  { category: 'social',       label: 'Social' },
+  { category: 'questions',    label: 'Questions' },
+  { category: 'prepositions', label: 'Places' },
+  { category: 'determiners',  label: 'Little words' },
+  { category: 'negation',     label: 'No & stop' },
+];
+
+/** Inline Fitzgerald Key colour object for a grid category. */
+export function getGridCategoryColor(category: FitzgeraldCategory) {
+  return FITZGERALD_COLORS[CATEGORY_TO_WORD_TYPE[category]];
+}
+
+// ---------------------------------------------------------------------------
+// Word data
+// ---------------------------------------------------------------------------
+
+export interface SupercoreWord {
+  id: string;
+  label: string;
+  category: FitzgeraldCategory;
+  arasaacId?: number;
+}
+
+/** ARASAAC pictogram URL for a numeric pictogram id. */
+export const ARASAAC_IMG = (id: number) =>
+  `https://static.arasaac.org/pictograms/${id}/${id}_500.png`;
+
+/**
+ * THE SUPERCORE 50 GRID
+ *
+ * Layout: 10 columns x 5 rows = 50 cells, left-to-right, top-to-bottom.
+ * THIS ORDER IS PERMANENT. NEVER CHANGE IT. Frozen to make the
+ * non-destructive contract enforceable at runtime.
+ */
+export const SUPERCORE_50: readonly SupercoreWord[] = Object.freeze([
+  // Row 1
+  { id: 'w01', label: 'I',         category: 'people',      arasaacId: 6632 },
+  { id: 'w02', label: 'you',       category: 'people',      arasaacId: 6625 },
+  { id: 'w03', label: 'want',      category: 'verbs',       arasaacId: 5441 },
+  { id: 'w04', label: 'need',      category: 'verbs',       arasaacId: 37160 },
+  { id: 'w05', label: 'like',      category: 'verbs',       arasaacId: 37826 },
+  { id: 'w06', label: "don't",     category: 'negation',    arasaacId: 5525 },
+  { id: 'w07', label: 'help',      category: 'social',      arasaacId: 32648 },
+  { id: 'w08', label: 'more',      category: 'determiners', arasaacId: 5508 },
+  { id: 'w09', label: 'stop',      category: 'negation',    arasaacId: 7196 },
+  { id: 'w10', label: 'go',        category: 'verbs',       arasaacId: 8142 },
+
+  // Row 2
+  { id: 'w11', label: 'come',      category: 'verbs',       arasaacId: 32669 },
+  { id: 'w12', label: 'look',      category: 'verbs',       arasaacId: 6564 },
+  { id: 'w13', label: 'eat',       category: 'verbs',       arasaacId: 6456 },
+  { id: 'w14', label: 'drink',     category: 'verbs',       arasaacId: 6061 },
+  { id: 'w15', label: 'play',      category: 'verbs',       arasaacId: 23392 },
+  { id: 'w16', label: 'yes',       category: 'social',      arasaacId: 5584 },
+  { id: 'w17', label: 'no',        category: 'negation',    arasaacId: 5526 },
+  { id: 'w18', label: 'please',    category: 'social',      arasaacId: 8195 },
+  { id: 'w19', label: 'thank you', category: 'social',      arasaacId: 8129 },
+  { id: 'w20', label: 'sorry',     category: 'social',      arasaacId: 11625 },
+
+  // Row 3
+  { id: 'w21', label: 'happy',     category: 'descriptors', arasaacId: 35533 },
+  { id: 'w22', label: 'sad',       category: 'descriptors', arasaacId: 35545 },
+  { id: 'w23', label: 'angry',     category: 'descriptors', arasaacId: 35539 },
+  { id: 'w24', label: 'tired',     category: 'descriptors', arasaacId: 35537 },
+  { id: 'w25', label: 'hot',       category: 'descriptors', arasaacId: 2300 },
+  { id: 'w26', label: 'cold',      category: 'descriptors', arasaacId: 4652 },
+  { id: 'w27', label: 'big',       category: 'descriptors', arasaacId: 4658 },
+  { id: 'w28', label: 'small',     category: 'descriptors', arasaacId: 4716 },
+  { id: 'w29', label: 'up',        category: 'prepositions', arasaacId: 5388 },
+  { id: 'w30', label: 'down',      category: 'prepositions', arasaacId: 37428 },
+
+  // Row 4
+  { id: 'w31', label: 'in',        category: 'prepositions', arasaacId: 7034 },
+  { id: 'w32', label: 'out',       category: 'prepositions', arasaacId: 6606 },
+  { id: 'w33', label: 'on',        category: 'prepositions', arasaacId: 7814 },
+  { id: 'w34', label: 'off',       category: 'prepositions', arasaacId: 27518 },
+  { id: 'w35', label: 'open',      category: 'verbs',       arasaacId: 24825 },
+  { id: 'w36', label: 'close',     category: 'verbs',       arasaacId: 30383 },
+  { id: 'w37', label: 'give',      category: 'verbs',       arasaacId: 28431 },
+  { id: 'w38', label: 'take',      category: 'verbs',       arasaacId: 10148 },
+  { id: 'w39', label: 'put',       category: 'verbs',       arasaacId: 32757 },
+  { id: 'w40', label: 'make',      category: 'verbs',       arasaacId: 32751 },
+
+  // Row 5
+  { id: 'w41', label: 'do',        category: 'verbs',       arasaacId: 6624 },
+  { id: 'w42', label: 'have',      category: 'verbs',       arasaacId: 32761 },
+  { id: 'w43', label: 'is',        category: 'verbs',       arasaacId: 8115 },
+  { id: 'w44', label: 'it',        category: 'determiners', arasaacId: 31670 },
+  { id: 'w45', label: 'that',      category: 'determiners', arasaacId: 6906 },
+  { id: 'w46', label: 'this',      category: 'determiners', arasaacId: 7095 },
+  { id: 'w47', label: 'what',      category: 'questions',   arasaacId: 22620 },
+  { id: 'w48', label: 'where',     category: 'questions',   arasaacId: 7764 },
+  { id: 'w49', label: 'who',       category: 'questions',   arasaacId: 9853 },
+  { id: 'w50', label: 'why',       category: 'questions',   arasaacId: 36719 },
+] as const);
+
+/** Lowercase label -> Supercore word, built once. */
+export const SUPERCORE_BY_LABEL: ReadonlyMap<string, SupercoreWord> = (() => {
+  const map = new Map<string, SupercoreWord>();
+  for (const w of SUPERCORE_50) map.set(w.label.toLowerCase(), w);
+  return map;
+})();
+
+/** All words in a category, in their permanent grid order. */
+export function wordsInCategory(category: FitzgeraldCategory): SupercoreWord[] {
+  return SUPERCORE_50.filter((w) => w.category === category);
+}
+
+// ---------------------------------------------------------------------------
+// Scene hotspots (Gamma / SceneField)
+// ---------------------------------------------------------------------------
+
+/**
+ * A curated set of large, high-value core words positioned over the Scene
+ * backdrop as percentages (x/y are the hotspot CENTRE, 0-100). Few, big
+ * targets - the whole point of the Scene surface. Every entry is a real
+ * Supercore word (looked up by id) so the Scene never invents vocabulary.
+ */
+export interface SceneHotspot {
+  id: string;
+  /** Centre X as a percentage of the scene width. */
+  x: number;
+  /** Centre Y as a percentage of the scene height. */
+  y: number;
+}
+
+export const SCENE_HOTSPOTS: readonly SceneHotspot[] = Object.freeze([
+  { id: 'w01', x: 16, y: 22 }, // I
+  { id: 'w02', x: 50, y: 16 }, // you
+  { id: 'w03', x: 82, y: 24 }, // want
+  { id: 'w13', x: 24, y: 46 }, // eat
+  { id: 'w14', x: 50, y: 42 }, // drink
+  { id: 'w15', x: 76, y: 48 }, // play
+  { id: 'w07', x: 14, y: 70 }, // help
+  { id: 'w08', x: 38, y: 74 }, // more
+  { id: 'w16', x: 62, y: 72 }, // yes
+  { id: 'w09', x: 86, y: 70 }, // stop
+  { id: 'w21', x: 32, y: 90 }, // happy
+  { id: 'w10', x: 68, y: 90 }, // go
+]);
+
+/** Resolve the curated Scene hotspots to their Supercore words + positions. */
+export function sceneHotspotWords(): { word: SupercoreWord; x: number; y: number }[] {
+  return SCENE_HOTSPOTS.map((h) => {
+    const word = SUPERCORE_50.find((w) => w.id === h.id);
+    if (!word) throw new Error(`Scene hotspot references unknown word id: ${h.id}`);
+    return { word, x: h.x, y: h.y };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared tap action (the ONE way any surface writes a core word)
+// ---------------------------------------------------------------------------
+
+/** Build the sentence-strip chip for a core word (Fitzgerald-coloured). */
+export function coreWordChip(word: SupercoreWord): SentenceWord {
+  const cls = FITZGERALD_CLASSES[word.category];
+  return {
+    label: word.label,
+    imageUrl: word.arasaacId ? ARASAAC_IMG(word.arasaacId) : undefined,
+    className: `${cls.bg} ${cls.text} ${cls.border}`,
+  };
+}
+
+/** Callback bundle for {@link performCoreTap}. Pure and injectable for tests. */
+export interface CoreTapHandlers {
+  /** Speak the word (shared TTS pipeline). */
+  speak: (text: string) => void;
+  /** Append a chip to the shared sentence store. */
+  add: (chip: SentenceWord) => void;
+  /** Log the tap for analytics/personalisation. */
+  log: (word: string) => void;
+}
+
+/**
+ * The single "tap a core word" action, shared by the grid and every surface.
+ * Speaks the word, appends its chip to the shared sentence strip, and logs the
+ * tap - in that order, exactly as the grid does. Purely delegates to the
+ * injected handlers so it is trivially testable and provably non-destructive
+ * (it never touches vocabulary, personal words or phrase folders).
+ */
+export function performCoreTap(word: SupercoreWord, handlers: CoreTapHandlers): void {
+  handlers.speak(word.label);
+  handlers.add(coreWordChip(word));
+  handlers.log(word.label);
+}

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,21 @@
+/**
+ * Feature flags for 8gent Jr.
+ *
+ * The repo has no prior flag abstraction - flags to date have been plain
+ * NEXT_PUBLIC_* env reads. This keeps that convention but centralises the
+ * layoutPrimitives flag so the check reads the same way everywhere.
+ *
+ * NEXT_PUBLIC_* vars are inlined at build time, so this evaluates identically
+ * on the server and in the browser. Default is OFF: unless the env var is the
+ * exact string 'true', the flag is disabled and the app behaves as it does
+ * today (only the four existing presets show; the Core screen renders the
+ * current grid).
+ */
+
+/**
+ * layoutPrimitives - the structural layout dimension (see ./layout-primitives).
+ * DEFAULT OFF. Enable by setting NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES=true.
+ */
+export function isLayoutPrimitivesEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_FF_LAYOUT_PRIMITIVES === 'true';
+}

--- a/src/lib/layout-presets.ts
+++ b/src/lib/layout-presets.ts
@@ -1,24 +1,18 @@
 /**
- * Layout Presets for the Talk Core surface.
+ * Shared layout tokens and types for the Talk Core surface.
  *
- * A layout preset bundles the handful of settings that change how the Talk
- * Core *looks and feels* - grid density, card size, and which helper rows are
- * shown. Picking a preset writes its whole bundle at once via updateSettings.
+ * This module holds the small, shared vocabulary the layout system is built
+ * from - card sizes, density, the settings bundle shape, and the card-size
+ * tokens the Core grid renders with. It intentionally does NOT hold a registry
+ * of layouts any more.
  *
- * Presets are inspired by real-world AAC layout philosophies:
- *  - "Core First" mirrors motor-planning-first systems (fixed, calm, few big
- *    targets, no moving prediction row) used for early/emerging communicators.
- *  - "Big & Simple" is a low-density, high-contrast layout for learners who
- *    need large tap targets and minimal visual load.
- *  - "Word Rich" is a high-density vocabulary layout for fluent communicators
- *    who benefit from more words on screen plus predictions.
- *  - "Quick Chat" foregrounds the child's own most-used words and predictions
- *    for fast everyday conversation.
- *  - "Custom" represents any hand-tuned combination the user has set.
+ * There is now a SINGLE registry of selectable layouts, and it lives in
+ * ./layout-primitives (see LAYOUT_PRIMITIVES). The classic density presets
+ * (Core First / Big & Simple / Word Rich / Quick Chat) are DERIVED from that
+ * one registry as LAYOUT_PRESETS, so there is one source of truth for the
+ * layout bundles and no duplicated magic numbers.
  *
- * Each preset is intentionally small and declarative - it is just data. The
- * Settings UI renders them as selectable cards; SupercoreGrid honours the
- * resulting settings. No banned hues (270-350) appear in any hint colour.
+ * No banned hues (270-350) appear in any token here.
  */
 
 /** Card size affects tap-target min-height and label font on the Core grid. */
@@ -29,7 +23,9 @@ export type CardSize = 'large' | 'medium' | 'small';
  *  future surfaces can branch on it without re-deriving from columns. */
 export type LayoutDensity = 'relaxed' | 'balanced' | 'compact';
 
-/** Identifier for the active preset. 'custom' = user-tuned, no preset match. */
+/** Identifier for the active classic preset. 'custom' = user-tuned, no match.
+ *  Retained as the selection field the flag-OFF Layout picker writes, so the
+ *  shipped-today behaviour is preserved byte-for-byte. */
 export type LayoutPresetId =
   | 'core-first'
   | 'big-simple'
@@ -47,77 +43,8 @@ export interface LayoutSettingsBundle {
   density: LayoutDensity;
 }
 
-export interface LayoutPreset extends LayoutSettingsBundle {
-  id: LayoutPresetId;
-  /** Friendly, child-facing name. */
-  name: string;
-  /** One-line description of who the layout suits. */
-  description: string;
-  /** Tiny visual hint for the picker card: a small grid preview. */
-  hint: {
-    /** Columns to render in the mini grid preview. */
-    cols: number;
-    /** Number of filled cells to render (visual density cue). */
-    cells: number;
-    /** Accent colour for the preview (NO hues 270-350). */
-    color: string;
-  };
-}
-
-/**
- * The selectable presets, in display order. 'custom' is intentionally NOT in
- * this list - it is a state the surface falls into when a user hand-tunes a
- * setting, not something you pick directly.
- */
-export const LAYOUT_PRESETS: LayoutPreset[] = [
-  {
-    id: 'core-first',
-    name: 'Core First',
-    description: 'Fewer, bigger core words. Calm and steady - no moving rows.',
-    gridColumns: 4,
-    cardSize: 'large',
-    showPredictions: false,
-    showPersonalVocab: false,
-    density: 'relaxed',
-    hint: { cols: 4, cells: 8, color: '#4CAF50' },
-  },
-  {
-    id: 'big-simple',
-    name: 'Big & Simple',
-    description: 'Three big columns with the fewest helper rows. Easy to aim at.',
-    gridColumns: 3,
-    cardSize: 'large',
-    showPredictions: false,
-    showPersonalVocab: true,
-    density: 'relaxed',
-    hint: { cols: 3, cells: 6, color: '#2196F3' },
-  },
-  {
-    id: 'word-rich',
-    name: 'Word Rich',
-    description: 'Six columns of smaller cards with next-word predictions on.',
-    gridColumns: 6,
-    cardSize: 'small',
-    showPredictions: true,
-    showPersonalVocab: true,
-    density: 'compact',
-    hint: { cols: 6, cells: 18, color: '#E8610A' },
-  },
-  {
-    id: 'quick-chat',
-    name: 'Quick Chat',
-    description: 'Your words and predictions up front for fast everyday talking.',
-    gridColumns: 4,
-    cardSize: 'medium',
-    showPredictions: true,
-    showPersonalVocab: true,
-    density: 'balanced',
-    hint: { cols: 4, cells: 12, color: '#009688' },
-  },
-];
-
 /** Card sizing tokens consumed by the Core grid buttons. minHeight in px,
- *  fontPx for the label, imgPx for the pictogram. Kept here so the preset
+ *  fontPx for the label, imgPx for the pictogram. Kept here so the layout
  *  system fully owns the look of card size. */
 export const CARD_SIZE_TOKENS: Record<CardSize, { minHeight: number; fontPx: number; imgPx: number }> = {
   large:  { minHeight: 104, fontPx: 16, imgPx: 60 },

--- a/src/lib/layout-primitives.test.ts
+++ b/src/lib/layout-primitives.test.ts
@@ -1,0 +1,212 @@
+// @ts-nocheck - bun:test types not wired to main tsconfig; run with `bun test`
+/**
+ * Tests for the Layout Primitives framework. Runs via `bun test`.
+ *
+ * Proves the hard constraints from the framework PR:
+ *   - the six primitives exist, are unique, and map to the right kinds
+ *   - alpha is the default and reuses the shipped core-first bundle
+ *   - NO primitive colour lands in the banned purple/pink hue band (270-350)
+ *   - flag OFF === current behaviour: the active primitive always resolves to
+ *     'alpha' (fixedGrid) regardless of what is stored
+ *   - switching primitive and back is non-destructive: it only changes the
+ *     layout bundle + selection, never vocabulary / categories / personal
+ *     words / phrase folders / any other setting
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_PRIMITIVE_ID,
+  LAYOUT_PRIMITIVES,
+  applyPrimitive,
+  getPrimitive,
+  resolveActivePrimitiveId,
+  type LayoutKind,
+} from './layout-primitives';
+import { LAYOUT_PRESETS } from './layout-presets';
+
+/** Convert a #RRGGBB hex to an HSL hue in [0,360). */
+function hexToHue(hex: string): number {
+  const m = hex.replace('#', '');
+  const r = parseInt(m.slice(0, 2), 16) / 255;
+  const g = parseInt(m.slice(2, 4), 16) / 255;
+  const b = parseInt(m.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  if (d === 0) return 0;
+  let h: number;
+  if (max === r) h = ((g - b) / d) % 6;
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  h *= 60;
+  return h < 0 ? h + 360 : h;
+}
+
+describe('LAYOUT_PRIMITIVES shape', () => {
+  test('has exactly six primitives', () => {
+    expect(LAYOUT_PRIMITIVES).toHaveLength(6);
+  });
+
+  test('ids are the expected Greek series and are unique', () => {
+    const ids = LAYOUT_PRIMITIVES.map((p) => p.id);
+    expect(ids).toEqual(['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta']);
+    expect(new Set(ids).size).toBe(6);
+  });
+
+  test('glyphs are unique Greek capitals', () => {
+    const glyphs = LAYOUT_PRIMITIVES.map((p) => p.glyph);
+    expect(glyphs).toEqual(['Α', 'Β', 'Γ', 'Δ', 'Ε', 'Ζ']);
+    expect(new Set(glyphs).size).toBe(6);
+  });
+
+  test('kinds cover the six structural surfaces', () => {
+    const byId = Object.fromEntries(LAYOUT_PRIMITIVES.map((p) => [p.id, p.kind]));
+    const expected: Record<string, LayoutKind> = {
+      alpha: 'fixedGrid',
+      beta: 'adaptiveGrid',
+      gamma: 'sceneField',
+      delta: 'textRail',
+      epsilon: 'flowBoard',
+      zeta: 'orbitCore',
+    };
+    expect(byId).toEqual(expected);
+  });
+
+  test('every primitive carries a complete bundle and hint', () => {
+    for (const p of LAYOUT_PRIMITIVES) {
+      expect(typeof p.bundle.gridColumns).toBe('number');
+      expect(['large', 'medium', 'small']).toContain(p.bundle.cardSize);
+      expect(typeof p.bundle.showPredictions).toBe('boolean');
+      expect(typeof p.bundle.showPersonalVocab).toBe('boolean');
+      expect(['relaxed', 'balanced', 'compact']).toContain(p.bundle.density);
+      expect(p.hint.cols).toBeGreaterThan(0);
+      expect(p.hint.cells).toBeGreaterThan(0);
+      expect(p.name.length).toBeGreaterThan(0);
+      expect(p.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('brand safety: no banned purple/pink hues (270-350)', () => {
+  test('no primitive hint colour falls in the banned band', () => {
+    for (const p of LAYOUT_PRIMITIVES) {
+      const hue = hexToHue(p.hint.color);
+      expect(hue >= 270 && hue <= 350).toBe(false);
+    }
+  });
+});
+
+describe('alpha is the default and reuses core-first', () => {
+  test('DEFAULT_PRIMITIVE_ID is alpha', () => {
+    expect(DEFAULT_PRIMITIVE_ID).toBe('alpha');
+  });
+
+  test('alpha maps to fixedGrid', () => {
+    expect(getPrimitive('alpha').kind).toBe('fixedGrid');
+  });
+
+  test("alpha's bundle equals the shipped core-first preset bundle", () => {
+    const coreFirst = LAYOUT_PRESETS.find((p) => p.id === 'core-first')!;
+    const alpha = getPrimitive('alpha');
+    expect(alpha.bundle).toEqual({
+      gridColumns: coreFirst.gridColumns,
+      cardSize: coreFirst.cardSize,
+      showPredictions: coreFirst.showPredictions,
+      showPersonalVocab: coreFirst.showPersonalVocab,
+      density: coreFirst.density,
+    });
+  });
+
+  test("beta's bundle equals the shipped word-rich preset bundle", () => {
+    const wordRich = LAYOUT_PRESETS.find((p) => p.id === 'word-rich')!;
+    const beta = getPrimitive('beta');
+    expect(beta.bundle).toEqual({
+      gridColumns: wordRich.gridColumns,
+      cardSize: wordRich.cardSize,
+      showPredictions: wordRich.showPredictions,
+      showPersonalVocab: wordRich.showPersonalVocab,
+      density: wordRich.density,
+    });
+  });
+});
+
+describe('getPrimitive fallbacks', () => {
+  test('unknown / null / undefined all fall back to the default', () => {
+    expect(getPrimitive('nope').id).toBe('alpha');
+    expect(getPrimitive(null).id).toBe('alpha');
+    expect(getPrimitive(undefined).id).toBe('alpha');
+  });
+});
+
+describe('flag OFF === current behaviour', () => {
+  test('flag off always resolves to alpha regardless of stored id', () => {
+    expect(resolveActivePrimitiveId(false, 'zeta')).toBe('alpha');
+    expect(resolveActivePrimitiveId(false, 'beta')).toBe('alpha');
+    expect(resolveActivePrimitiveId(false, null)).toBe('alpha');
+  });
+
+  test('flag on honours a valid stored id and falls back for garbage', () => {
+    expect(resolveActivePrimitiveId(true, 'zeta')).toBe('zeta');
+    expect(resolveActivePrimitiveId(true, 'garbage')).toBe('alpha');
+    expect(resolveActivePrimitiveId(true, null)).toBe('alpha');
+  });
+});
+
+describe('non-destructive switch-and-back', () => {
+  // A settings-like object carrying BOTH layout fields and unrelated data that
+  // must survive any primitive switch untouched.
+  const baseSettings = {
+    // layout bundle fields (alpha / core-first values)
+    gridColumns: 4,
+    cardSize: 'large' as const,
+    showPredictions: false,
+    showPersonalVocab: false,
+    density: 'relaxed' as const,
+    activeLayoutPrimitive: 'alpha' as const,
+    // unrelated data that must never change
+    childName: 'Robin',
+    selectedVoiceId: 'voice-123',
+    glpStage: 2,
+    guardianConfirmed: true,
+    parentEmailConfirmed: true,
+  };
+
+  test('switching to beta only changes bundle + selection', () => {
+    const afterBeta = applyPrimitive(baseSettings, 'beta');
+    const beta = getPrimitive('beta');
+    // Bundle applied + selection recorded.
+    expect(afterBeta.activeLayoutPrimitive).toBe('beta');
+    expect(afterBeta.gridColumns).toBe(beta.bundle.gridColumns);
+    expect(afterBeta.cardSize).toBe(beta.bundle.cardSize);
+    expect(afterBeta.showPredictions).toBe(beta.bundle.showPredictions);
+    // Unrelated data untouched.
+    expect(afterBeta.childName).toBe('Robin');
+    expect(afterBeta.selectedVoiceId).toBe('voice-123');
+    expect(afterBeta.glpStage).toBe(2);
+    expect(afterBeta.guardianConfirmed).toBe(true);
+    expect(afterBeta.parentEmailConfirmed).toBe(true);
+  });
+
+  test('switching to a primitive and back to alpha restores the bundle exactly', () => {
+    const afterBeta = applyPrimitive(baseSettings, 'beta');
+    const backToAlpha = applyPrimitive(afterBeta, 'alpha');
+    // Layout bundle is byte-for-byte the original alpha bundle again.
+    expect(backToAlpha.gridColumns).toBe(baseSettings.gridColumns);
+    expect(backToAlpha.cardSize).toBe(baseSettings.cardSize);
+    expect(backToAlpha.showPredictions).toBe(baseSettings.showPredictions);
+    expect(backToAlpha.showPersonalVocab).toBe(baseSettings.showPersonalVocab);
+    expect(backToAlpha.density).toBe(baseSettings.density);
+    expect(backToAlpha.activeLayoutPrimitive).toBe('alpha');
+    // And all unrelated data is still exactly as it started.
+    expect(backToAlpha.childName).toBe(baseSettings.childName);
+    expect(backToAlpha.selectedVoiceId).toBe(baseSettings.selectedVoiceId);
+    expect(backToAlpha.glpStage).toBe(baseSettings.glpStage);
+    expect(backToAlpha.guardianConfirmed).toBe(baseSettings.guardianConfirmed);
+    expect(backToAlpha.parentEmailConfirmed).toBe(baseSettings.parentEmailConfirmed);
+  });
+
+  test('applyPrimitive does not mutate its input', () => {
+    const snapshot = JSON.stringify(baseSettings);
+    applyPrimitive(baseSettings, 'zeta');
+    expect(JSON.stringify(baseSettings)).toBe(snapshot);
+  });
+});

--- a/src/lib/layout-primitives.test.ts
+++ b/src/lib/layout-primitives.test.ts
@@ -1,27 +1,34 @@
 // @ts-nocheck - bun:test types not wired to main tsconfig; run with `bun test`
 /**
- * Tests for the Layout Primitives framework. Runs via `bun test`.
+ * Tests for the consolidated Layout registry. Runs via `bun test`.
  *
- * Proves the hard constraints from the framework PR:
- *   - the six primitives exist, are unique, and map to the right kinds
- *   - alpha is the default and reuses the shipped core-first bundle
+ * After consolidation there is ONE source of truth (LAYOUT_PRIMITIVES). The
+ * classic density presets (LAYOUT_PRESETS) are DERIVED from it. These tests
+ * prove:
+ *   - the eight primitives exist, are unique, and map to the right kinds
+ *   - every primitive carries BOTH a structural kind AND a full settings bundle
+ *   - the four classic presets are derived and reuse the primitive bundles
+ *     (no duplicated data)
  *   - NO primitive colour lands in the banned purple/pink hue band (270-350)
  *   - flag OFF === current behaviour: the active primitive always resolves to
  *     'alpha' (fixedGrid) regardless of what is stored
- *   - switching primitive and back is non-destructive: it only changes the
- *     layout bundle + selection, never vocabulary / categories / personal
- *     words / phrase folders / any other setting
+ *   - selecting a preset writes kind + bundle; switching and back is
+ *     non-destructive (never touches vocabulary / categories / personal words /
+ *     phrase folders / any other setting)
+ *   - Custom state is detected when the layout no longer matches any preset
  */
 import { describe, expect, test } from 'bun:test';
 import {
   DEFAULT_PRIMITIVE_ID,
   LAYOUT_PRIMITIVES,
+  LAYOUT_PRESETS,
   applyPrimitive,
+  bundlesMatch,
   getPrimitive,
   resolveActivePrimitiveId,
+  activePrimitiveIdForSettings,
   type LayoutKind,
 } from './layout-primitives';
-import { LAYOUT_PRESETS } from './layout-presets';
 
 /** Convert a #RRGGBB hex to an HSL hue in [0,360). */
 function hexToHue(hex: string): number {
@@ -41,28 +48,30 @@ function hexToHue(hex: string): number {
   return h < 0 ? h + 360 : h;
 }
 
-describe('LAYOUT_PRIMITIVES shape', () => {
-  test('has exactly six primitives', () => {
-    expect(LAYOUT_PRIMITIVES).toHaveLength(6);
+describe('LAYOUT_PRIMITIVES shape (single unified registry)', () => {
+  test('has exactly eight primitives', () => {
+    expect(LAYOUT_PRIMITIVES).toHaveLength(8);
   });
 
-  test('ids are the expected Greek series and are unique', () => {
+  test('ids are the expected series and are unique', () => {
     const ids = LAYOUT_PRIMITIVES.map((p) => p.id);
-    expect(ids).toEqual(['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta']);
-    expect(new Set(ids).size).toBe(6);
+    expect(ids).toEqual(['alpha', 'eta', 'beta', 'theta', 'gamma', 'delta', 'epsilon', 'zeta']);
+    expect(new Set(ids).size).toBe(8);
   });
 
   test('glyphs are unique Greek capitals', () => {
     const glyphs = LAYOUT_PRIMITIVES.map((p) => p.glyph);
-    expect(glyphs).toEqual(['Α', 'Β', 'Γ', 'Δ', 'Ε', 'Ζ']);
-    expect(new Set(glyphs).size).toBe(6);
+    expect(glyphs).toEqual(['Α', 'Η', 'Β', 'Θ', 'Γ', 'Δ', 'Ε', 'Ζ']);
+    expect(new Set(glyphs).size).toBe(8);
   });
 
-  test('kinds cover the six structural surfaces', () => {
+  test('kinds cover the structural surfaces', () => {
     const byId = Object.fromEntries(LAYOUT_PRIMITIVES.map((p) => [p.id, p.kind]));
     const expected: Record<string, LayoutKind> = {
       alpha: 'fixedGrid',
+      eta: 'fixedGrid',
       beta: 'adaptiveGrid',
+      theta: 'fixedGrid',
       gamma: 'sceneField',
       delta: 'textRail',
       epsilon: 'flowBoard',
@@ -71,8 +80,9 @@ describe('LAYOUT_PRIMITIVES shape', () => {
     expect(byId).toEqual(expected);
   });
 
-  test('every primitive carries a complete bundle and hint', () => {
+  test('every primitive carries a complete bundle, a kind and a hint', () => {
     for (const p of LAYOUT_PRIMITIVES) {
+      expect(typeof p.kind).toBe('string');
       expect(typeof p.bundle.gridColumns).toBe('number');
       expect(['large', 'medium', 'small']).toContain(p.bundle.cardSize);
       expect(typeof p.bundle.showPredictions).toBe('boolean');
@@ -95,7 +105,44 @@ describe('brand safety: no banned purple/pink hues (270-350)', () => {
   });
 });
 
-describe('alpha is the default and reuses core-first', () => {
+describe('classic presets are derived from the single registry', () => {
+  test('LAYOUT_PRESETS derives the four classic density presets in order', () => {
+    expect(LAYOUT_PRESETS.map((p) => p.id)).toEqual([
+      'core-first',
+      'big-simple',
+      'word-rich',
+      'quick-chat',
+    ]);
+  });
+
+  test('each classic preset reuses its backing primitive bundle (no duplicated data)', () => {
+    for (const preset of LAYOUT_PRESETS) {
+      const backing = LAYOUT_PRIMITIVES.find((p) => p.classic?.id === preset.id)!;
+      expect(bundlesMatch(preset, backing.bundle)).toBe(true);
+      // flat bundle fields on the derived preset equal the primitive bundle
+      expect(preset.gridColumns).toBe(backing.bundle.gridColumns);
+      expect(preset.cardSize).toBe(backing.bundle.cardSize);
+      expect(preset.showPredictions).toBe(backing.bundle.showPredictions);
+      expect(preset.showPersonalVocab).toBe(backing.bundle.showPersonalVocab);
+      expect(preset.density).toBe(backing.bundle.density);
+    }
+  });
+
+  test('classic preset copy matches the shipped-today values (flag-off parity)', () => {
+    const byId = Object.fromEntries(LAYOUT_PRESETS.map((p) => [p.id, p]));
+    expect(byId['core-first'].name).toBe('Core First');
+    expect(byId['big-simple'].name).toBe('Big & Simple');
+    expect(byId['word-rich'].name).toBe('Word Rich');
+    expect(byId['quick-chat'].name).toBe('Quick Chat');
+    // Bundle values preserved exactly.
+    expect(byId['core-first']).toMatchObject({ gridColumns: 4, cardSize: 'large', showPredictions: false, showPersonalVocab: false, density: 'relaxed' });
+    expect(byId['big-simple']).toMatchObject({ gridColumns: 3, cardSize: 'large', showPredictions: false, showPersonalVocab: true, density: 'relaxed' });
+    expect(byId['word-rich']).toMatchObject({ gridColumns: 6, cardSize: 'small', showPredictions: true, showPersonalVocab: true, density: 'compact' });
+    expect(byId['quick-chat']).toMatchObject({ gridColumns: 4, cardSize: 'medium', showPredictions: true, showPersonalVocab: true, density: 'balanced' });
+  });
+});
+
+describe('alpha is the safe default / fallback', () => {
   test('DEFAULT_PRIMITIVE_ID is alpha', () => {
     expect(DEFAULT_PRIMITIVE_ID).toBe('alpha');
   });
@@ -104,28 +151,21 @@ describe('alpha is the default and reuses core-first', () => {
     expect(getPrimitive('alpha').kind).toBe('fixedGrid');
   });
 
-  test("alpha's bundle equals the shipped core-first preset bundle", () => {
+  test("alpha's bundle equals the classic core-first bundle", () => {
     const coreFirst = LAYOUT_PRESETS.find((p) => p.id === 'core-first')!;
-    const alpha = getPrimitive('alpha');
-    expect(alpha.bundle).toEqual({
-      gridColumns: coreFirst.gridColumns,
-      cardSize: coreFirst.cardSize,
-      showPredictions: coreFirst.showPredictions,
-      showPersonalVocab: coreFirst.showPersonalVocab,
-      density: coreFirst.density,
-    });
+    expect(bundlesMatch(getPrimitive('alpha').bundle, coreFirst)).toBe(true);
   });
 
-  test("beta's bundle equals the shipped word-rich preset bundle", () => {
+  test("beta's bundle equals the classic word-rich bundle", () => {
     const wordRich = LAYOUT_PRESETS.find((p) => p.id === 'word-rich')!;
-    const beta = getPrimitive('beta');
-    expect(beta.bundle).toEqual({
-      gridColumns: wordRich.gridColumns,
-      cardSize: wordRich.cardSize,
-      showPredictions: wordRich.showPredictions,
-      showPersonalVocab: wordRich.showPersonalVocab,
-      density: wordRich.density,
-    });
+    expect(bundlesMatch(getPrimitive('beta').bundle, wordRich)).toBe(true);
+  });
+
+  test("eta reuses big-simple and theta reuses quick-chat", () => {
+    const bigSimple = LAYOUT_PRESETS.find((p) => p.id === 'big-simple')!;
+    const quickChat = LAYOUT_PRESETS.find((p) => p.id === 'quick-chat')!;
+    expect(bundlesMatch(getPrimitive('eta').bundle, bigSimple)).toBe(true);
+    expect(bundlesMatch(getPrimitive('theta').bundle, quickChat)).toBe(true);
   });
 });
 
@@ -140,20 +180,19 @@ describe('getPrimitive fallbacks', () => {
 describe('flag OFF === current behaviour', () => {
   test('flag off always resolves to alpha regardless of stored id', () => {
     expect(resolveActivePrimitiveId(false, 'zeta')).toBe('alpha');
-    expect(resolveActivePrimitiveId(false, 'beta')).toBe('alpha');
+    expect(resolveActivePrimitiveId(false, 'eta')).toBe('alpha');
     expect(resolveActivePrimitiveId(false, null)).toBe('alpha');
   });
 
   test('flag on honours a valid stored id and falls back for garbage', () => {
     expect(resolveActivePrimitiveId(true, 'zeta')).toBe('zeta');
+    expect(resolveActivePrimitiveId(true, 'theta')).toBe('theta');
     expect(resolveActivePrimitiveId(true, 'garbage')).toBe('alpha');
     expect(resolveActivePrimitiveId(true, null)).toBe('alpha');
   });
 });
 
-describe('non-destructive switch-and-back', () => {
-  // A settings-like object carrying BOTH layout fields and unrelated data that
-  // must survive any primitive switch untouched.
+describe('selecting a preset applies kind + bundle in one action', () => {
   const baseSettings = {
     // layout bundle fields (alpha / core-first values)
     gridColumns: 4,
@@ -170,15 +209,26 @@ describe('non-destructive switch-and-back', () => {
     parentEmailConfirmed: true,
   };
 
+  test('applyPrimitive spreads the whole bundle and records the selection', () => {
+    for (const p of LAYOUT_PRIMITIVES) {
+      const after = applyPrimitive(baseSettings, p.id);
+      expect(after.activeLayoutPrimitive).toBe(p.id);
+      expect(after.gridColumns).toBe(p.bundle.gridColumns);
+      expect(after.cardSize).toBe(p.bundle.cardSize);
+      expect(after.showPredictions).toBe(p.bundle.showPredictions);
+      expect(after.showPersonalVocab).toBe(p.bundle.showPersonalVocab);
+      expect(after.density).toBe(p.bundle.density);
+    }
+  });
+
   test('switching to beta only changes bundle + selection', () => {
     const afterBeta = applyPrimitive(baseSettings, 'beta');
     const beta = getPrimitive('beta');
-    // Bundle applied + selection recorded.
     expect(afterBeta.activeLayoutPrimitive).toBe('beta');
     expect(afterBeta.gridColumns).toBe(beta.bundle.gridColumns);
     expect(afterBeta.cardSize).toBe(beta.bundle.cardSize);
-    expect(afterBeta.showPredictions).toBe(beta.bundle.showPredictions);
-    // Unrelated data untouched.
+    // Unrelated data untouched (vocabulary/categories/personal words/phrase
+    // folders live in separate storage; these stand-ins prove nothing else moves).
     expect(afterBeta.childName).toBe('Robin');
     expect(afterBeta.selectedVoiceId).toBe('voice-123');
     expect(afterBeta.glpStage).toBe(2);
@@ -186,17 +236,15 @@ describe('non-destructive switch-and-back', () => {
     expect(afterBeta.parentEmailConfirmed).toBe(true);
   });
 
-  test('switching to a primitive and back to alpha restores the bundle exactly', () => {
-    const afterBeta = applyPrimitive(baseSettings, 'beta');
-    const backToAlpha = applyPrimitive(afterBeta, 'alpha');
-    // Layout bundle is byte-for-byte the original alpha bundle again.
+  test('switching to a preset and back to alpha restores the bundle exactly', () => {
+    const afterZeta = applyPrimitive(baseSettings, 'zeta');
+    const backToAlpha = applyPrimitive(afterZeta, 'alpha');
     expect(backToAlpha.gridColumns).toBe(baseSettings.gridColumns);
     expect(backToAlpha.cardSize).toBe(baseSettings.cardSize);
     expect(backToAlpha.showPredictions).toBe(baseSettings.showPredictions);
     expect(backToAlpha.showPersonalVocab).toBe(baseSettings.showPersonalVocab);
     expect(backToAlpha.density).toBe(baseSettings.density);
     expect(backToAlpha.activeLayoutPrimitive).toBe('alpha');
-    // And all unrelated data is still exactly as it started.
     expect(backToAlpha.childName).toBe(baseSettings.childName);
     expect(backToAlpha.selectedVoiceId).toBe(baseSettings.selectedVoiceId);
     expect(backToAlpha.glpStage).toBe(baseSettings.glpStage);
@@ -208,5 +256,42 @@ describe('non-destructive switch-and-back', () => {
     const snapshot = JSON.stringify(baseSettings);
     applyPrimitive(baseSettings, 'zeta');
     expect(JSON.stringify(baseSettings)).toBe(snapshot);
+  });
+});
+
+describe('Custom state detection', () => {
+  test('a settings bundle that matches a preset resolves to that preset id', () => {
+    const eta = getPrimitive('eta');
+    const settings = { ...eta.bundle, activeLayoutPrimitive: 'eta' as const };
+    expect(activePrimitiveIdForSettings(settings)).toBe('eta');
+  });
+
+  test('the stored selection wins when two presets share a bundle', () => {
+    // eta (Big & Simple) and gamma (Scene) share an identical bundle; the
+    // explicit stored selection disambiguates.
+    const gamma = getPrimitive('gamma');
+    expect(bundlesMatch(gamma.bundle, getPrimitive('eta').bundle)).toBe(true);
+    const settings = { ...gamma.bundle, activeLayoutPrimitive: 'gamma' as const };
+    expect(activePrimitiveIdForSettings(settings)).toBe('gamma');
+  });
+
+  test('hand-tuning a knob away from every preset yields custom', () => {
+    const eta = getPrimitive('eta');
+    // Bump grid columns to a value no preset uses.
+    const settings = { ...eta.bundle, gridColumns: 9, activeLayoutPrimitive: 'eta' as const };
+    expect(activePrimitiveIdForSettings(settings)).toBe('custom');
+  });
+
+  test('the shipped default (Big & Simple bundle, eta) is not custom', () => {
+    // Mirrors DEFAULT_SETTINGS: big-simple bundle + activeLayoutPrimitive 'eta'.
+    const settings = {
+      gridColumns: 3,
+      cardSize: 'large' as const,
+      showPredictions: false,
+      showPersonalVocab: true,
+      density: 'relaxed' as const,
+      activeLayoutPrimitive: 'eta' as const,
+    };
+    expect(activePrimitiveIdForSettings(settings)).toBe('eta');
   });
 });

--- a/src/lib/layout-primitives.ts
+++ b/src/lib/layout-primitives.ts
@@ -1,18 +1,23 @@
 /**
- * Layout Primitives - a STRUCTURAL layout dimension for the Talk Core surface.
+ * Layout Primitives - the SINGLE registry of selectable Talk Core layouts.
  *
- * The existing layout-presets system (see ./layout-presets) changes the
- * DENSITY and CARD SIZE of the SAME grid. Presets answer "how tightly packed
- * and how big are the cards?". Primitives answer a different, orthogonal
- * question: "what SHAPE of surface renders the vocabulary at all?" - a fixed
- * grid, an adaptive grid, a scene field, a text rail, a flowing board, or a
- * radial orbit core.
+ * Before consolidation the app had two competing lists: a set of DENSITY
+ * presets (Core First / Big & Simple / Word Rich / Quick Chat) and a separate
+ * set of STRUCTURAL primitives (Steady Grid / Busy Grid / Scene / ...). That
+ * meant two Layout choosers in Settings. This file is now the ONE source of
+ * truth: every selectable layout is a primitive that carries BOTH a structural
+ * `kind` (which surface renders it) AND the full settings `bundle` (grid,
+ * card size, helper rows, density). Selecting one is a single theme-like action:
+ * write `activeLayoutPrimitive` and spread the bundle via updateSettings.
  *
- * This file is ADDITIVE. It imports the existing bundle type and reuses the
- * existing preset bundles where the task calls for it, so nothing about the
- * current grid changes. Selecting a primitive is presentation-only: it never
- * touches vocabulary, categories, personal words or phrase folders (those live
- * in their own localStorage keys, independent of AppSettings).
+ * The classic density presets are DERIVED from this registry (see
+ * LAYOUT_PRESETS below), so their bundle values are never duplicated. Four of
+ * the primitives carry a `classic` descriptor so the flag-OFF Layout picker
+ * renders exactly as it did before consolidation.
+ *
+ * Selecting a primitive is presentation-only: it never touches vocabulary,
+ * categories, personal words or phrase folders (those live in their own
+ * localStorage keys, independent of AppSettings).
  *
  * Feature-flagged OFF by default (see ./feature-flags). When the flag is off,
  * the active primitive always resolves to 'alpha' (fixedGrid) and the app
@@ -21,9 +26,9 @@
  * No banned hues (270-350, purple/pink) appear in any primitive colour.
  */
 
-import {
-  LAYOUT_PRESETS,
-  type LayoutSettingsBundle,
+import type {
+  LayoutSettingsBundle,
+  LayoutPresetId,
 } from './layout-presets';
 
 /**
@@ -40,76 +45,114 @@ export type LayoutKind =
   | 'flowBoard'
   | 'orbitCore';
 
-/** Stable identifier for a primitive. Greek-letter series, alpha = default. */
+/** Stable identifier for a primitive. Greek-letter series, alpha = default.
+ *  eta/theta are the two extra calm grids carried over from the classic
+ *  Big & Simple and Quick Chat presets so no useful tuning is lost. */
 export type LayoutPrimitiveId =
   | 'alpha'
+  | 'eta'
   | 'beta'
+  | 'theta'
   | 'gamma'
   | 'delta'
   | 'epsilon'
   | 'zeta';
 
 /** The child-facing glyph shown on each primitive card. */
-export type LayoutPrimitiveGlyph = 'Α' | 'Β' | 'Γ' | 'Δ' | 'Ε' | 'Ζ';
+export type LayoutPrimitiveGlyph = 'Α' | 'Η' | 'Β' | 'Θ' | 'Γ' | 'Δ' | 'Ε' | 'Ζ';
+
+/** A small grid preview shown on a picker card. */
+export interface LayoutHint {
+  /** Columns to render in the mini preview. */
+  cols: number;
+  /** Number of filled cells to render (visual density cue). */
+  cells: number;
+  /** Accent colour for the preview (NO hues 270-350). */
+  color: string;
+}
+
+/**
+ * The classic-preset descriptor. Present on the four primitives that correspond
+ * to a density preset shipped before consolidation. It carries the classic id,
+ * name, copy and hint so the flag-OFF Layout picker (LAYOUT_PRESETS, derived
+ * below) renders byte-identically to what shipped. Absent on the four
+ * structural-only surfaces (scene / rail / flow / orbit).
+ */
+export interface ClassicPresetMeta {
+  id: Exclude<LayoutPresetId, 'custom'>;
+  name: string;
+  description: string;
+  hint: LayoutHint;
+}
 
 export interface LayoutPrimitive {
   id: LayoutPrimitiveId;
   /** Greek capital glyph rendered on the picker card. */
   glyph: LayoutPrimitiveGlyph;
-  /** Friendly, child-facing name. */
+  /** Friendly, child-facing name (unified theme name). */
   name: string;
   /** Which structural surface this primitive renders. */
   kind: LayoutKind;
-  /** Layout settings applied when this primitive is chosen (reuses the preset
-   *  bundle shape so it spreads straight into updateSettings). */
+  /** Layout settings applied when this primitive is chosen (spreads straight
+   *  into updateSettings). */
   bundle: LayoutSettingsBundle;
   /** One-line description of the shape and who it suits. */
   description: string;
   /** Tiny visual hint for the picker card: a small grid preview. */
-  hint: {
-    /** Columns to render in the mini preview. */
-    cols: number;
-    /** Number of filled cells to render (visual density cue). */
-    cells: number;
-    /** Accent colour for the preview (NO hues 270-350). */
-    color: string;
-  };
+  hint: LayoutHint;
+  /** Present when this primitive doubles as a classic density preset. */
+  classic?: ClassicPresetMeta;
 }
 
-/** The default primitive. Reused in several places so it is named once. */
+/** The default primitive used as a safe fallback for unknown/garbage ids and as
+ *  the flag-OFF resolution constant. Reused in several places so it is named
+ *  once. */
 export const DEFAULT_PRIMITIVE_ID: LayoutPrimitiveId = 'alpha';
 
-/** Look up an existing preset bundle by id, stripped to the bundle fields.
- *  Keeps alpha/beta genuinely reusing the shipped preset values rather than
- *  copying magic numbers, so the default surface stays identical to today. */
-function bundleFromPreset(presetId: string): LayoutSettingsBundle {
-  const preset = LAYOUT_PRESETS.find((p) => p.id === presetId);
-  if (!preset) {
-    // Should never happen - the preset ids are compile-time constants. Fall
-    // back to the calmest possible bundle rather than throwing in the UI path.
-    return {
-      gridColumns: 4,
-      cardSize: 'large',
-      showPredictions: false,
-      showPersonalVocab: false,
-      density: 'relaxed',
-    };
-  }
-  return {
-    gridColumns: preset.gridColumns,
-    cardSize: preset.cardSize,
-    showPredictions: preset.showPredictions,
-    showPersonalVocab: preset.showPersonalVocab,
-    density: preset.density,
-  };
-}
+/**
+ * The canonical layout bundles, defined once here (single source of truth).
+ * The classic presets reuse these exact values, so there are no duplicated
+ * magic numbers anywhere in the layout system.
+ */
+const CORE_FIRST_BUNDLE: LayoutSettingsBundle = {
+  gridColumns: 4,
+  cardSize: 'large',
+  showPredictions: false,
+  showPersonalVocab: false,
+  density: 'relaxed',
+};
+const BIG_SIMPLE_BUNDLE: LayoutSettingsBundle = {
+  gridColumns: 3,
+  cardSize: 'large',
+  showPredictions: false,
+  showPersonalVocab: true,
+  density: 'relaxed',
+};
+const WORD_RICH_BUNDLE: LayoutSettingsBundle = {
+  gridColumns: 6,
+  cardSize: 'small',
+  showPredictions: true,
+  showPersonalVocab: true,
+  density: 'compact',
+};
+const QUICK_CHAT_BUNDLE: LayoutSettingsBundle = {
+  gridColumns: 4,
+  cardSize: 'medium',
+  showPredictions: true,
+  showPersonalVocab: true,
+  density: 'balanced',
+};
 
 /**
- * The six structural primitives, in display order.
+ * The eight selectable layouts, in display order.
  *
- * Mapping (per spec):
- *   alpha   Α -> fixedGrid    (reuses core-first bundle - THE DEFAULT)
- *   beta    Β -> adaptiveGrid (reuses word-rich bundle - more columns)
+ * The first four are calm/working grids (they also back the classic presets);
+ * the last four are the experimental structural surfaces (grid-backed for now).
+ *
+ *   alpha   Α -> fixedGrid    (Core First bundle - the classic default calm grid)
+ *   eta     Η -> fixedGrid    (Big & Simple bundle - the shipped default)
+ *   beta    Β -> adaptiveGrid (Word Rich bundle - dense, predictions on)
+ *   theta   Θ -> fixedGrid    (Quick Chat bundle - your words + predictions)
  *   gamma   Γ -> sceneField   (few big cards, calm scene)
  *   delta   Δ -> textRail     (text-forward, predictions on)
  *   epsilon Ε -> flowBoard    (medium cards, flowing board)
@@ -121,18 +164,60 @@ export const LAYOUT_PRIMITIVES: LayoutPrimitive[] = [
     glyph: 'Α',
     name: 'Steady Grid',
     kind: 'fixedGrid',
-    bundle: bundleFromPreset('core-first'),
+    bundle: CORE_FIRST_BUNDLE,
     description: 'The classic fixed grid. Words never move - calm and reliable.',
     hint: { cols: 4, cells: 8, color: '#4CAF50' },
+    classic: {
+      id: 'core-first',
+      name: 'Core First',
+      description: 'Fewer, bigger core words. Calm and steady - no moving rows.',
+      hint: { cols: 4, cells: 8, color: '#4CAF50' },
+    },
+  },
+  {
+    id: 'eta',
+    glyph: 'Η',
+    name: 'Big & Simple',
+    kind: 'fixedGrid',
+    bundle: BIG_SIMPLE_BUNDLE,
+    description: 'Three big columns with the fewest helper rows. Easy to aim at.',
+    hint: { cols: 3, cells: 6, color: '#2196F3' },
+    classic: {
+      id: 'big-simple',
+      name: 'Big & Simple',
+      description: 'Three big columns with the fewest helper rows. Easy to aim at.',
+      hint: { cols: 3, cells: 6, color: '#2196F3' },
+    },
   },
   {
     id: 'beta',
     glyph: 'Β',
     name: 'Busy Grid',
     kind: 'adaptiveGrid',
-    bundle: bundleFromPreset('word-rich'),
+    bundle: WORD_RICH_BUNDLE,
     description: 'More words on screen with next-word helpers for fluent talkers.',
     hint: { cols: 6, cells: 18, color: '#E8610A' },
+    classic: {
+      id: 'word-rich',
+      name: 'Word Rich',
+      description: 'Six columns of smaller cards with next-word predictions on.',
+      hint: { cols: 6, cells: 18, color: '#E8610A' },
+    },
+  },
+  {
+    id: 'theta',
+    glyph: 'Θ',
+    name: 'Quick Chat',
+    kind: 'fixedGrid',
+    bundle: QUICK_CHAT_BUNDLE,
+    description: 'Your words and predictions up front for fast everyday talking.',
+    hint: { cols: 4, cells: 12, color: '#009688' },
+    classic: {
+      id: 'quick-chat',
+      name: 'Quick Chat',
+      description: 'Your words and predictions up front for fast everyday talking.',
+      hint: { cols: 4, cells: 12, color: '#009688' },
+    },
   },
   {
     id: 'gamma',
@@ -245,3 +330,69 @@ export function applyPrimitive<T extends LayoutSettingsBundle & Record<string, u
     activeLayoutPrimitive: primitive.id,
   };
 }
+
+/** True when two bundles carry identical layout values. */
+export function bundlesMatch(a: LayoutSettingsBundle, b: LayoutSettingsBundle): boolean {
+  return (
+    a.gridColumns === b.gridColumns &&
+    a.cardSize === b.cardSize &&
+    a.showPredictions === b.showPredictions &&
+    a.showPersonalVocab === b.showPersonalVocab &&
+    a.density === b.density
+  );
+}
+
+/**
+ * Resolve the selected unified-picker id for a settings object, or 'custom'
+ * when the current layout no longer matches any preset (i.e. the user
+ * hand-tuned a knob away from every preset).
+ *
+ * The stored `activeLayoutPrimitive` is trusted first: if its bundle still
+ * matches the current settings, that id wins (this disambiguates presets that
+ * happen to share a bundle, e.g. Big & Simple vs Scene). Only if the stored
+ * selection no longer matches do we look for any other preset with the same
+ * bundle before falling back to 'custom'.
+ */
+export function activePrimitiveIdForSettings(
+  s: LayoutSettingsBundle & { activeLayoutPrimitive?: string | null },
+): LayoutPrimitiveId | 'custom' {
+  const stored = getPrimitive(s.activeLayoutPrimitive);
+  if (bundlesMatch(stored.bundle, s)) return stored.id;
+  const match = LAYOUT_PRIMITIVES.find((p) => bundlesMatch(p.bundle, s));
+  return match ? match.id : 'custom';
+}
+
+// ---------------------------------------------------------------------------
+// Derived classic presets (flag-OFF Layout picker)
+// ---------------------------------------------------------------------------
+
+/**
+ * A classic density preset, in the flat shape the flag-OFF Layout picker
+ * renders (bundle fields at the top level, plus a hint). DERIVED from the
+ * primitives that carry a `classic` descriptor - never authored twice.
+ */
+export interface LayoutPreset extends LayoutSettingsBundle {
+  id: Exclude<LayoutPresetId, 'custom'>;
+  name: string;
+  description: string;
+  hint: LayoutHint;
+}
+
+/**
+ * The four classic density presets (Core First / Big & Simple / Word Rich /
+ * Quick Chat), derived from the single registry so the flag-OFF picker keeps
+ * working exactly as it shipped, with no duplicated data.
+ */
+export const LAYOUT_PRESETS: LayoutPreset[] = LAYOUT_PRIMITIVES.filter(
+  (p): p is LayoutPrimitive & { classic: ClassicPresetMeta } => p.classic !== undefined,
+).map((p) => ({
+  id: p.classic.id,
+  name: p.classic.name,
+  description: p.classic.description,
+  gridColumns: p.bundle.gridColumns,
+  cardSize: p.bundle.cardSize,
+  showPredictions: p.bundle.showPredictions,
+  showPersonalVocab: p.bundle.showPersonalVocab,
+  density: p.bundle.density,
+  hint: p.classic.hint,
+}));

--- a/src/lib/layout-primitives.ts
+++ b/src/lib/layout-primitives.ts
@@ -1,0 +1,247 @@
+/**
+ * Layout Primitives - a STRUCTURAL layout dimension for the Talk Core surface.
+ *
+ * The existing layout-presets system (see ./layout-presets) changes the
+ * DENSITY and CARD SIZE of the SAME grid. Presets answer "how tightly packed
+ * and how big are the cards?". Primitives answer a different, orthogonal
+ * question: "what SHAPE of surface renders the vocabulary at all?" - a fixed
+ * grid, an adaptive grid, a scene field, a text rail, a flowing board, or a
+ * radial orbit core.
+ *
+ * This file is ADDITIVE. It imports the existing bundle type and reuses the
+ * existing preset bundles where the task calls for it, so nothing about the
+ * current grid changes. Selecting a primitive is presentation-only: it never
+ * touches vocabulary, categories, personal words or phrase folders (those live
+ * in their own localStorage keys, independent of AppSettings).
+ *
+ * Feature-flagged OFF by default (see ./feature-flags). When the flag is off,
+ * the active primitive always resolves to 'alpha' (fixedGrid) and the app
+ * behaves exactly as it does today.
+ *
+ * No banned hues (270-350, purple/pink) appear in any primitive colour.
+ */
+
+import {
+  LAYOUT_PRESETS,
+  type LayoutSettingsBundle,
+} from './layout-presets';
+
+/**
+ * The structural kind of a Talk Core surface. Each kind is a distinct way of
+ * arranging the vocabulary on screen. In THIS framework PR every kind renders
+ * the existing SupercoreGrid; the scene/text/flow/orbit surfaces are a later
+ * PR. The kind is what a surface-router switches on.
+ */
+export type LayoutKind =
+  | 'fixedGrid'
+  | 'adaptiveGrid'
+  | 'sceneField'
+  | 'textRail'
+  | 'flowBoard'
+  | 'orbitCore';
+
+/** Stable identifier for a primitive. Greek-letter series, alpha = default. */
+export type LayoutPrimitiveId =
+  | 'alpha'
+  | 'beta'
+  | 'gamma'
+  | 'delta'
+  | 'epsilon'
+  | 'zeta';
+
+/** The child-facing glyph shown on each primitive card. */
+export type LayoutPrimitiveGlyph = 'Α' | 'Β' | 'Γ' | 'Δ' | 'Ε' | 'Ζ';
+
+export interface LayoutPrimitive {
+  id: LayoutPrimitiveId;
+  /** Greek capital glyph rendered on the picker card. */
+  glyph: LayoutPrimitiveGlyph;
+  /** Friendly, child-facing name. */
+  name: string;
+  /** Which structural surface this primitive renders. */
+  kind: LayoutKind;
+  /** Layout settings applied when this primitive is chosen (reuses the preset
+   *  bundle shape so it spreads straight into updateSettings). */
+  bundle: LayoutSettingsBundle;
+  /** One-line description of the shape and who it suits. */
+  description: string;
+  /** Tiny visual hint for the picker card: a small grid preview. */
+  hint: {
+    /** Columns to render in the mini preview. */
+    cols: number;
+    /** Number of filled cells to render (visual density cue). */
+    cells: number;
+    /** Accent colour for the preview (NO hues 270-350). */
+    color: string;
+  };
+}
+
+/** The default primitive. Reused in several places so it is named once. */
+export const DEFAULT_PRIMITIVE_ID: LayoutPrimitiveId = 'alpha';
+
+/** Look up an existing preset bundle by id, stripped to the bundle fields.
+ *  Keeps alpha/beta genuinely reusing the shipped preset values rather than
+ *  copying magic numbers, so the default surface stays identical to today. */
+function bundleFromPreset(presetId: string): LayoutSettingsBundle {
+  const preset = LAYOUT_PRESETS.find((p) => p.id === presetId);
+  if (!preset) {
+    // Should never happen - the preset ids are compile-time constants. Fall
+    // back to the calmest possible bundle rather than throwing in the UI path.
+    return {
+      gridColumns: 4,
+      cardSize: 'large',
+      showPredictions: false,
+      showPersonalVocab: false,
+      density: 'relaxed',
+    };
+  }
+  return {
+    gridColumns: preset.gridColumns,
+    cardSize: preset.cardSize,
+    showPredictions: preset.showPredictions,
+    showPersonalVocab: preset.showPersonalVocab,
+    density: preset.density,
+  };
+}
+
+/**
+ * The six structural primitives, in display order.
+ *
+ * Mapping (per spec):
+ *   alpha   Α -> fixedGrid    (reuses core-first bundle - THE DEFAULT)
+ *   beta    Β -> adaptiveGrid (reuses word-rich bundle - more columns)
+ *   gamma   Γ -> sceneField   (few big cards, calm scene)
+ *   delta   Δ -> textRail     (text-forward, predictions on)
+ *   epsilon Ε -> flowBoard    (medium cards, flowing board)
+ *   zeta    Ζ -> orbitCore    (core-forward radial arrangement)
+ */
+export const LAYOUT_PRIMITIVES: LayoutPrimitive[] = [
+  {
+    id: 'alpha',
+    glyph: 'Α',
+    name: 'Steady Grid',
+    kind: 'fixedGrid',
+    bundle: bundleFromPreset('core-first'),
+    description: 'The classic fixed grid. Words never move - calm and reliable.',
+    hint: { cols: 4, cells: 8, color: '#4CAF50' },
+  },
+  {
+    id: 'beta',
+    glyph: 'Β',
+    name: 'Busy Grid',
+    kind: 'adaptiveGrid',
+    bundle: bundleFromPreset('word-rich'),
+    description: 'More words on screen with next-word helpers for fluent talkers.',
+    hint: { cols: 6, cells: 18, color: '#E8610A' },
+  },
+  {
+    id: 'gamma',
+    glyph: 'Γ',
+    name: 'Scene',
+    kind: 'sceneField',
+    bundle: {
+      gridColumns: 3,
+      cardSize: 'large',
+      showPredictions: false,
+      showPersonalVocab: true,
+      density: 'relaxed',
+    },
+    description: 'Big picture cards arranged like a scene. Coming soon.',
+    hint: { cols: 3, cells: 6, color: '#2196F3' },
+  },
+  {
+    id: 'delta',
+    glyph: 'Δ',
+    name: 'Word Rail',
+    kind: 'textRail',
+    bundle: {
+      gridColumns: 4,
+      cardSize: 'medium',
+      showPredictions: true,
+      showPersonalVocab: true,
+      density: 'balanced',
+    },
+    description: 'A text-forward rail with predictions up front. Coming soon.',
+    hint: { cols: 4, cells: 12, color: '#009688' },
+  },
+  {
+    id: 'epsilon',
+    glyph: 'Ε',
+    name: 'Flow Board',
+    kind: 'flowBoard',
+    bundle: {
+      gridColumns: 5,
+      cardSize: 'medium',
+      showPredictions: true,
+      showPersonalVocab: true,
+      density: 'balanced',
+    },
+    description: 'Cards flow to fit the screen at any size. Coming soon.',
+    hint: { cols: 5, cells: 15, color: '#F4A100' },
+  },
+  {
+    id: 'zeta',
+    glyph: 'Ζ',
+    name: 'Orbit Core',
+    kind: 'orbitCore',
+    bundle: {
+      gridColumns: 4,
+      cardSize: 'large',
+      showPredictions: false,
+      showPersonalVocab: true,
+      density: 'relaxed',
+    },
+    description: 'Core words held close in a radial arrangement. Coming soon.',
+    hint: { cols: 4, cells: 8, color: '#F44336' },
+  },
+];
+
+/** Fast id -> primitive lookup, built once. */
+const PRIMITIVE_BY_ID: Record<LayoutPrimitiveId, LayoutPrimitive> =
+  LAYOUT_PRIMITIVES.reduce((acc, p) => {
+    acc[p.id] = p;
+    return acc;
+  }, {} as Record<LayoutPrimitiveId, LayoutPrimitive>);
+
+/** Get a primitive by id, always falling back to the default. Never throws. */
+export function getPrimitive(id: string | null | undefined): LayoutPrimitive {
+  if (id && id in PRIMITIVE_BY_ID) {
+    return PRIMITIVE_BY_ID[id as LayoutPrimitiveId];
+  }
+  return PRIMITIVE_BY_ID[DEFAULT_PRIMITIVE_ID];
+}
+
+/**
+ * Resolve which primitive id is actually active given the feature flag.
+ *
+ * This is the single choke-point that guarantees flag-off === today: when the
+ * flag is off, the active primitive is ALWAYS 'alpha' (fixedGrid), no matter
+ * what is stored in settings. Callers must route surface selection through
+ * this function.
+ */
+export function resolveActivePrimitiveId(
+  flagEnabled: boolean,
+  storedId: string | null | undefined,
+): LayoutPrimitiveId {
+  if (!flagEnabled) return DEFAULT_PRIMITIVE_ID;
+  return getPrimitive(storedId).id;
+}
+
+/**
+ * Purely apply a primitive's layout bundle onto an existing settings-like
+ * object, returning a NEW object. Only the five bundle fields plus
+ * activeLayoutPrimitive change; every other field (childName, voice, consent,
+ * etc.) is preserved untouched. Used by the Settings picker and covered by the
+ * switch-and-back test that proves data is never lost.
+ */
+export function applyPrimitive<T extends LayoutSettingsBundle & Record<string, unknown>>(
+  base: T,
+  id: LayoutPrimitiveId,
+): T & { activeLayoutPrimitive: LayoutPrimitiveId } {
+  const primitive = getPrimitive(id);
+  return {
+    ...base,
+    ...primitive.bundle,
+    activeLayoutPrimitive: primitive.id,
+  };
+}

--- a/src/lib/layout-primitives.ts
+++ b/src/lib/layout-primitives.ts
@@ -231,7 +231,7 @@ export const LAYOUT_PRIMITIVES: LayoutPrimitive[] = [
       showPersonalVocab: true,
       density: 'relaxed',
     },
-    description: 'Big picture cards arranged like a scene. Coming soon.',
+    description: 'Big picture cards arranged like a scene.',
     hint: { cols: 3, cells: 6, color: '#2196F3' },
   },
   {
@@ -246,7 +246,7 @@ export const LAYOUT_PRIMITIVES: LayoutPrimitive[] = [
       showPersonalVocab: true,
       density: 'balanced',
     },
-    description: 'A text-forward rail with predictions up front. Coming soon.',
+    description: 'A text-forward rail with predictions up front.',
     hint: { cols: 4, cells: 12, color: '#009688' },
   },
   {
@@ -261,7 +261,7 @@ export const LAYOUT_PRIMITIVES: LayoutPrimitive[] = [
       showPersonalVocab: true,
       density: 'balanced',
     },
-    description: 'Cards flow to fit the screen at any size. Coming soon.',
+    description: 'Cards flow to fit the screen at any size.',
     hint: { cols: 5, cells: 15, color: '#F4A100' },
   },
   {
@@ -276,7 +276,7 @@ export const LAYOUT_PRIMITIVES: LayoutPrimitive[] = [
       showPersonalVocab: true,
       density: 'relaxed',
     },
-    description: 'Core words held close in a radial arrangement. Coming soon.',
+    description: 'Core words held close in a radial arrangement.',
     hint: { cols: 4, cells: 8, color: '#F44336' },
   },
 ];


### PR DESCRIPTION
The four Layout Primitive surfaces (Scene, Word Rail, Flow Board, Orbit Core) have been real since 93d460f, but the registry descriptions shown in the Settings picker still ended with "Coming soon."

This drops that suffix so the picker copy is accurate and matches the iOS registry word for word (PodJamz/8gent-jr-ios#66) for cross-platform parity.

## Test plan
- `bun test` on `layout-primitives.test.ts` + `surfaces.test.ts`: 37 pass, 0 fail.
- Copy-only change to `src/lib/layout-primitives.ts`; no behavior touched.

Closes nothing on its own; part of the web/iOS parity pass on #220.